### PR TITLE
[codex] fix quiz scoring and voteban cleanup bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,20 +2,22 @@ DEFAULT_LANG=kk
 TELEGRAM_API_BASE=https://api.telegram.org/bot
 
 AI_PROVIDER=gemini
-GEMINI_MODEL=gemini-3-flash-preview
 WTF_GEMINI_MODEL=gemini-3.1-flash-lite-preview
-FALLBACK_MODEL=gemini-2.5-flash
+NEWS_GEMINI_MODEL=gemini-3-flash-preview
+QUIZ_GEMINI_MODEL=gemini-3-flash-preview
 GROQ_MODEL=llama-3.3-70b-versatile
 WTF_FALLBACK_PROVIDER=deepseek  # deepseek | llama (Groq is not wired to /wtf in the bot)
+DEEPSEEK_MODEL=deepseek-chat
 
 CHATS_KK="-1234567890"
 CHATS_ZH="-1234567890"
 CHATS_RU="-1234567890"
 
-TELEGRAM_BOT_TOKEN=<your_bot_token>
-TELEGRAM_WEBHOOK_SECRET_TOKEN=<your_webhook_secret_token>
+BOT_TOKEN=<your_bot_token>
+WEBHOOK_SECRET_TOKEN=<your_webhook_secret_token>
 
 GEMINI_API_KEY=<your_gemini_api_key>
 GROQ_API_KEY=<your_groq_api_key>
+DEEPSEEK_API_KEY=<your_deepseek_api_key>
 
 ADMIN_USER_ID=<your_admin_user_id>

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -43,7 +43,7 @@ aws sts get-caller-identity
    123456789:ABCdefGHIjkLMNopqrsTUVwxyz
    ```
 
-5. **Save this token** — you will use it as `TELEGRAM_BOT_TOKEN`. Do not share it or commit it to git.
+5. **Save this token** — you will use it as `BOT_TOKEN`. Do not share it or commit it to git.
 
 Optional: Create a test group, add your bot as admin with "Delete messages" and "Restrict members" permissions to test the captcha and kick flows. Add it to a second group to test the quiz.
 
@@ -51,7 +51,7 @@ Optional: Create a test group, add your bot as admin with "Delete messages" and 
 
 ## 3. Get External API Keys
 
-Zerde uses two external APIs beyond Telegram:
+Zerde can use three external APIs beyond Telegram:
 
 ### Google Gemini (for News and Quiz translation)
 
@@ -59,11 +59,15 @@ Zerde uses two external APIs beyond Telegram:
 2. Create an API key. Copy it — this is your `GEMINI_API_KEY`.
 3. Free tier is sufficient for daily digest volumes.
 
-### QuizAPI (for Daily Tech Quiz)
+### Groq (for async spam checks)
 
-1. Go to [quizapi.io](https://quizapi.io) and register a free account.
-2. Generate an API key in your dashboard. Copy it — this is your `QUIZAPI_KEY`.
-3. The free plan covers the daily quiz volume.
+1. Go to [console.groq.com](https://console.groq.com/) and create an API key.
+2. Copy it — this is your `GROQ_API_KEY`.
+
+### DeepSeek (optional fallback for explain/quiz/news)
+
+1. Go to [platform.deepseek.com](https://platform.deepseek.com/) and create an API key.
+2. Copy it — this is your `DEEPSEEK_API_KEY`.
 
 ---
 
@@ -85,20 +89,25 @@ Edit `.env` and fill in all required values:
 
 ```ini
 # Required
-TELEGRAM_BOT_TOKEN=<token from BotFather>
-TELEGRAM_WEBHOOK_SECRET_TOKEN=<hex string from openssl above>
+BOT_TOKEN=<token from BotFather>
+WEBHOOK_SECRET_TOKEN=<hex string from openssl above>
 GEMINI_API_KEY=<your Gemini API key>
-QUIZAPI_KEY=<your QuizAPI key>
+GROQ_API_KEY=<your Groq API key>
+DEEPSEEK_API_KEY=<your DeepSeek API key>
 
 # Optional — configure chat IDs to receive news/quiz
 NEWS_CHATS_KK=<comma-separated chat IDs for Kazakh news>
 NEWS_CHATS_ZH=<comma-separated chat IDs for Chinese news>
 NEWS_CHATS_RU=<comma-separated chat IDs for Russian news>
-QUIZ_CHATS=<comma-separated chat IDs for daily quiz>
+QUIZ_CHATS_KK=<comma-separated chat IDs for Kazakh quiz>
+QUIZ_CHATS_ZH=<comma-separated chat IDs for Chinese quiz>
+QUIZ_CHATS_RU=<comma-separated chat IDs for Russian quiz>
 
 # Optional — defaults shown
 AI_PROVIDER=gemini
-LLM_MODEL=gemini-2.5-flash
+WTF_GEMINI_MODEL=gemini-3.1-flash-lite-preview
+NEWS_GEMINI_MODEL=gemini-3-flash-preview
+QUIZ_GEMINI_MODEL=gemini-3-flash-preview
 DEFAULT_LANG=kk
 ```
 
@@ -140,7 +149,7 @@ Telegram must send updates to your API Gateway URL.
 
 ```bash
 curl -F "url=<YOUR_API_ENDPOINT>/webhook" \
-     -F "secret_token=<YOUR_TELEGRAM_WEBHOOK_SECRET_TOKEN>" \
+     -F "secret_token=<YOUR_WEBHOOK_SECRET_TOKEN>" \
      "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook"
 ```
 

--- a/src/bot/services/handlers/quiz.py
+++ b/src/bot/services/handlers/quiz.py
@@ -79,10 +79,10 @@ def handle_poll_answer(ctx: Context) -> None:
     points = int(quiz_record.get("points", 1))
 
     if selected_option == correct_option_id:
-        ctx.quiz_repo.update_score_correct(chat_id, user_id, first_name, points=points)
+        ctx.quiz_repo.update_score_correct(chat_id, user_id, first_name, poll_id=poll_id, points=points)
         logger.info("Correct answer recorded", extra={"user_id": user_id, "chat_id": chat_id, "points": points})
     else:
-        ctx.quiz_repo.update_score_wrong(chat_id, user_id, first_name)
+        ctx.quiz_repo.update_score_wrong(chat_id, user_id, first_name, poll_id=poll_id)
         logger.info("Wrong answer recorded", extra={"user_id": user_id, "chat_id": chat_id})
 
 

--- a/src/bot/services/handlers/voteban.py
+++ b/src/bot/services/handlers/voteban.py
@@ -205,17 +205,17 @@ def _finalize_ban(ctx: Context, target_user_id: int, votes_for: int) -> None:
             ),
         )
 
-        sent_message_id = session.get("reply_message_id")
+        vote_message_id = session.get("sent_message_id") or ctx.message_id
+        target_message_id = session.get("reply_message_id")
         logger.info(
             "Deleting vote message and user's reply message",
-            extra={"msg_id": ctx.message_id, "sent_message_id": sent_message_id},
+            extra={"vote_message_id": vote_message_id, "target_message_id": target_message_id},
         )
-        if ctx.message_id and sent_message_id:
+        for msg_id in dict.fromkeys(m for m in (ctx.message_id, vote_message_id, target_message_id) if m):
             try:
-                ctx.bot.delete_message(ctx.chat_id, ctx.message_id)
-                ctx.bot.delete_message(ctx.chat_id, sent_message_id)
+                ctx.bot.delete_message(ctx.chat_id, msg_id)
             except Exception:
-                logger.exception(f"Failed to delete vote message: {ctx.message_id}")
+                logger.exception(f"Failed to delete vote/target message: {msg_id}")
 
         ctx.vote_repo.delete_vote_session(ctx.chat_id, target_user_id)
         if ctx.stats_repo:

--- a/src/bot/services/repositories/quiz.py
+++ b/src/bot/services/repositories/quiz.py
@@ -58,16 +58,27 @@ class QuizRepository:
             logger.error("Failed to get user score", extra={"error": str(e)})
             return None
 
-    def update_score_correct(self, chat_id: str, user_id: str, first_name: str, points: int = 1) -> None:
+    def update_score_correct(
+        self,
+        chat_id: str,
+        user_id: str,
+        first_name: str,
+        *,
+        poll_id: str,
+        points: int = 1,
+    ) -> None:
         """Update user score for a correct answer with streak logic.
 
-        Atomic conditional write prevents double-counting on duplicate poll_answer events.
+        Atomic conditional write prevents double-counting duplicate poll_answer events
+        while still allowing multiple different quiz polls on the same day.
         """
         today = _today_almaty()
         yesterday = _yesterday_almaty()
         current = self.get_user_score(chat_id, user_id)
 
-        if current and current.get("last_correct_date") == yesterday:
+        if current and current.get("last_correct_date") == today:
+            new_streak = int(current.get("current_streak", 1))
+        elif current and current.get("last_correct_date") == yesterday:
             new_streak = int(current.get("current_streak", 0)) + 1
         else:
             new_streak = 1
@@ -83,9 +94,12 @@ class QuizRepository:
                     "    best_streak = :best,"
                     "    last_correct_date = :today,"
                     "    last_answered_date = :today,"
+                    "    answered_poll_ids = list_append(if_not_exists(answered_poll_ids, :empty_list), :poll_list),"
                     "    first_name = :name"
                 ),
-                ConditionExpression=("attribute_not_exists(last_answered_date) OR last_answered_date <> :today"),
+                ConditionExpression=(
+                    "attribute_not_exists(answered_poll_ids) OR NOT contains(answered_poll_ids, :poll_id)"
+                ),
                 ExpressionAttributeValues={
                     ":zero": 0,
                     ":pts": points,
@@ -93,20 +107,30 @@ class QuizRepository:
                     ":best": best_streak,
                     ":today": today,
                     ":name": first_name,
+                    ":empty_list": [],
+                    ":poll_list": [poll_id],
+                    ":poll_id": poll_id,
                 },
             )
-            logger.info("Correct answer recorded", extra={"user_id": user_id, "chat_id": chat_id, "points": points})
+            logger.info(
+                "Correct answer recorded",
+                extra={"user_id": user_id, "chat_id": chat_id, "poll_id": poll_id, "points": points},
+            )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                logger.info("Duplicate poll_answer ignored", extra={"user_id": user_id, "chat_id": chat_id})
+                logger.info(
+                    "Duplicate poll_answer ignored",
+                    extra={"user_id": user_id, "chat_id": chat_id, "poll_id": poll_id},
+                )
                 return
             logger.error("Failed to update score (correct)", extra={"error": str(e)})
             raise
 
-    def update_score_wrong(self, chat_id: str, user_id: str, first_name: str) -> None:
+    def update_score_wrong(self, chat_id: str, user_id: str, first_name: str, *, poll_id: str) -> None:
         """Update user record for a wrong answer — reset streak.
 
-        Uses if_not_exists to avoid a pre-read; conditional write blocks duplicates.
+        Uses if_not_exists to avoid a pre-read; conditional write blocks duplicate
+        answers for the same poll, not other polls on the same day.
         """
         today = _today_almaty()
         try:
@@ -118,21 +142,30 @@ class QuizRepository:
                     "    current_streak = :zero,"
                     "    best_streak = if_not_exists(best_streak, :zero),"
                     "    last_answered_date = :today,"
+                    "    answered_poll_ids = list_append(if_not_exists(answered_poll_ids, :empty_list), :poll_list),"
                     "    first_name = :name,"
                     "    last_correct_date = if_not_exists(last_correct_date, :empty)"
                 ),
-                ConditionExpression=("attribute_not_exists(last_answered_date) OR last_answered_date <> :today"),
+                ConditionExpression=(
+                    "attribute_not_exists(answered_poll_ids) OR NOT contains(answered_poll_ids, :poll_id)"
+                ),
                 ExpressionAttributeValues={
                     ":zero": 0,
                     ":today": today,
                     ":name": first_name,
                     ":empty": "",
+                    ":empty_list": [],
+                    ":poll_list": [poll_id],
+                    ":poll_id": poll_id,
                 },
             )
-            logger.info("Wrong answer recorded", extra={"user_id": user_id, "chat_id": chat_id})
+            logger.info("Wrong answer recorded", extra={"user_id": user_id, "chat_id": chat_id, "poll_id": poll_id})
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                logger.info("Duplicate poll_answer ignored", extra={"user_id": user_id, "chat_id": chat_id})
+                logger.info(
+                    "Duplicate poll_answer ignored",
+                    extra={"user_id": user_id, "chat_id": chat_id, "poll_id": poll_id},
+                )
                 return
             logger.error("Failed to update score (wrong)", extra={"error": str(e)})
             raise

--- a/src/quiz/services/quiz_service.py
+++ b/src/quiz/services/quiz_service.py
@@ -462,6 +462,26 @@ class QuizService:
             extra={"chat_id": chat_id, "topic": topic, "lang": lang, "difficulty": difficulty},
         )
 
+        def save_sent_poll(question: dict, poll_question: str, poll_result: dict, category: str) -> bool:
+            poll_id = str(poll_result.get("poll", {}).get("id", ""))
+            if not poll_id:
+                logger.error("On-demand poll result missing poll id", extra={"chat_id": chat_id, "topic": topic})
+                return False
+            return self._repo.save_quiz_record(
+                chat_id=chat_id,
+                question=poll_question,
+                options=question["options"],
+                correct_option_id=question["correct_option_index"],
+                explanation=question.get("explanation"),
+                category=category,
+                lang=lang,
+                poll_id=poll_id,
+                message_id=int(poll_result.get("message_id", 0)),
+                difficulty=difficulty,
+                points=question["points"],
+                record_key=f"ONDEMAND#{poll_id}",
+            )
+
         # ── Bank path ────────────────────────────────────────────────────────
         banked_category = _GENQUIZ_TOPIC_TO_BANKED.get(topic.lower().strip())
         if banked_category:
@@ -499,6 +519,9 @@ class QuizService:
                         "Genquiz sent from bank",
                         extra={"chat_id": chat_id, "category": banked_category, "lang": lang},
                     )
+                    if not save_sent_poll(question, poll_question, poll_result, banked_category):
+                        logger.error("Failed to save genquiz poll lookup", extra={"chat_id": chat_id})
+                        return {"status": "error", "reason": "failed to save poll record"}
                     # Commit question queue only after confirmed send (Bug #2 fix).
                     self._repo.save_genquiz_question_queue(banked_category, str(chat_id), genquiz_remaining)
                     return {"status": "ok", "sent": 1, "total": 1}
@@ -526,6 +549,9 @@ class QuizService:
 
         if poll_result:
             logger.info("On-demand quiz sent via AI", extra={"chat_id": chat_id, "topic": topic})
+            if not save_sent_poll(question, question["question"], poll_result, topic):
+                logger.error("Failed to save on-demand quiz poll lookup", extra={"chat_id": chat_id, "topic": topic})
+                return {"status": "error", "reason": "failed to save poll record"}
             return {"status": "ok", "sent": 1, "total": 1}
 
         logger.error("Failed to send on-demand quiz poll", extra={"chat_id": chat_id})

--- a/src/quiz/services/repository.py
+++ b/src/quiz/services/repository.py
@@ -317,21 +317,24 @@ class QuizRepository:
         message_id: int,
         difficulty: str = "easy",
         points: int = 1,
+        record_key: str | None = None,
     ) -> bool:
-        """Write a daily quiz record for a chat.
+        """Write a quiz poll lookup record for a chat.
 
-        Returns True on success, False if a record already exists for today
-        (idempotent: safe to call on Lambda retry without overwriting a live poll).
+        Daily quizzes use ``DATE#YYYY-MM-DD``. On-demand quizzes pass a unique
+        ``record_key`` (normally ``ONDEMAND#<poll_id>``) so their poll answers can
+        be scored without colliding with the daily idempotency record.
         """
         now = datetime.now(_ALMATY_TZ)
         today = now.strftime("%Y-%m-%d")
+        sk = record_key or f"DATE#{today}"
         ttl = int(time.time()) + (_TTL_DAYS * 86400)
 
         try:
             self._table.put_item(
                 Item={
                     "PK": f"QUIZ#{chat_id}",
-                    "SK": f"DATE#{today}",
+                    "SK": sk,
                     "question": question,
                     "options": options,
                     "correct_option_id": correct_option_id,
@@ -347,13 +350,13 @@ class QuizRepository:
                 },
                 ConditionExpression=Attr("PK").not_exists(),
             )
-            logger.info("Quiz record saved", extra={"chat_id": chat_id, "date": today})
+            logger.info("Quiz record saved", extra={"chat_id": chat_id, "sk": sk, "poll_id": poll_id})
             return True
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
                 logger.warning(
-                    "Quiz record already exists for today, skipping save",
-                    extra={"chat_id": chat_id, "date": today},
+                    "Quiz record already exists, skipping save",
+                    extra={"chat_id": chat_id, "sk": sk, "poll_id": poll_id},
                 )
                 return False
             logger.error("Failed to save quiz record", extra={"chat_id": chat_id, "error": str(e)})

--- a/tests/test_quiz_handler.py
+++ b/tests/test_quiz_handler.py
@@ -35,18 +35,25 @@ class TestHandlePollAnswer:
         ctx = Context(update, bot, quiz_repo=quiz_repo)
         return ctx
 
-    # def test_correct_answer_updates_score(self):
-    #     quiz_repo = MagicMock()
-    #     quiz_repo.lookup_poll.return_value = {
-    #         "PK": "QUIZ#-100123",
-    #         "SK": "DATE#2026-04-05",
-    #         "correct_option_id": 2,
-    #     }
-    #     ctx = self._make_ctx("poll123", 456, 2, quiz_repo)
+    def test_correct_answer_updates_score_with_poll_id(self):
+        quiz_repo = MagicMock()
+        quiz_repo.lookup_poll.return_value = {
+            "PK": "QUIZ#-100123",
+            "SK": "DATE#2026-04-05",
+            "correct_option_id": 2,
+            "points": 3,
+        }
+        ctx = self._make_ctx("poll123", 456, 2, quiz_repo)
 
-    #     handle_poll_answer(ctx)
+        handle_poll_answer(ctx)
 
-    #     quiz_repo.update_score_correct.assert_called_once_with("-100123", "456", "Test")
+        quiz_repo.update_score_correct.assert_called_once_with(
+            "-100123",
+            "456",
+            "Test",
+            poll_id="poll123",
+            points=3,
+        )
 
     def test_wrong_answer_updates_score(self):
         quiz_repo = MagicMock()
@@ -59,7 +66,7 @@ class TestHandlePollAnswer:
 
         handle_poll_answer(ctx)
 
-        quiz_repo.update_score_wrong.assert_called_once_with("-100123", "456", "Test")
+        quiz_repo.update_score_wrong.assert_called_once_with("-100123", "456", "Test", poll_id="poll123")
 
     def test_unknown_poll_id_ignored(self):
         quiz_repo = MagicMock()

--- a/tests/test_quiz_service_on_demand.py
+++ b/tests/test_quiz_service_on_demand.py
@@ -1,0 +1,115 @@
+"""Tests for QuizService on-demand poll persistence."""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+_zerde = os.path.join(os.path.dirname(__file__), "..", "src", "shared", "python")
+if _zerde not in sys.path:
+    sys.path.insert(0, _zerde)
+
+os.environ.setdefault("BOT_TOKEN", "test-bot-token")
+os.environ.setdefault("TABLE_NAME", "test-quiz-table")
+os.environ.setdefault("GEMINI_API_KEY", "test-gemini-key")
+os.environ.setdefault("QUIZ_LLM_RPD", "1000")
+os.environ.setdefault("DEEPSEEK_API_KEY", "test-deepseek-key")
+
+_quiz_dir = os.path.join(os.path.dirname(__file__), "..", "src", "quiz")
+_saved_modules: dict[str, object] = {}
+
+try:
+    for mod_name in list(sys.modules):
+        if mod_name in ("core", "services") or mod_name.startswith(("core.", "services.")):
+            _saved_modules[mod_name] = sys.modules.pop(mod_name)
+
+    sys.path.insert(0, _quiz_dir)
+    from services.quiz_service import QuizService  # noqa: E402
+finally:
+    if _quiz_dir in sys.path:
+        sys.path.remove(_quiz_dir)
+    for mod_name in list(sys.modules):
+        if mod_name in ("core", "services") or mod_name.startswith(("core.", "services.")):
+            sys.modules.pop(mod_name, None)
+    sys.modules.update(_saved_modules)
+
+
+def _make_service() -> QuizService:
+    svc = QuizService.__new__(QuizService)
+    svc._generator = MagicMock()
+    svc._sender = MagicMock()
+    svc._repo = MagicMock()
+    svc._repo.save_quiz_record.return_value = True
+    return svc
+
+
+def _question(points: int = 3) -> dict:
+    return {
+        "question": "What is Python?",
+        "options": ["Language", "Database", "Cloud", "Protocol"],
+        "correct_option_index": 0,
+        "explanation": "Python is a language.",
+        "difficulty": "medium",
+        "points": points,
+    }
+
+
+def test_ai_on_demand_quiz_saves_poll_lookup_record() -> None:
+    svc = _make_service()
+    question = _question(points=3)
+    svc._generator.generate_question.return_value = question
+    svc._sender.send_quiz_poll.return_value = {"poll": {"id": "poll-ai"}, "message_id": 321}
+
+    result = svc.process_on_demand_quiz("-100123", "kk", "python", "medium")
+
+    assert result == {"status": "ok", "sent": 1, "total": 1}
+    svc._repo.save_quiz_record.assert_called_once_with(
+        chat_id="-100123",
+        question="What is Python?",
+        options=question["options"],
+        correct_option_id=0,
+        explanation="Python is a language.",
+        category="python",
+        lang="kk",
+        poll_id="poll-ai",
+        message_id=321,
+        difficulty="medium",
+        points=3,
+        record_key="ONDEMAND#poll-ai",
+    )
+
+
+def test_banked_on_demand_quiz_saves_lookup_before_committing_queue() -> None:
+    svc = _make_service()
+    banked = {
+        **_question(points=1),
+        "source_label": "AWS CLF-C02 Practice Exam",
+    }
+    svc._pick_banked_question_for_genquiz = MagicMock(return_value=(banked, ["aws-clf-c02::next"]))
+    svc._sender.send_quiz_poll.return_value = {"poll": {"id": "poll-bank"}, "message_id": 654}
+
+    result = svc.process_on_demand_quiz("-100123", "en", "aws", "easy")
+
+    assert result == {"status": "ok", "sent": 1, "total": 1}
+    svc._repo.save_quiz_record.assert_called_once()
+    save_call_index = [c[0] for c in svc._repo.method_calls].index("save_quiz_record")
+    queue_call_index = [c[0] for c in svc._repo.method_calls].index("save_genquiz_question_queue")
+    assert save_call_index < queue_call_index
+
+    kwargs = svc._repo.save_quiz_record.call_args.kwargs
+    assert kwargs["chat_id"] == "-100123"
+    assert kwargs["poll_id"] == "poll-bank"
+    assert kwargs["record_key"] == "ONDEMAND#poll-bank"
+    assert kwargs["category"] == "cloud"
+    assert "AWS CLF-C02 Practice Exam" in kwargs["question"]
+
+
+def test_banked_on_demand_quiz_does_not_commit_queue_when_lookup_save_fails() -> None:
+    svc = _make_service()
+    svc._repo.save_quiz_record.return_value = False
+    svc._pick_banked_question_for_genquiz = MagicMock(return_value=(_question(points=1), ["next"]))
+    svc._sender.send_quiz_poll.return_value = {"poll": {"id": "poll-bank"}, "message_id": 654}
+
+    result = svc.process_on_demand_quiz("-100123", "en", "aws", "easy")
+
+    assert result == {"status": "error", "reason": "failed to save poll record"}
+    svc._repo.save_genquiz_question_queue.assert_not_called()

--- a/tests/test_quiz_streak.py
+++ b/tests/test_quiz_streak.py
@@ -35,13 +35,18 @@ class TestStreakCorrectAnswer:
 
         repo = QuizRepository()
         repo.get_user_score = MagicMock(return_value=None)
-        repo.update_score_correct("chat1", "user1", "Test")
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-1")
 
         mock_table.update_item.assert_called_once()
-        vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
+        call_kwargs = mock_table.update_item.call_args[1]
+        vals = call_kwargs["ExpressionAttributeValues"]
         assert vals[":pts"] == 1
         assert vals[":streak"] == 1
         assert vals[":best"] == 1
+        assert vals[":poll_id"] == "poll-1"
+        assert vals[":poll_list"] == ["poll-1"]
+        assert "answered_poll_ids" in call_kwargs["ConditionExpression"]
+        assert "last_answered_date <> :today" not in call_kwargs["ConditionExpression"]
 
     @_PATCH_YESTERDAY
     @_PATCH_TODAY
@@ -64,7 +69,7 @@ class TestStreakCorrectAnswer:
                 "first_name": "Test",
             }
         )
-        repo.update_score_correct("chat1", "user1", "Test")
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-2")
 
         mock_table.update_item.assert_called_once()
         vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
@@ -93,13 +98,68 @@ class TestStreakCorrectAnswer:
                 "first_name": "Test",
             }
         )
-        repo.update_score_correct("chat1", "user1", "Test")
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-3")
 
         mock_table.update_item.assert_called_once()
         vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
         assert vals[":pts"] == 1
         assert vals[":streak"] == 1
         assert vals[":best"] == 8  # Preserved
+
+    @_PATCH_YESTERDAY
+    @_PATCH_TODAY
+    @patch("services.repositories.quiz.get_dynamodb")
+    def test_second_correct_same_day_keeps_streak(self, mock_dynamo, _m_today, _m_yday):
+        mock_table = MagicMock()
+        mock_dynamo.return_value.Table.return_value = mock_table
+
+        from services.repositories.quiz import QuizRepository
+
+        repo = QuizRepository()
+        repo.get_user_score = MagicMock(
+            return_value={
+                "total_score": 5,
+                "week_score": 3,
+                "current_streak": 4,
+                "best_streak": 4,
+                "last_correct_date": FROZEN_TODAY,
+                "last_answered_date": FROZEN_TODAY,
+                "answered_poll_ids": ["poll-1"],
+                "first_name": "Test",
+            }
+        )
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-4")
+
+        mock_table.update_item.assert_called_once()
+        vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
+        assert vals[":streak"] == 4
+        assert vals[":best"] == 4
+
+    @_PATCH_YESTERDAY
+    @_PATCH_TODAY
+    @patch("services.repositories.quiz.get_dynamodb")
+    def test_different_poll_same_day_is_allowed_by_condition(self, mock_dynamo, _m_today, _m_yday):
+        mock_table = MagicMock()
+        mock_dynamo.return_value.Table.return_value = mock_table
+
+        from services.repositories.quiz import QuizRepository
+
+        repo = QuizRepository()
+        repo.get_user_score = MagicMock(
+            return_value={
+                "current_streak": 1,
+                "best_streak": 1,
+                "last_correct_date": FROZEN_TODAY,
+                "last_answered_date": FROZEN_TODAY,
+                "answered_poll_ids": ["poll-1"],
+            }
+        )
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-2")
+
+        condition = mock_table.update_item.call_args[1]["ConditionExpression"]
+        vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
+        assert "NOT contains(answered_poll_ids, :poll_id)" in condition
+        assert vals[":poll_id"] == "poll-2"
 
     @_PATCH_YESTERDAY
     @_PATCH_TODAY
@@ -125,7 +185,7 @@ class TestStreakCorrectAnswer:
             }
         )
         # Must not raise
-        repo.update_score_correct("chat1", "user1", "Test")
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-1")
         mock_table.update_item.assert_called_once()
 
 
@@ -142,15 +202,17 @@ class TestStreakWrongAnswer:
         from services.repositories.quiz import QuizRepository
 
         repo = QuizRepository()
-        repo.update_score_wrong("chat1", "user1", "Test")
+        repo.update_score_wrong("chat1", "user1", "Test", poll_id="poll-1")
 
         mock_table.update_item.assert_called_once()
         call_kwargs = mock_table.update_item.call_args[1]
         vals = call_kwargs["ExpressionAttributeValues"]
         assert vals[":zero"] == 0
         assert vals[":today"] == FROZEN_TODAY
+        assert vals[":poll_id"] == "poll-1"
         # streak reset is expressed via :zero in the UpdateExpression
         assert "current_streak = :zero" in call_kwargs["UpdateExpression"]
+        assert "answered_poll_ids" in call_kwargs["ConditionExpression"]
 
     @_PATCH_YESTERDAY
     @_PATCH_TODAY
@@ -165,5 +227,5 @@ class TestStreakWrongAnswer:
 
         repo = QuizRepository()
         # Must not raise
-        repo.update_score_wrong("chat1", "user1", "Test")
+        repo.update_score_wrong("chat1", "user1", "Test", poll_id="poll-1")
         mock_table.update_item.assert_called_once()

--- a/tests/test_voteban.py
+++ b/tests/test_voteban.py
@@ -1,0 +1,26 @@
+"""Tests for vote-to-ban finalization cleanup."""
+
+from unittest.mock import MagicMock, call
+
+from services.handlers.voteban import _finalize_ban
+
+
+def test_finalize_ban_deletes_vote_message_and_target_message_once() -> None:
+    ctx = MagicMock()
+    ctx.chat_id = -100123
+    ctx.message_id = 777
+    ctx.stats_repo = MagicMock()
+    ctx.vote_repo.get_vote_session.return_value = {
+        "reply_message_id": 555,
+        "sent_message_id": 777,
+        "target_username": "target",
+        "target_first_name": "Target",
+        "votes_for_info": [{"id": 1, "username": "voter", "first_name": "Voter"}],
+    }
+
+    _finalize_ban(ctx, target_user_id=42, votes_for=5)
+
+    ctx.bot.kick_chat_member.assert_called_once_with(-100123, 42)
+    ctx.bot.delete_message.assert_has_calls([call(-100123, 777), call(-100123, 555)])
+    assert ctx.bot.delete_message.call_count == 2
+    ctx.vote_repo.delete_vote_session.assert_called_once_with(-100123, 42)


### PR DESCRIPTION
## Summary
- persist on-demand /genquiz poll lookup records so poll_answer updates can be scored
- change quiz answer idempotency from once-per-day to once-per-poll while preserving same-day streak behavior
- clean up voteban finalization message deletion so vote and target messages use explicit IDs
- update local env docs to match current BOT_TOKEN/WEBHOOK_SECRET_TOKEN and provider env names

## Validation
- uv run pytest tests/test_quiz_handler.py tests/test_quiz_streak.py tests/test_quiz_service_on_demand.py tests/test_voteban.py -q
- uv run pre-commit run --files .env.example docs/LOCAL_TESTING.md src/bot/services/handlers/quiz.py src/bot/services/handlers/voteban.py src/bot/services/repositories/quiz.py src/quiz/services/repository.py src/quiz/services/quiz_service.py tests/test_quiz_handler.py tests/test_quiz_streak.py tests/test_quiz_service_on_demand.py tests/test_voteban.py
- uv run pre-commit run --all-files
- uv run pytest tests/ -q