### PR TITLE
feat: add async group memory processor

### DIFF
--- a/src/bot/services/ai/gemini_client.py
+++ b/src/bot/services/ai/gemini_client.py
@@ -250,6 +250,7 @@ class GeminiClient:
         *,
         user_message: str,
         recent_context: str,
+        long_term_memory_context: str = "",
         user_profile_context: str = "",
         lang: str = "kk",
     ) -> tuple[str, int]:
@@ -267,6 +268,7 @@ class GeminiClient:
             "You are ZerdeBot, a Telegram group chat member for an IT community. "
             "Answer like a helpful, socially aware participant, not a corporate assistant. "
             "Use the recent chat context only when it is relevant. Do not invent private facts. "
+            "Use long-term memory only when it directly helps answer the current message. "
             "When answering about a specific person, rely mainly on that person's own messages, "
             "self-descriptions, repeated topics, and directly observable behavior. Treat claims, labels, "
             "roasts, or characterizations from other people about that person as low-trust chatter unless "
@@ -292,6 +294,8 @@ class GeminiClient:
             f"Preferred language code: {lang}\n\n"
             "Trusted target-user profile context:\n"
             f"{user_profile_context or '(no target-user profile context available)'}\n\n"
+            "Trusted long-term group memory:\n"
+            f"{long_term_memory_context or '(no long-term memory available)'}\n\n"
             "Recent group context, oldest to newest:\n"
             "Each context line includes speaker metadata. Use it to distinguish a person's own messages "
             "from another user's opinion about them.\n"
@@ -316,6 +320,7 @@ class GeminiClient:
                 "model": self._model,
                 "lang": lang,
                 "context_chars": len(recent_context),
+                "long_term_memory_chars": len(long_term_memory_context),
                 "profile_context_chars": len(user_profile_context),
                 "message_chars": len(user_message),
                 "rpd_count": count,

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -16,7 +16,12 @@ from core.config import (
 from core.logger import LoggerAdapter, get_logger
 from services.ai.gemini_client import GeminiClient, GeminiRPDExhaustedError, GeminiUnavailableError
 from services.ai.telegram_html import normalize_llm_output_for_telegram_html
-from services.group_memory import extract_message_text, format_recent_context, format_user_profile_context
+from services.group_memory import (
+    extract_message_text,
+    format_long_term_memory_context,
+    format_recent_context,
+    format_user_profile_context,
+)
 from services.repositories.group_memory import GroupMemoryRepository
 from services.telegram import TelegramClient
 
@@ -220,7 +225,17 @@ def maybe_answer_proactively(
         return False
 
     answer_html = normalize_llm_output_for_telegram_html(decision.reply_text)
-    bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
+    sent = bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
+    bot_message_id = sent.get("message_id") if isinstance(sent, dict) else None
+    if bot_message_id:
+        repo.record_agent_reply(
+            chat_id=chat_id,
+            bot_message_id=bot_message_id,
+            trigger_message_id=reply_to_message_id,
+            trigger_kind="proactive",
+            reason=decision.reason or "I judged this as an open question where a short answer could help.",
+            confidence=decision.confidence,
+        )
     logger.info(
         "Group agent handled update",
         extra={
@@ -249,6 +264,7 @@ def answer_group_question(
         return False
 
     recent_context = format_recent_context(repo, chat_id, limit=AGENT_RECENT_CONTEXT_LIMIT)
+    long_term_memory_context = format_long_term_memory_context(repo, chat_id)
     ignored_usernames = {AGENT_BOT_USERNAME} if AGENT_BOT_USERNAME else set()
     user_profile_context = format_user_profile_context(
         repo,
@@ -261,6 +277,7 @@ def answer_group_question(
         answer, _ = gemini.group_chat_reply(
             user_message=user_text,
             recent_context=recent_context,
+            long_term_memory_context=long_term_memory_context,
             user_profile_context=user_profile_context,
             lang=lang,
         )
@@ -275,5 +292,17 @@ def answer_group_question(
         return False
 
     answer_html = normalize_llm_output_for_telegram_html(answer)
-    bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
+    sent = bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
+    bot_message_id = sent.get("message_id") if isinstance(sent, dict) else None
+    if bot_message_id:
+        repo.record_agent_reply(
+            chat_id=chat_id,
+            bot_message_id=bot_message_id,
+            trigger_message_id=reply_to_message_id,
+            trigger_kind="explicit",
+            reason=(
+                "I was mentioned, replied to, or called through /ask, "
+                "so I answered with recent and trusted memory context."
+            ),
+        )
     return True

--- a/src/bot/services/group_memory.py
+++ b/src/bot/services/group_memory.py
@@ -8,6 +8,7 @@ from typing import Any
 from core.config import GROUP_MEMORY_ENABLED, GROUP_MEMORY_RECENT_LIMIT
 from core.logger import LoggerAdapter, get_logger
 from services.repositories.group_memory import GroupMemoryRepository
+from services.repositories.sqs import SQSClient
 
 logger = LoggerAdapter(get_logger(__name__), {})
 
@@ -52,8 +53,13 @@ def is_storable_group_message(update: dict[str, Any]) -> bool:
     return bool(text and not text.startswith("/"))
 
 
-def observe_update(repo: GroupMemoryRepository | None, update: dict[str, Any]) -> None:
-    """Persist a human group message when global and per-chat memory are enabled."""
+def observe_update(
+    repo: GroupMemoryRepository | None,
+    update: dict[str, Any],
+    *,
+    sqs_repo: SQSClient | None = None,
+) -> None:
+    """Persist recent context and enqueue long-term processing for opted-in group messages."""
     if not GROUP_MEMORY_ENABLED or repo is None or not is_storable_group_message(update):
         return
 
@@ -70,16 +76,28 @@ def observe_update(repo: GroupMemoryRepository | None, update: dict[str, Any]) -
         return
 
     try:
+        sender_name = display_name(user)
+        username = user.get("username")
         repo.store_message(
             chat_id=chat_id,
             message_id=message_id,
             user_id=user_id,
-            display_name=display_name(user),
-            username=user.get("username"),
+            display_name=sender_name,
+            username=username,
             text=text,
             created_at=message.get("date"),
         )
         logger.debug("Stored group memory message", extra={"chat_id": chat_id, "message_id": message_id})
+        if sqs_repo:
+            sqs_repo.send_group_memory_task(
+                chat_id=chat_id,
+                message_id=message_id,
+                user_id=user_id,
+                display_name=sender_name,
+                username=username,
+                text=text,
+                created_at=message.get("date"),
+            )
     except Exception:
         logger.exception("Failed to store group memory message", extra={"chat_id": chat_id, "message_id": message_id})
 
@@ -105,6 +123,24 @@ def format_recent_context(repo: GroupMemoryRepository, chat_id: int | str, *, li
                 speaker_bits.append(f"username=@{username.lstrip('@')}")
             speaker_bits.append(f"name={name[:80]}")
             lines.append(f"[speaker {' '.join(speaker_bits)}] {text[:700]}")
+    return "\n".join(lines)
+
+
+def format_long_term_memory_context(repo: GroupMemoryRepository, chat_id: int | str, *, limit: int = 12) -> str:
+    """Render recent important memories extracted by the async memory processor."""
+    memories = repo.get_recent_long_term_memories(chat_id, limit=limit)
+    lines: list[str] = []
+    for item in memories:
+        kind = str(item.get("kind") or "memory")
+        name = str(item.get("display_name") or item.get("username") or item.get("user_id") or "Unknown")
+        summary = str(item.get("summary") or item.get("text") or "").replace("\n", " ").strip()
+        reason = str(item.get("reason") or "").strip()
+        if not summary:
+            continue
+        prefix = f"[{kind} speaker={name[:80]}]"
+        if reason:
+            prefix = f"{prefix} reason={reason[:120]}"
+        lines.append(f"{prefix} {summary[:500]}")
     return "\n".join(lines)
 
 

--- a/src/bot/services/group_memory_processor.py
+++ b/src/bot/services/group_memory_processor.py
@@ -1,0 +1,204 @@
+"""Async long-term group memory extraction for PROCESS_GROUP_MEMORY tasks."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from core.logger import LoggerAdapter, get_logger
+from services.repositories.group_memory import GroupMemoryRepository
+
+logger = LoggerAdapter(get_logger(__name__), {})
+
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}\b")
+_PHONE_RE = re.compile(r"(?:\+?\d[\s().-]*){9,}")
+_SECRET_CUES = (
+    "password",
+    "passwd",
+    "secret",
+    "api key",
+    "token",
+    "пароль",
+    "құпия",
+    "密码",
+    "令牌",
+)
+_SENSITIVE_CUES = (
+    "diagnosis",
+    "medical",
+    "salary",
+    "passport",
+    "credit card",
+    "диагноз",
+    "медицина",
+    "зарплата",
+    "паспорт",
+    "жалақы",
+    "ауырып",
+    "身份证",
+    "工资",
+    "银行卡",
+)
+_EVENT_CUES = (
+    "today",
+    "tomorrow",
+    "yesterday",
+    "meeting",
+    "deploy",
+    "release",
+    "incident",
+    "deadline",
+    "сегодня",
+    "завтра",
+    "вчера",
+    "релиз",
+    "созвон",
+    "бүгін",
+    "ертең",
+    "кеше",
+    "релиз",
+    "жиналыс",
+    "今天",
+    "明天",
+    "昨天",
+    "发布",
+)
+_GROUP_FACT_CUES = (
+    "we decided",
+    "we agreed",
+    "let's use",
+    "по договоренности",
+    "решили",
+    "договорились",
+    "келістік",
+    "шештік",
+    "用",
+    "决定",
+)
+_PREFERENCE_CUES = (
+    "i prefer",
+    "i like",
+    "i hate",
+    "i use",
+    "my stack",
+    "предпочитаю",
+    "люблю",
+    "ненавижу",
+    "использую",
+    "маған ұнайды",
+    "ұнатпаймын",
+    "қолданам",
+    "我喜欢",
+    "我不喜欢",
+    "我用",
+)
+_JOKE_CUES = (
+    "inside joke",
+    "meme",
+    "лол",
+    "хаха",
+    "ахах",
+    "әзіл",
+    "қалжың",
+    "мем",
+    "哈哈",
+    "梗",
+)
+
+
+@dataclass(frozen=True)
+class MemoryClassification:
+    kind: str
+    summary: str
+    reason: str
+    confidence: float
+
+
+def _contains_any(text: str, cues: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(cue in lowered for cue in cues)
+
+
+def _is_sensitive(text: str) -> bool:
+    lowered = text.lower()
+    return bool(_EMAIL_RE.search(text) or _PHONE_RE.search(text) or any(cue in lowered for cue in _SECRET_CUES))
+
+
+def _should_skip_for_privacy(text: str) -> bool:
+    return _is_sensitive(text) or _contains_any(text, _SENSITIVE_CUES)
+
+
+def classify_long_term_memory(text: str) -> MemoryClassification | None:
+    """Classify a message into a trusted long-term memory item, if worth keeping."""
+    cleaned = " ".join((text or "").split())
+    if len(cleaned) < 12 or _should_skip_for_privacy(cleaned):
+        return None
+
+    if _contains_any(cleaned, _GROUP_FACT_CUES):
+        return MemoryClassification(
+            kind="group_fact",
+            summary=cleaned[:280],
+            reason="group decision or shared preference",
+            confidence=0.72,
+        )
+    if _contains_any(cleaned, _PREFERENCE_CUES):
+        return MemoryClassification(
+            kind="user_fact",
+            summary=cleaned[:280],
+            reason="user stated a preference or recurring personal context",
+            confidence=0.7,
+        )
+    if _contains_any(cleaned, _EVENT_CUES):
+        return MemoryClassification(
+            kind="event",
+            summary=cleaned[:280],
+            reason="time-bound event or operational update",
+            confidence=0.66,
+        )
+    if _contains_any(cleaned, _JOKE_CUES):
+        return MemoryClassification(
+            kind="joke",
+            summary=cleaned[:280],
+            reason="possible recurring group joke or meme",
+            confidence=0.62,
+        )
+    return None
+
+
+def process_group_memory_task(body: dict[str, Any], *, repo: GroupMemoryRepository | None = None) -> None:
+    """Process one SQS group-memory task and store important long-term memory."""
+    repo = repo or GroupMemoryRepository()
+    try:
+        chat_id = body["chat_id"]
+        message_id = body["message_id"]
+        user_id = body["user_id"]
+        display_name = str(body.get("display_name") or user_id)
+        username = body.get("username")
+        text = str(body.get("text") or "").strip()
+    except KeyError as exc:
+        logger.warning("PROCESS_GROUP_MEMORY missing required field", extra={"missing": str(exc)})
+        return
+
+    classification = classify_long_term_memory(text)
+    if not classification:
+        logger.debug("PROCESS_GROUP_MEMORY skipped low-value or sensitive message", extra={"chat_id": chat_id})
+        return
+
+    repo.store_long_term_memory(
+        chat_id=chat_id,
+        message_id=message_id,
+        user_id=user_id,
+        display_name=display_name,
+        username=str(username) if username else None,
+        text=text,
+        kind=classification.kind,
+        summary=classification.summary,
+        reason=classification.reason,
+        confidence=classification.confidence,
+        created_at=body.get("created_at"),
+    )
+    logger.info(
+        "PROCESS_GROUP_MEMORY stored long-term memory",
+        extra={"chat_id": chat_id, "message_id": message_id, "kind": classification.kind},
+    )

--- a/src/bot/services/handlers/__init__.py
+++ b/src/bot/services/handlers/__init__.py
@@ -17,6 +17,7 @@ from services.handlers.commands import (
     handle_agent_on,
     handle_ask,
     handle_forget_group,
+    handle_forget_me,
     handle_help,
     handle_memory_off,
     handle_memory_on,
@@ -26,6 +27,7 @@ from services.handlers.commands import (
     handle_start,
     handle_stats,
     handle_support,
+    handle_why_reply,
 )
 from services.handlers.explain_document import handle_document_auto_summary
 from services.handlers.quiz import handle_poll_answer, handle_quizstats
@@ -75,6 +77,8 @@ def register_handlers(dp: Dispatcher) -> None:
     dp.command("ask")(handle_ask)
     dp.command("memory_status")(handle_memory_status)
     dp.command("forget_group")(handle_forget_group)
+    dp.command("forget_me")(handle_forget_me)
+    dp.command("why_reply")(handle_why_reply)
     dp.command("voteban")(handle_voteban_command)
     dp.command("wtf")(handle_wtf)
     dp.command("explain")(handle_explain)

--- a/src/bot/services/handlers/commands.py
+++ b/src/bot/services/handlers/commands.py
@@ -210,7 +210,22 @@ def handle_memory_status(ctx: Context) -> None:
     settings = ctx.memory_repo.get_chat_settings(ctx.chat_id)
     memory = "on" if settings["memory_enabled"] else "off"
     agent = "on" if settings["agent_enabled"] else "off"
-    ctx.reply(f"Group memory: {memory}\nGroup agent: {agent}", ctx.message_id)
+    overview = ctx.memory_repo.get_memory_overview(ctx.chat_id)
+    ctx.reply(
+        (
+            f"Group memory: {memory}\n"
+            f"Group agent: {agent}\n"
+            f"Recent messages: {overview['recent_messages']}\n"
+            f"User profiles: {overview['user_profiles']}\n"
+            f"Long-term memory: "
+            f"{overview['events']} events, "
+            f"{overview['user_facts']} user facts, "
+            f"{overview['group_facts']} group facts, "
+            f"{overview['jokes']} jokes\n"
+            f"Recorded agent replies: {overview['agent_replies']}"
+        ),
+        ctx.message_id,
+    )
 
 
 def handle_ask(ctx: Context) -> None:
@@ -245,6 +260,40 @@ def handle_forget_group(ctx: Context) -> None:
         return
     deleted = ctx.memory_repo.delete_chat_memory(ctx.chat_id)
     ctx.reply(f"Deleted {deleted} memory items for this group.", ctx.message_id)
+
+
+def handle_forget_me(ctx: Context) -> None:
+    if not _require_memory_repo(ctx):
+        return
+    if not ctx.user_id:
+        ctx.reply("I could not identify your Telegram user id.", ctx.message_id)
+        return
+    deleted = ctx.memory_repo.delete_user_memory(ctx.chat_id, ctx.user_id)
+    ctx.reply(f"Deleted {deleted} memory items linked to you in this group.", ctx.message_id)
+
+
+def handle_why_reply(ctx: Context) -> None:
+    if not _require_memory_repo(ctx):
+        return
+    bot_message_id = None
+    if ctx.reply_to_message:
+        sender = ctx.reply_to_message.get("from") or {}
+        if sender.get("is_bot"):
+            bot_message_id = ctx.reply_to_message.get("message_id")
+
+    item = ctx.memory_repo.get_agent_reply_explanation(ctx.chat_id, bot_message_id=bot_message_id)
+    if not item:
+        ctx.reply("I do not have a recorded reason for that reply.", ctx.message_id)
+        return
+
+    trigger_kind = item.get("trigger_kind") or "unknown"
+    reason = item.get("reason") or "No reason recorded."
+    confidence = item.get("confidence")
+    confidence_line = f"\nConfidence: {float(confidence):.2f}" if confidence is not None else ""
+    ctx.reply(
+        f"Why I replied: {reason}\nTrigger: {trigger_kind}{confidence_line}",
+        ctx.message_id,
+    )
 
 
 def handle_quiz_generate(ctx: Context) -> None:

--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -39,6 +39,23 @@ class GroupMemoryRepository:
         return f"MSG#{created_at_ms:013d}#{message_id}"
 
     @staticmethod
+    def _memory_sk(kind: str, created_at_ms: int, message_id: int | str, user_id: int | str | None = None) -> str:
+        if kind == "user_fact" and user_id is not None:
+            return f"USER_FACT#{user_id}#{created_at_ms:013d}#{message_id}"
+        prefix = {
+            "event": "EVENT",
+            "group_fact": "GROUP_FACT",
+            "joke": "JOKE",
+        }.get(kind)
+        if not prefix:
+            raise ValueError(f"Unsupported long-term memory kind: {kind}")
+        return f"{prefix}#{created_at_ms:013d}#{message_id}"
+
+    @staticmethod
+    def _agent_reply_sk(message_id: int | str) -> str:
+        return f"AGENT_REPLY#{int(message_id):013d}"
+
+    @staticmethod
     def _normalise_profile_samples(value: Any) -> list[str]:
         if not isinstance(value, list):
             return []
@@ -259,6 +276,59 @@ class GroupMemoryRepository:
         items = resp.get("Items") or []
         return list(reversed(items))
 
+    def store_long_term_memory(
+        self,
+        *,
+        chat_id: int | str,
+        message_id: int | str,
+        user_id: int | str,
+        display_name: str,
+        username: str | None,
+        text: str,
+        kind: str,
+        summary: str,
+        reason: str,
+        confidence: float,
+        created_at: int | None = None,
+    ) -> None:
+        """Store one trusted long-term memory extracted from a user's own message."""
+        now = int(time.time())
+        created_at = created_at or now
+        created_at_ms = created_at * 1000
+        ttl = now + GROUP_MEMORY_RETENTION_DAYS * 24 * 60 * 60
+        item = {
+            "pk": self._chat_pk(chat_id),
+            "sk": self._memory_sk(kind, created_at_ms, message_id, user_id),
+            "kind": kind,
+            "chat_id": str(chat_id),
+            "message_id": int(message_id),
+            "user_id": str(user_id),
+            "display_name": display_name,
+            "text": text[:1200],
+            "summary": summary[:500],
+            "reason": reason[:240],
+            "confidence": Decimal(str(max(0.0, min(1.0, confidence)))),
+            "created_at": created_at,
+            "ttl": ttl,
+        }
+        if username:
+            item["username"] = username
+        self.table.put_item(Item=item)
+
+    def get_recent_long_term_memories(self, chat_id: int | str, *, limit: int = 12) -> list[dict[str, Any]]:
+        """Return recent important memories across long-term memory item types."""
+        items: list[dict[str, Any]] = []
+        per_kind_limit = max(1, limit // 2)
+        for prefix in ("EVENT#", "USER_FACT#", "GROUP_FACT#", "JOKE#"):
+            resp = self.table.query(
+                KeyConditionExpression=Key("pk").eq(self._chat_pk(chat_id)) & Key("sk").begins_with(prefix),
+                ScanIndexForward=False,
+                Limit=per_kind_limit,
+            )
+            items.extend(resp.get("Items") or [])
+        newest = sorted(items, key=lambda row: int(row.get("created_at") or 0), reverse=True)[:limit]
+        return list(reversed(newest))
+
     def get_user_profile(self, chat_id: int | str, user_id: int | str) -> dict[str, Any]:
         resp = self.table.get_item(Key={"pk": self._chat_pk(chat_id), "sk": self._user_sk(user_id)})
         return resp.get("Item") or {}
@@ -326,6 +396,121 @@ class GroupMemoryRepository:
             if code == "ConditionalCheckFailedException":
                 return False
             raise
+
+    def record_agent_reply(
+        self,
+        *,
+        chat_id: int | str,
+        bot_message_id: int | str,
+        trigger_message_id: int | str,
+        trigger_kind: str,
+        reason: str,
+        confidence: float | None = None,
+    ) -> None:
+        now = int(time.time())
+        ttl = now + 7 * 24 * 60 * 60
+        item: dict[str, Any] = {
+            "pk": self._chat_pk(chat_id),
+            "sk": self._agent_reply_sk(bot_message_id),
+            "kind": "agent_reply",
+            "chat_id": str(chat_id),
+            "bot_message_id": int(bot_message_id),
+            "trigger_message_id": int(trigger_message_id),
+            "trigger_kind": trigger_kind,
+            "reason": reason[:500],
+            "created_at": now,
+            "ttl": ttl,
+        }
+        if confidence is not None:
+            item["confidence"] = Decimal(str(max(0.0, min(1.0, confidence))))
+        self.table.put_item(Item=item)
+
+    def get_agent_reply_explanation(
+        self,
+        chat_id: int | str,
+        *,
+        bot_message_id: int | str | None = None,
+    ) -> dict[str, Any]:
+        if bot_message_id is not None:
+            resp = self.table.get_item(Key={"pk": self._chat_pk(chat_id), "sk": self._agent_reply_sk(bot_message_id)})
+            return resp.get("Item") or {}
+
+        resp = self.table.query(
+            KeyConditionExpression=Key("pk").eq(self._chat_pk(chat_id)) & Key("sk").begins_with("AGENT_REPLY#"),
+            ScanIndexForward=False,
+            Limit=1,
+        )
+        items = resp.get("Items") or []
+        return items[0] if items else {}
+
+    def get_memory_overview(self, chat_id: int | str) -> dict[str, Any]:
+        counts = {
+            "recent_messages": 0,
+            "user_profiles": 0,
+            "events": 0,
+            "user_facts": 0,
+            "group_facts": 0,
+            "jokes": 0,
+            "agent_replies": 0,
+        }
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)),
+                "ProjectionExpression": "sk",
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.query(**kwargs)
+            for item in resp.get("Items") or []:
+                sk = str(item.get("sk") or "")
+                if sk.startswith("MSG#"):
+                    counts["recent_messages"] += 1
+                elif sk.startswith("USER#"):
+                    counts["user_profiles"] += 1
+                elif sk.startswith("EVENT#"):
+                    counts["events"] += 1
+                elif sk.startswith("USER_FACT#"):
+                    counts["user_facts"] += 1
+                elif sk.startswith("GROUP_FACT#"):
+                    counts["group_facts"] += 1
+                elif sk.startswith("JOKE#"):
+                    counts["jokes"] += 1
+                elif sk.startswith("AGENT_REPLY#"):
+                    counts["agent_replies"] += 1
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return counts
+
+    def delete_user_memory(self, chat_id: int | str, user_id: int | str) -> int:
+        deleted = 0
+        user_id_str = str(user_id)
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)),
+                "ProjectionExpression": "pk, sk, user_id",
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.query(**kwargs)
+            to_delete = []
+            for item in resp.get("Items") or []:
+                sk = str(item.get("sk") or "")
+                if (
+                    item.get("user_id") == user_id_str
+                    or sk == self._user_sk(user_id)
+                    or sk.startswith(f"USER_FACT#{user_id_str}#")
+                ):
+                    to_delete.append(item)
+            if to_delete:
+                with self.table.batch_writer() as batch:
+                    for item in to_delete:
+                        batch.delete_item(Key={"pk": item["pk"], "sk": item["sk"]})
+                        deleted += 1
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return deleted
 
     def delete_chat_memory(self, chat_id: int | str) -> int:
         deleted = 0

--- a/src/bot/services/repositories/sqs.py
+++ b/src/bot/services/repositories/sqs.py
@@ -1,4 +1,4 @@
-"""SQS client for deferred timeout tasks."""
+"""SQS client for asynchronous bot tasks."""
 
 import json
 
@@ -19,7 +19,7 @@ def _get_sqs_client():
 
 
 class SQSClient:
-    """Sends delayed CHECK_TIMEOUT tasks to SQS."""
+    """Sends asynchronous bot tasks to SQS."""
 
     def __init__(self) -> None:
         self.queue_url = QUEUE_URL
@@ -144,3 +144,41 @@ class SQSClient:
             )
         except Exception as e:
             logger.exception("Failed to send spam check task to SQS", extra={"error": e})
+
+    def send_group_memory_task(
+        self,
+        *,
+        chat_id: int,
+        message_id: int,
+        user_id: int,
+        display_name: str,
+        username: str | None,
+        text: str,
+        created_at: int | None = None,
+    ) -> None:
+        """Enqueue a group message for async long-term memory processing."""
+        payload: dict[str, object] = {
+            "task_type": "PROCESS_GROUP_MEMORY",
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "user_id": user_id,
+            "display_name": display_name,
+            "text": text,
+        }
+        if username:
+            payload["username"] = username
+        if created_at:
+            payload["created_at"] = created_at
+
+        try:
+            self.sqs_client.send_message(
+                QueueUrl=self.queue_url,
+                MessageBody=json.dumps(payload),
+            )
+            logger.info(
+                "Queued group memory task",
+                extra={"chat_id": chat_id, "message_id": message_id, "user_id": user_id},
+            )
+        except Exception as e:
+            logger.exception("Failed to send group memory task to SQS", extra={"error": e, "chat_id": chat_id})
+            raise

--- a/src/bot/services/sqs_task_router.py
+++ b/src/bot/services/sqs_task_router.py
@@ -1,4 +1,4 @@
-"""SQS record routing: captcha timeout, /wtf async explain, Groq spam check."""
+"""SQS record routing: captcha timeout, async explain, spam, and memory tasks."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from typing import Any
 
 from core.config import is_configured_group_chat
 from core.logger import LoggerAdapter, get_logger
+from services.group_memory_processor import process_group_memory_task
 from services.handlers import process_explain_task, process_timeout_task
 from services.repositories.captcha import CaptchaRepository
 from services.spam.processor import process_spam_check_task
@@ -45,6 +46,8 @@ def process_sqs_event(
                 process_explain_task(bot, body)
             elif task_type == "SPAM_CHECK":
                 process_spam_check_task(bot, body, captcha_repo=captcha_repo)
+            elif task_type == "PROCESS_GROUP_MEMORY":
+                process_group_memory_task(body)
             else:
                 logger.warning(
                     "Unexpected SQS record: unsupported task_type, ignoring",

--- a/src/bot/webhook.py
+++ b/src/bot/webhook.py
@@ -101,7 +101,7 @@ def _handle_api_gateway(
             screener.run(body)
 
         if not has_pending_captcha:
-            observe_group_memory_update(dispatcher.memory_repo, body)
+            observe_group_memory_update(dispatcher.memory_repo, body, sqs_repo=_sqs_client)
 
         if not is_event_relevant_to_bot(body):
             logger.info("Event not relevant to bot, ignoring")

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -5,9 +5,12 @@ from unittest.mock import MagicMock
 from services import group_agent, group_memory
 from services.ai import gemini_client
 from services.ai.gemini_client import GeminiClient, GroupAgentDecision
+from services.group_memory_processor import classify_long_term_memory, process_group_memory_task
 from services.handlers import commands
 from services.handlers.commands import handle_ask
+from services.repositories import sqs as sqs_module
 from services.repositories.group_memory import GroupMemoryRepository
+from services.repositories.sqs import SQSClient
 
 
 def _group_update(text: str = "hello @ZerdeBot") -> dict:
@@ -24,10 +27,11 @@ def _group_update(text: str = "hello @ZerdeBot") -> dict:
 
 def test_observe_update_stores_opted_in_group_message(monkeypatch):
     repo = MagicMock()
+    sqs = MagicMock()
     repo.is_memory_enabled.return_value = True
     monkeypatch.setattr(group_memory, "GROUP_MEMORY_ENABLED", True)
 
-    group_memory.observe_update(repo, _group_update("we discussed OpenSearch today"))
+    group_memory.observe_update(repo, _group_update("we discussed OpenSearch today"), sqs_repo=sqs)
 
     repo.store_message.assert_called_once()
     kwargs = repo.store_message.call_args.kwargs
@@ -36,6 +40,8 @@ def test_observe_update_stores_opted_in_group_message(monkeypatch):
     assert kwargs["user_id"] == 42
     assert kwargs["display_name"] == "Ada"
     assert kwargs["text"] == "we discussed OpenSearch today"
+    sqs.send_group_memory_task.assert_called_once()
+    assert sqs.send_group_memory_task.call_args.kwargs["text"] == "we discussed OpenSearch today"
 
 
 def test_observe_update_skips_when_chat_has_not_opted_in(monkeypatch):
@@ -135,6 +141,93 @@ def test_format_user_profile_context_uses_target_profile_not_third_party_label()
     assert "own_topic_terms: python, opensearch" in context
     assert "OpenSearch индексациясын қарап жүрмін" in context
     assert "токсик" not in context
+
+
+def test_format_long_term_memory_context_renders_important_memories():
+    repo = MagicMock()
+    repo.get_recent_long_term_memories.return_value = [
+        {
+            "kind": "event",
+            "display_name": "Ada",
+            "summary": "Tomorrow we deploy the OpenSearch memory processor",
+            "reason": "time-bound event",
+        }
+    ]
+
+    context = group_memory.format_long_term_memory_context(repo, -100123)
+
+    assert "[event speaker=Ada]" in context
+    assert "Tomorrow we deploy" in context
+
+
+def test_classify_long_term_memory_detects_user_preference():
+    result = classify_long_term_memory("I prefer OpenSearch for AWS-native memory retrieval")
+
+    assert result is not None
+    assert result.kind == "user_fact"
+
+
+def test_classify_long_term_memory_skips_sensitive_messages():
+    assert classify_long_term_memory("my password is hunter2 and email is ada@example.com") is None
+
+
+def test_process_group_memory_task_stores_only_important_memory():
+    repo = MagicMock()
+
+    process_group_memory_task(
+        {
+            "chat_id": -100123,
+            "message_id": 11,
+            "user_id": 42,
+            "display_name": "Ada",
+            "username": "ada",
+            "text": "Tomorrow we deploy the group memory processor",
+            "created_at": 1_700_000_000,
+        },
+        repo=repo,
+    )
+
+    repo.store_long_term_memory.assert_called_once()
+    assert repo.store_long_term_memory.call_args.kwargs["kind"] == "event"
+
+
+def test_process_group_memory_task_skips_chatter():
+    repo = MagicMock()
+
+    process_group_memory_task(
+        {
+            "chat_id": -100123,
+            "message_id": 11,
+            "user_id": 42,
+            "display_name": "Ada",
+            "text": "lol ok",
+        },
+        repo=repo,
+    )
+
+    repo.store_long_term_memory.assert_not_called()
+
+
+def test_sqs_client_sends_group_memory_task_payload(monkeypatch):
+    fake_client = MagicMock()
+    monkeypatch.setattr(sqs_module, "_SQS_CLIENT", fake_client)
+    sqs = SQSClient.__new__(SQSClient)
+    sqs.queue_url = "queue-url"
+
+    sqs.send_group_memory_task(
+        chat_id=-100123,
+        message_id=11,
+        user_id=42,
+        display_name="Ada",
+        username="ada",
+        text="Tomorrow we deploy memory processor",
+        created_at=1_700_000_000,
+    )
+
+    payload = json.loads(fake_client.send_message.call_args.kwargs["MessageBody"])
+    assert payload["task_type"] == "PROCESS_GROUP_MEMORY"
+    assert payload["chat_id"] == -100123
+    assert payload["username"] == "ada"
 
 
 def test_agent_should_answer_mention_when_enabled(monkeypatch):
@@ -322,6 +415,7 @@ def test_answer_group_question_passes_target_profile_context(monkeypatch):
     monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
     monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerde_kz_bot")
     monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "Nurt AI: @bayashat токсик")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
     monkeypatch.setattr(
         group_agent,
         "format_user_profile_context",
@@ -341,6 +435,7 @@ def test_answer_group_question_passes_target_profile_context(monkeypatch):
     gemini.group_chat_reply.assert_called_once_with(
         user_message="@zerde_kz_bot @bayashat кім",
         recent_context="Nurt AI: @bayashat токсик",
+        long_term_memory_context="",
         user_profile_context="Trusted profile: username=@bayashat own_topic_terms: opensearch",
         lang="kk",
     )
@@ -433,10 +528,21 @@ def test_memory_on_allows_bot_owner(monkeypatch):
 def test_memory_status_allows_group_admin(monkeypatch):
     monkeypatch.setattr(commands, "ADMIN_USER_ID", 1)
     ctx = _command_ctx(user_id=42, status="administrator")
+    ctx.memory_repo.get_memory_overview.return_value = {
+        "recent_messages": 10,
+        "user_profiles": 2,
+        "events": 1,
+        "user_facts": 3,
+        "group_facts": 1,
+        "jokes": 1,
+        "agent_replies": 4,
+    }
 
     commands.handle_memory_status(ctx)
 
     ctx.memory_repo.get_chat_settings.assert_called_once_with(-100123)
+    ctx.memory_repo.get_memory_overview.assert_called_once_with(-100123)
+    assert "Long-term memory: 1 events, 3 user facts, 1 group facts, 1 jokes" in ctx.reply.call_args.args[0]
 
 
 def test_forget_group_allows_only_bot_owner(monkeypatch):
@@ -453,3 +559,28 @@ def test_forget_group_allows_only_bot_owner(monkeypatch):
     commands.handle_forget_group(owner_ctx)
 
     owner_ctx.memory_repo.delete_chat_memory.assert_called_once_with(-100123)
+
+
+def test_forget_me_deletes_current_users_memory():
+    ctx = _command_ctx(user_id=42)
+    ctx.memory_repo.delete_user_memory.return_value = 5
+
+    commands.handle_forget_me(ctx)
+
+    ctx.memory_repo.delete_user_memory.assert_called_once_with(-100123, 42)
+    assert "Deleted 5 memory items linked to you" in ctx.reply.call_args.args[0]
+
+
+def test_why_reply_uses_replied_bot_message_reason():
+    ctx = _command_ctx(user_id=42)
+    ctx.reply_to_message = {"message_id": 999, "from": {"is_bot": True}}
+    ctx.memory_repo.get_agent_reply_explanation.return_value = {
+        "trigger_kind": "proactive",
+        "reason": "open question with no human answer yet",
+        "confidence": Decimal("0.86"),
+    }
+
+    commands.handle_why_reply(ctx)
+
+    ctx.memory_repo.get_agent_reply_explanation.assert_called_once_with(-100123, bot_message_id=999)
+    assert "open question" in ctx.reply.call_args.args[0]

--- a/tests/test_sqs_task_router.py
+++ b/tests/test_sqs_task_router.py
@@ -71,6 +71,23 @@ def test_spam_check_routes() -> None:
     mock_ps.assert_called_once_with(bot, body, captcha_repo=captcha)
 
 
+def test_process_group_memory_routes() -> None:
+    body = {
+        "task_type": "PROCESS_GROUP_MEMORY",
+        "chat_id": -1001,
+        "user_id": 7,
+        "message_id": 8,
+        "display_name": "Ada",
+        "text": "Tomorrow we deploy the memory processor",
+    }
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch("services.sqs_task_router.process_group_memory_task") as mock_pm,
+    ):
+        process_sqs_event({"Records": [_record(body)]}, MagicMock(), MagicMock())
+    mock_pm.assert_called_once_with(body)
+
+
 def test_non_whitelisted_chat_skips_handlers() -> None:
     body = {
         "task_type": "SPAM_CHECK",


### PR DESCRIPTION
## Summary
- enqueue opted-in group messages as PROCESS_GROUP_MEMORY SQS tasks after synchronous recent-context storage
- add a lightweight privacy-aware memory processor that stores important EVENT, USER_FACT, GROUP_FACT, and JOKE items in the existing DynamoDB memory table
- feed recent long-term memories into group agent replies and record reply explanations for /why_reply
- expand transparency controls with detailed /memory_status, /forget_me, and /why_reply

## Validation
- uv run pytest tests/ -q
- uv run pre-commit run --all-files

## Notes
- This intentionally avoids vector search for now; it creates the trusted long-term memory substrate that OpenSearch or embeddings can retrieve from in a later phase.
