### PR TITLE
[codex] Improve group agent context and architecture docs

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+This file guides Codex when working in this repository. Keep it current with `docs/ARCHITECTURE.md` and `.codex/skills/zerdebot-development/SKILL.md`.
 
 ## Commands
 
@@ -8,85 +8,129 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 # Install dependencies
 uv sync --frozen
 
-# Activate virtual environment
-source .venv/bin/activate
+# Validate Python behavior
+uv run pytest tests/ -q
+uv run pre-commit run --all-files
 
-# Validate CDK infrastructure (run from infra/)
+# Validate CDK infrastructure
 cd infra && uv run cdk synth -c env=dev
 cd infra && uv run cdk diff -c env=dev
 
-# Deploy to AWS
+# Deploy / destroy
 cd infra && uv run cdk deploy -c env=dev
-
-# Destroy stack
 cd infra && uv run cdk destroy -c env=dev
-
-# Tests and lint
-uv run pytest tests/ -q
-uv run pre-commit run --all-files
 ```
 
-Pre-commit runs Black, Isort, and Flake8. Run `uv run pre-commit install` once locally.
+When changing `infra/`, include meaningful `cd infra && uv run cdk diff -c env=dev` output in PR notes. If the diff is only environment config such as `CHAT_LANG_MAP`, say that explicitly.
 
-When changing `infra/`, include `cd infra && uv run cdk diff -c env=dev` output in PR descriptions.
+## Product Direction
 
-## Architecture (current)
+ZerdeBot started as a simple serverless Telegram bot and LLM wrapper. It is now a **memory-enabled agentic Telegram group bot**:
 
-ZerdeBot is a serverless Telegram bot and related jobs on AWS (CDK in `infra/`). Python Lambdas share a **Lambda Layer** with small utilities only (`src/shared/python/zerde_common/`): typed env helpers, SSM secret batch load, JSON logging helpers, provider error types, log redaction helpers.
+- It observes opted-in group messages.
+- It stores recent context, user profiles, long-term memory, daily summaries, and agent reply metadata in DynamoDB.
+- It indexes long-term memory in S3 Vectors for semantic RAG retrieval.
+- It answers `/ask`, @mentions, and reply-to-bot follow-ups with structured context.
+- It may proactively answer only after conservative local and LLM social-timing gates.
+- It still supports captcha, anti-spam, voteban, daily news, and quizzes.
+
+RAG is one capability inside the agent. Do not treat vector search as the only source of truth; recent context, target-user profiles, reply-thread context, and query-filtered long-term memory are also part of the answer path.
+
+## Architecture
 
 ```mermaid
 flowchart LR
-  Telegram[Telegram] --> APIGW[API_Gateway_HTTP]
-  APIGW --> BotLambda[Lambda_bot]
-  BotLambda --> SQS[SQS_timeout_tasks_queue]
-  SQS --> BotLambda
-  EB[EventBridge_schedules] --> NewsLambda[Lambda_news]
-  EB --> QuizLambda[Lambda_quiz]
+  Telegram[Telegram_groups] --> APIGW[HTTP_API_Gateway]
+  APIGW --> BotLambda[Bot_Lambda_webhook_and_SQS_worker]
+  MainQ[SQS_timeout_tasks_queue] --> BotLambda
+  VectorQ[SQS_vector_memory_queue] --> BotLambda
+  BotLambda --> MainQ
+  BotLambda --> VectorQ
+  BotLambda --> Stats[(DynamoDB_stats)]
+  BotLambda --> Memory[(DynamoDB_group_memory)]
+  BotLambda --> S3Vectors[S3_Vectors_memory_index]
+  BotLambda --> Gemini[Gemini]
+  BotLambda --> Groq[Groq]
+  EventBridge[EventBridge_schedules] --> NewsLambda[News_Lambda]
+  EventBridge --> QuizLambda[Quiz_Lambda]
+  Layer[zerde_common_layer] -.-> BotLambda
+  Layer -.-> NewsLambda
+  Layer -.-> QuizLambda
 ```
 
 | Lambda | Package | Entry | Purpose |
 |--------|---------|-------|---------|
-| Bot | `src/bot/` | `main.py:lambda_handler` | API Gateway: verify secret, spam, dispatcher. Same function consumes SQS: `CHECK_TIMEOUT`, `PROCESS_EXPLAIN`, `SPAM_CHECK` (shared container = lower /wtf latency). |
-| News | `src/news/` | `main.py:lambda_handler` | Scheduled digest pipeline |
-| Quiz | `src/quiz/` | `main.py:lambda_handler` | Scheduled quiz + on-demand via bot invoke |
+| Bot | `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and SQS worker. Handles captcha, voteban, spam, `/ask`, agent replies, group memory, vector indexing, and cleanup commands. |
+| News | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest. |
+| Quiz | `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand quiz workflow. |
 
-**Bot package (`src/bot/`):**
+Detailed architecture lives in `docs/ARCHITECTURE.md`.
 
-- `main.py` — one handler: SQS path → `services.sqs_task_router.process_sqs_event`; else → `webhook.handle_event`
-- `app.py` — lazy wiring: `get_bot()`, `get_dispatcher()`, `get_captcha_repo()` (avoid eager init / cold-start cost)
-- `webhook.py` — API Gateway path: secret verification, spam screening service, dispatcher
-- `services/sqs_task_router.py` — SQS record routing; failures **re-raise** so SQS retry + DLQ apply
-- `services/spam/screening_service.py` — rule-based spam + SQS hand-off for Groq check
-- `core/config.py` — non-secret env at import; when `SSM_SECRET_PREFIX` is set, all bot secrets are **batch-loaded once** at import, then getters read `os.environ`
-- `core/dispatcher.py`, `core/translations.py`, `services/handlers/`, `services/repositories/`, `services/telegram.py` — as before
+## Bot Package Map
 
-**Shared layer:** `src/shared/python/zerde_common/` — wired in CDK to bot, news, and quiz Lambdas.
+- `main.py` — detects SQS vs API Gateway and delegates.
+- `app.py` — lazy wiring for Telegram client, dispatcher, captcha repo, and memory repo.
+- `webhook.py` — verifies Telegram secret, screens spam, observes memory, filters irrelevant events, routes agent/commands.
+- `services/sqs_task_router.py` — routes SQS tasks and re-raises failures for retry/DLQ semantics.
+- `services/group_memory.py` — stores recent group context, formats prompt context, target-user profile context, and query-filtered long-term memory.
+- `services/group_memory_processor.py` — async long-term extraction and daily summaries.
+- `services/group_agent.py` — agent trigger policy, proactive gating, reply-thread continuity, answer-length policy.
+- `services/vector_memory.py` — embedding, S3 Vectors indexing, semantic retrieval, cleanup/backfill.
+- `services/repositories/group_memory.py` — DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters.
+- `services/ai/gemini_client.py` — Gemini calls for agent answers, proactive decisions, summaries, embeddings.
+- `services/spam/` — rule-based spam screening plus Groq async checks.
 
-**Infrastructure (`infra/`):**
+## Memory Table
 
-- `stack.py` — `MessagingConstruct`, `BotConstruct`, `NewsConstruct`, `QuizConstruct`, shared layer, CloudWatch alarms
-- `components/bot.py` — one bot Lambda, stats DynamoDB, HTTP API, SQS send + consume
-- `components/messaging.py` — main SQS queue + **DLQ** (`self.dlq`, `self.queue`)
-- `components/news.py`, `components/quiz.py` — scheduled Lambdas + prod EventBridge rules
-- `components/observability.py` — Lambda errors/throttles/duration p95 + DLQ visible alarms (no SNS in repo; subscribe in console if needed)
-- `components/zerde_layer.py` — shared Python layer asset
+Single table partitioned by `pk=CHAT#<chat_id>`:
 
-## Secrets and config
+- `SETTINGS` — memory/agent flags.
+- `MSG#<created_at_ms>#<message_id>` — recent non-command group messages.
+- `USER#<user_id>` — profile from the user's own messages only.
+- `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...` — long-term memories.
+- `DAILY_SUMMARY#YYYY-MM-DD` — compressed daily group memory.
+- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering user message, and reason for reply-thread continuity and `/agent why`.
+- `VECTOR_BACKFILL` — vector backfill status.
+- `PROACTIVE#YYYYMMDD` — daily proactive reply reservation counter.
 
-- Deploy-time `.env` is loaded in `stack.py` for **non-secret** CDK context only.
-- Runtime secrets live in **SSM Parameter Store** under `SSM_SECRET_PREFIX` (e.g. `/zerde/{env}/bot-token`). Bot loads all mapped keys in **one** `GetParameters` call at `core.config` import; news/quiz use their own policies.
-- Local/tests: set env vars directly; leave `SSM_SECRET_PREFIX` empty to skip SSM.
+Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `DAILY_SUMMARY#`.
 
-Lambda env names differ from informal names: `BOT_TOKEN`, `WEBHOOK_SECRET_TOKEN` (not `TELEGRAM_*` in Lambda env).
+## SQS Tasks
 
-## Key design decisions
+- `CHECK_TIMEOUT` — captcha timeout enforcement.
+- `SPAM_CHECK` — async Groq spam decision.
+- `PROCESS_GROUP_ASK` — async explicit `/ask` answer.
+- `PROCESS_GROUP_MEMORY` — classify/store long-term memory from one message.
+- `PROCESS_DAILY_GROUP_SUMMARIES` — daily summaries for configured groups.
+- `PROCESS_VECTOR_MEMORY` — embed/index one memory item.
+- `PROCESS_VECTOR_MEMORY_BACKFILL` — page through vectorizable memory and enqueue indexing.
 
-- **No SnapStart** on these Lambdas (low-frequency / different trade-offs).
-- **One bot Lambda** (API + SQS) so `/wtf` and similar async paths reuse the same warm container; IAM covers webhook + SQS.
-- **Synchronous Telegram updates** via API Gateway; async work via SQS (`/wtf`, spam check, captcha timeout).
-- **Structured JSON logs** via `zerde_common` + per-handler `LoggerAdapter`; no AWS Lambda Powertools dependency in the runtime bundle (keeps cold start lean).
-- **PythonFunction** (`aws_lambda_python_alpha`) bundles each Lambda from its `requirements.txt`; Docker required at synth/deploy time.
+## Secrets And Config
 
-## Naming constants
+- Deploy-time `.env` is loaded by `infra/stack.py` for non-secret CDK config and local runs.
+- Runtime secrets live in SSM Parameter Store under `SSM_SECRET_PREFIX`, for example `/zerde/prod/bot-token`.
+- Bot Lambda env names are `BOT_TOKEN`, `WEBHOOK_SECRET_TOKEN`, `GEMINI_API_KEY`, `GEMINI_EMBEDDING_API_KEY`, `GROQ_API_KEY`, and `DEEPSEEK_API_KEY`; avoid old informal names such as `TELEGRAM_BOT_TOKEN`.
+- Telegram BotFather privacy mode must be disabled, or the bot must be an admin, for full group context.
 
-`CONSTRUCT_PREFIX` ("ZerdeServerless") and `RESOURCE_PREFIX` ("zerde-serverless") live in `components/constants.py` — do not duplicate as string literals in constructs.
+## Key Design Decisions
+
+- **No SnapStart**: low-frequency workloads and Python package trade-offs make SnapStart unnecessary here.
+- **One bot Lambda for webhook and SQS**: `/ask`, spam, captcha, memory, and vector tasks share warm containers and common wiring.
+- **Separate vector queue**: slower embedding/backfill work does not block real-time timeout/spam/ask tasks.
+- **Trust hierarchy for agent answers**: current user message and reply-thread context > target user's own profile > query-matched vector memory > query-filtered long-term memory > recent group chatter.
+- **Prompt pollution control**: do not inject unfiltered recent long-term memories into answers; filter by query or use vector retrieval.
+- **Reply length control**: follow-up replies should stay short unless the user explicitly asks for detail.
+- **Structured logging**: use `zerde_common` and avoid logging full prompts, model responses, API keys, Telegram files, or user secrets.
+
+## Documentation Maintenance
+
+When making a large change to architecture, memory, agent behavior, SQS tasks, data schemas, environment variables, or infrastructure:
+
+1. Update `docs/ARCHITECTURE.md`.
+2. Update this file.
+3. Update `.codex/skills/zerdebot-development/SKILL.md`.
+4. Update `README.md`, `docs/README_kk.md`, and `docs/README_ru.md` when user-visible behavior changes.
+5. Update `docs/LOCAL_TESTING.md` and `.env.example` when setup/config changes.
+6. Update `docs/telegram_history_import.md` when import or vector indexing behavior changes.
+
+Historical documents under `docs/superpowers/` are plan snapshots, not current architecture references.

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -1,29 +1,78 @@
 ---
 name: zerdebot-development
-description: Work on the ZerdeBot repository, a serverless AWS CDK Telegram bot with Python Lambdas for bot/webhook/SQS, news, quiz, spam, and AI provider integrations. Use when Codex is asked to inspect, modify, test, review, deploy-plan, debug, or optimize this repo, especially changes involving `src/bot`, `src/news`, `src/quiz`, `src/shared`, `infra`, AI providers such as Gemini/DeepSeek/Groq, Telegram behavior, SQS workflows, DynamoDB repositories, or CDK infrastructure.
+description: Work on the ZerdeBot repository, a serverless AWS CDK Telegram group-chat agent with Python Lambdas for bot/webhook/SQS, RAG memory, DynamoDB profiles, S3 Vectors semantic retrieval, Gemini/Groq/DeepSeek AI integrations, news digests, quizzes, spam controls, and CDK infrastructure. Use when Codex is asked to inspect, modify, test, review, document, deploy-plan, debug, or optimize this repo, especially changes involving `src/bot`, `src/news`, `src/quiz`, `src/shared`, `infra`, group memory, agent behavior, `/ask`, vector indexing, Telegram behavior, SQS workflows, DynamoDB repositories, or AI providers.
 ---
 
 # ZerdeBot Development
 
-## Overview
+## Operating Posture
 
-Use this skill as the project-specific operating guide for ZerdeBot. It keeps Codex aligned with the repo architecture, validation commands, deployment constraints, and AI-provider reliability expectations.
+Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wrapper. The bot combines serverless community tooling with RAG memory and social agent behavior:
+
+- Recent group context and user profiles live in DynamoDB.
+- Long-term memory and daily summaries live in DynamoDB and are indexed in S3 Vectors.
+- Gemini handles agent answers, proactive timing decisions, summaries, and embeddings.
+- Groq handles async spam checks.
+- The bot should answer only when useful, keep reply length appropriate, and avoid prompt pollution from irrelevant memories.
 
 ## First Steps
 
-1. Read `.codex/AGENTS.md` before making non-trivial code, infra, AI, or deployment changes.
-2. Check the active branch and dirty worktree with `git status --short --branch`.
-3. Preserve user changes. Do not revert unrelated files.
-4. Prefer focused changes that follow existing package boundaries.
+1. Read `.codex/AGENTS.md` before non-trivial code, infra, AI, memory, or deployment work.
+2. Read `docs/ARCHITECTURE.md` before changing group memory, agent behavior, SQS routing, DynamoDB schema, vector retrieval, or CDK wiring.
+3. Check branch and worktree with `git status --short --branch`.
+4. Preserve user changes. Do not revert unrelated files.
+5. Prefer repo patterns and focused changes over new abstractions.
 
 ## Repository Map
 
-- `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, spam screening, `/wtf`, `/explain`, `/genquiz` invoke path.
+- `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector indexing.
+- `src/bot/services/group_agent.py`: agent trigger policy, proactive gating, reply-thread continuity, response length policy.
+- `src/bot/services/group_memory.py`: recent context observation and prompt formatting, target-user profiles, query-filtered long-term context.
+- `src/bot/services/group_memory_processor.py`: async long-term memory extraction and daily summaries.
+- `src/bot/services/vector_memory.py`: Gemini embeddings, S3 Vectors indexing/retrieval, vector cleanup/backfill.
+- `src/bot/services/repositories/group_memory.py`: DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, and proactive counters.
 - `src/news/`: scheduled news digest Lambda.
-- `src/quiz/`: scheduled and on-demand quiz Lambda, AI-generated question bank, Telegram poll sending.
+- `src/quiz/`: scheduled and on-demand quiz Lambda.
 - `src/shared/python/zerde_common/`: shared Lambda layer utilities.
 - `infra/`: AWS CDK stack and constructs.
-- `tests/`: pytest coverage for bot, quiz, spam, shared utilities.
+- `docs/ARCHITECTURE.md`: current architecture source of truth.
+- `tests/`: pytest coverage for bot, quiz, spam, shared utilities, memory, and agent behavior.
+
+## Memory And Agent Guardrails
+
+- Do not inject unfiltered long-term memory into agent prompts. Use query-filtered long-term context and semantic vector retrieval.
+- User profile context must be derived from the target user's own messages; third-party roasts or labels are low trust.
+- Reply-to-bot follow-ups must include prior `AGENT_REPLY#...` answer context when available.
+- Store useful bot answer metadata in `AGENT_REPLY#...` so `/agent why` and thread continuation work.
+- Keep proactive participation conservative: local open-question prefilter, bot-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
+- Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.
+- If cleaning production memory, first back up exact DynamoDB items and vector keys locally, then delete narrowly.
+
+## SQS And Persistence
+
+SQS handler failures should re-raise when retry/DLQ semantics are intended. Current bot SQS task types:
+
+- `CHECK_TIMEOUT`
+- `SPAM_CHECK`
+- `PROCESS_GROUP_ASK`
+- `PROCESS_GROUP_MEMORY`
+- `PROCESS_DAILY_GROUP_SUMMARIES`
+- `PROCESS_VECTOR_MEMORY`
+- `PROCESS_VECTOR_MEMORY_BACKFILL`
+
+DynamoDB memory key families:
+
+- `SETTINGS`
+- `MSG#...`
+- `USER#...`
+- `EVENT#...`
+- `USER_FACT#...`
+- `GROUP_FACT#...`
+- `JOKE#...`
+- `DAILY_SUMMARY#...`
+- `AGENT_REPLY#...`
+- `VECTOR_BACKFILL`
+- `PROACTIVE#...`
 
 ## Common Commands
 
@@ -45,29 +94,34 @@ Treat AI behavior as user-facing reliability work:
 
 - Verify current model names against official provider docs when model availability, preview/stable status, or rate limits matter.
 - Avoid preview/shutdown model IDs for production defaults.
-- Prefer fast fallback for interactive commands (`/wtf`, `/explain`, `/genquiz`) over long primary-provider retries.
+- Prefer fast fallback for interactive commands and `/ask` paths over long primary-provider retries.
 - Keep scheduled/batch paths allowed to retry longer than interactive user commands.
 - Map provider transport, 429, 5xx, and parse failures into consistent error types where the codebase already has that pattern.
-- Do not log full model prompts, responses, API keys, Telegram file contents, or user secrets.
+- Do not log full prompts, model responses, API keys, Telegram file contents, or user secrets.
 
 ## Implementation Guidance
 
-- Bot SQS routing failures should re-raise when retry/DLQ semantics are intended.
 - Keep Lambda cold-start cost low: use lazy wiring and avoid unnecessary runtime dependencies.
 - Use `zerde_common` for shared provider errors, config helpers, redaction, and structured logging.
-- Keep Lambda env names consistent with code: `BOT_TOKEN`, `WEBHOOK_SECRET_TOKEN`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`.
+- Keep Lambda env names consistent with code: `BOT_TOKEN`, `WEBHOOK_SECRET_TOKEN`, `GEMINI_API_KEY`, `GEMINI_EMBEDDING_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`.
 - Use `CONSTRUCT_PREFIX` and `RESOURCE_PREFIX` from `infra/components/constants.py`; do not duplicate those string literals in constructs.
-- If editing Telegram HTML output, normalize/escape LLM output before sending.
+- If editing Telegram HTML output, normalize/escape LLM output before sending and respect Telegram length constraints.
+
+## Documentation Maintenance
+
+For substantial changes, update documentation proactively in the same work:
+
+- Always update `.codex/AGENTS.md`, `docs/ARCHITECTURE.md`, and this skill for architecture, memory, agent, SQS, data schema, or infra changes.
+- Update `README.md`, `docs/README_kk.md`, and `docs/README_ru.md` for user-visible behavior changes.
+- Update `docs/LOCAL_TESTING.md` and `.env.example` for setup/config changes.
+- Update `docs/telegram_history_import.md` for import, backfill, or vector indexing changes.
+- Historical files under `docs/superpowers/` are plan snapshots; do not rewrite them as current architecture unless explicitly asked.
 
 ## Validation Expectations
 
-Choose validation proportional to the change:
+Choose validation proportional to risk:
 
-- Narrow Python change: run the directly relevant pytest files.
-- Shared behavior, AI provider routing, repositories, dispatcher, or Telegram formatting: run `uv run pytest tests/ -q`.
+- Narrow Python change: run relevant pytest files.
+- Shared behavior, AI provider routing, repositories, dispatcher, memory, or Telegram formatting: run `uv run pytest tests/ -q`.
 - Formatting/lint-sensitive work: run `uv run pre-commit run --all-files`.
-- CDK or Lambda env changes: run `cd infra && uv run cdk diff -c env=dev`.
-
-## Reference
-
-Detailed architecture, command, secret, and design-decision guidance lives in `.codex/AGENTS.md`. Read it when context is needed rather than duplicating it here.
+- CDK or Lambda env changes: run `cd infra && uv run cdk diff -c env=dev` and report the diff.

--- a/.codex/skills/zerdebot-development/agents/openai.yaml
+++ b/.codex/skills/zerdebot-development/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ZerdeBot Development"
-  short_description: "Work safely on the ZerdeBot serverless Telegram bot."
-  default_prompt: "Use $zerdebot-development to inspect, change, test, and validate this repository."
+  short_description: "Work safely on the ZerdeBot serverless Telegram agent with RAG memory."
+  default_prompt: "Use $zerdebot-development to inspect, change, document, test, and validate this memory-enabled agentic Telegram bot."

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 DEFAULT_LANG=kk
 TELEGRAM_API_BASE=https://api.telegram.org/bot
 
-AI_PROVIDER=gemini
 GEMINI_MODEL=gemini-3.1-flash-lite
 NEWS_GEMINI_MODEL=gemini-3.1-flash-lite
 QUIZ_GEMINI_MODEL=gemini-3.1-flash-lite
@@ -40,11 +39,18 @@ AGENT_PROACTIVE_FINAL_THRESHOLD=0.72
 CHATS_KK="-1234567890"
 CHATS_ZH="-1234567890"
 CHATS_RU="-1234567890"
+NEWS_CHATS_KK=
+NEWS_CHATS_ZH=
+NEWS_CHATS_RU=
+QUIZ_CHATS_KK=
+QUIZ_CHATS_ZH=
+QUIZ_CHATS_RU=
 
 BOT_TOKEN=<your_bot_token>
 WEBHOOK_SECRET_TOKEN=<your_webhook_secret_token>
 
 GEMINI_API_KEY=<your_gemini_api_key>
+GEMINI_EMBEDDING_API_KEY=
 GROQ_API_KEY=<your_groq_api_key>
 DEEPSEEK_API_KEY=<your_deepseek_api_key>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,12 @@ Edit `.env` and fill in the required values. See the table below for all keys.
 
 | Variable | Description |
 |----------|-------------|
-| `TELEGRAM_BOT_TOKEN` | Token from [@BotFather](https://t.me/botfather) |
-| `TELEGRAM_WEBHOOK_SECRET_TOKEN` | Random secret for webhook validation (`openssl rand -hex 32`) |
-| `GEMINI_API_KEY` | Google Gemini API key (for news summarization and quiz translation) |
-| `QUIZAPI_KEY` | [QuizAPI](https://quizapi.io/) key (for daily quiz questions) |
+| `BOT_TOKEN` | Token from [@BotFather](https://t.me/botfather) |
+| `WEBHOOK_SECRET_TOKEN` | Random secret for webhook validation (`openssl rand -hex 32`) |
+| `GEMINI_API_KEY` | Google Gemini API key for agent replies, news, summaries, and quiz generation |
+| `GEMINI_EMBEDDING_API_KEY` | Optional separate Gemini key for vector embeddings; falls back to `GEMINI_API_KEY` when unset |
+| `GROQ_API_KEY` | Groq API key for async spam checks |
+| `DEEPSEEK_API_KEY` | Optional DeepSeek fallback key |
 
 **Optional (have defaults):**
 
@@ -73,12 +75,18 @@ Edit `.env` and fill in the required values. See the table below for all keys.
 |----------|---------|-------------|
 | `DEFAULT_LANG` | `kk` | Default bot language (`kk`, `ru`, `zh`) |
 | `TELEGRAM_API_BASE` | `https://api.telegram.org/bot` | Override for local testing proxies |
-| `AI_PROVIDER` | `gemini` | AI provider for news/quiz (`gemini`) |
-| `LLM_MODEL` | `gemini-2.5-flash` | LLM model name |
+| `GEMINI_MODEL` | `gemini-3.1-flash-lite` | Bot agent and memory-summary model |
+| `NEWS_GEMINI_MODEL` | `gemini-3.1-flash-lite` | News digest model |
+| `QUIZ_GEMINI_MODEL` | `gemini-3.1-flash-lite` | Quiz generation model |
+| `GROUP_MEMORY_ENABLED` | `true` | Enables recent group memory and long-term memory writes |
+| `VECTOR_MEMORY_ENABLED` | `true` | Enables S3 Vectors semantic memory indexing/retrieval |
+| `AGENT_ENABLED` | `true` | Enables `/ask`, @mention, reply-to-bot, and proactive agent behavior |
+| `AGENT_BOT_USERNAME` | `@zerde_kz_bot` | Bot username used for mention detection |
+| `CHATS_KK` / `CHATS_ZH` / `CHATS_RU` | _(empty)_ | Whitelisted bot chats and language mapping |
 | `NEWS_CHATS_KK` | _(empty)_ | Comma-separated chat IDs for Kazakh news digest |
 | `NEWS_CHATS_ZH` | _(empty)_ | Comma-separated chat IDs for Chinese news digest |
 | `NEWS_CHATS_RU` | _(empty)_ | Comma-separated chat IDs for Russian news digest |
-| `QUIZ_CHATS` | _(empty)_ | Comma-separated chat IDs for daily quiz |
+| `QUIZ_CHATS_KK` / `QUIZ_CHATS_ZH` / `QUIZ_CHATS_RU` | _(empty)_ | Per-language quiz target chats |
 
 Never commit `.env` — it is in `.gitignore`.
 
@@ -130,18 +138,22 @@ uv run cdk synth -c env=dev
 | Path | Description |
 |------|-------------|
 | `infra/` | AWS CDK stacks: API Gateway, DynamoDB, SQS, EventBridge, all Lambdas |
-| `src/bot/` | Bot Lambda — webhook handler, captcha, voteban, quiz scoring, stats |
+| `src/bot/` | Bot Lambda — webhook handler, SQS worker, captcha, voteban, spam, group memory, RAG agent, vector indexing |
 | `src/news/` | News Lambda — fetches IT news, summarizes via Gemini, sends multilingual digest |
-| `src/quiz/` | Quiz Lambda — fetches tech questions from QuizAPI, sends daily Telegram quizzes |
+| `src/quiz/` | Quiz Lambda — generates/sends multilingual developer quizzes |
+| `src/shared/python/zerde_common/` | Shared Lambda layer utilities |
+| `docs/ARCHITECTURE.md` | Current architecture source of truth |
 | `scripts/` | DevOps helpers: OIDC setup, webhook registration |
 
-**Three independent Lambda functions:**
+**Lambda functions and workloads:**
 
 | Lambda | Entry | Trigger | Responsibility |
 |--------|-------|---------|----------------|
-| `src/bot/` | `main.py` | API Gateway + SQS | Captcha, voteban, quiz score tracking, `/stats`, `/quizstats` |
-| `src/news/` | `main.py` | EventBridge (daily) | Fetch news → Gemini summary → send to Kazakh/Russian/Chinese chats |
-| `src/quiz/` | `main.py` | EventBridge (daily) | Fetch quiz questions from QuizAPI → send Telegram poll → track scores |
+| `src/bot/` | `main.py` | API Gateway + SQS | Telegram webhook, captcha, voteban, spam checks, `/ask`, agent replies, memory writes, vector indexing |
+| `src/news/` | `main.py` | EventBridge (daily) | Fetch news → Gemini/DeepSeek-compatible summary → send multilingual digest |
+| `src/quiz/` | `main.py` | EventBridge + bot invoke | Generate quiz questions → send Telegram poll → track scores |
+
+Large changes to architecture, memory, agent behavior, SQS tasks, or infrastructure must update `docs/ARCHITECTURE.md`, `.codex/AGENTS.md`, and `.codex/skills/zerdebot-development/SKILL.md` in the same PR.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🛡️ Zerde Bot
+# Zerde Bot
 
-[ 🇬🇧 English ](README.md) | [ 🇰🇿 Қазақша ](docs/README_KK.md) | [ 🇷🇺 Русский ](docs/README_RU.md)
+[English](README.md) | [Қазақша](docs/README_kk.md) | [Русский](docs/README_ru.md)
 
 ![Python](https://img.shields.io/badge/Python-3.13-blue.svg)
 ![uv](https://img.shields.io/badge/uv-Managed-purple.svg?logo=python)
@@ -10,139 +10,133 @@
 ![AWS CDK](https://img.shields.io/badge/AWS_CDK-v2-orange.svg)
 ![AWS Lambda](https://img.shields.io/badge/AWS_Lambda-Serverless-ff9900.svg?logo=awslambda&logoColor=white)
 ![DynamoDB](https://img.shields.io/badge/Amazon_DynamoDB-NoSQL-4053D6.svg?logo=amazondynamodb&logoColor=white)
+![S3 Vectors](https://img.shields.io/badge/S3_Vectors-RAG_memory-569A31.svg?logo=amazons3&logoColor=white)
 ![Google Gemini](https://img.shields.io/badge/Google_Gemini-AI-8E75B2.svg?logo=googlegemini&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-CI%2FCD-2088FF.svg?logo=githubactions&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 
-![Zerde Bot Architecture](assets/architecture.png)
+**Zerde** is a serverless Telegram bot for IT communities. It started as a simple LLM wrapper and community-management bot; it is now an **agentic group-chat bot with RAG memory**. It can answer explicit `/ask` prompts, follow reply threads, remember group context, retrieve relevant long-term memories, and decide when it is socially useful to join a conversation.
 
-**Zerde** is a production-ready, serverless Telegram bot for IT community management — handling anti-spam, community voting, daily AI-powered news digests, and interactive tech quizzes, all without managing a single server.
-
-Built with **Python 3.13** and **AWS CDK v2**. Running 24/7 on AWS Free Tier at **$0/month**.
+The bot still handles moderation, captcha, voteban, daily AI news digests, and tech quizzes. The current architecture is optimized for small community workloads on AWS serverless infrastructure.
 
 ---
 
-## 🌟 Built on a Serverless Starter Template ($0 Cost)
+## What Changed
 
-Curious about how to build a bot like this from scratch without paying for servers?
+Zerde is no longer "just call an LLM with the latest message." The bot now has:
 
-**Zerde Bot** is a real-world implementation built on top of the **[serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter)** — an open-source template for building production-grade serverless Telegram bots on AWS.
+- **Recent memory**: non-command group messages stored in DynamoDB as `MSG#...`.
+- **User profiles**: lightweight per-user context derived from each user's own messages.
+- **Long-term memory**: extracted `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, and `DAILY_SUMMARY#...` items.
+- **Vector RAG**: long-term memories embedded with Gemini and indexed in S3 Vectors for semantic retrieval.
+- **Agent behavior**: explicit `/ask`, @mention handling, reply-to-bot thread continuity, proactive reply gating, reply-length budgeting, and `/agent why`.
+- **Memory controls**: `/memory`, `/agent`, `/memory forget me`, and owner-only group cleanup commands.
 
-**The biggest advantage? It costs exactly $0/month.** Because it uses a 100% serverless architecture (API Gateway, Lambda, DynamoDB, SQS, CDK), you only pay for what you use. For most Telegram bots, the traffic falls entirely within the generous AWS Free Tier.
-
-If you want to build your own bot with the same robust architecture, zero maintenance, and zero hosting fees, start with the template! It gives you the wiring, CI/CD, and project structure out of the box.
+RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, then ask the LLM to answer with that context. Zerde uses RAG as one layer inside a larger group-chat agent.
 
 ---
 
-## ✨ Key Features
+## Key Features
 
 | Feature | Description |
 |---------|-------------|
-| 🛡️ **Smart Captcha & Anti-Spam** | Automatically mutes new members until they verify via an inline button. Unverified users are kicked after **60 seconds** using an SQS Delay Queue. |
-| 🗳️ **Community Voteban** | Democratized moderation. Reply to a message with `/voteban` to initiate a vote. Requires 7 community votes to ban or forgive a user. |
-| 📰 **AI-Powered Daily News** | Daily EventBridge cron triggers a Lambda to fetch IT news, summarize it via **Google Gemini API** in Kazakh, Russian, and Chinese, and broadcast it to groups. |
-| 🧠 **Interactive IT Quizzes** | Automated daily tech quizzes sourced from QuizAPI. The bot tracks individual scores, maintains daily streaks, and features a community leaderboard. |
-| 📊 **Community Analytics** | Comprehensive tracking of joins, verification success rates, and moderation stats per group. |
-| ⚡ **Zero-Cost Serverless** | 100% Infrastructure as Code (AWS CDK). Uses Lambda **SnapStart** for ultra-fast cold starts. Stays entirely within the AWS Free Tier ($0/month). |
+| Group-chat agent | Answers `/ask`, @mentions, and replies to bot messages with recent, profile, long-term, and semantic memory context. |
+| RAG memory | Stores group memory in DynamoDB and indexes long-term memory in S3 Vectors for query-matched retrieval. |
+| Reply thread continuity | Records bot answers in `AGENT_REPLY#...` items so follow-up replies know what the bot just said. |
+| Social timing | Proactive replies pass local heuristics, recent bot activity penalties, Gemini judgment, and per-chat daily limits. |
+| Smart captcha and anti-spam | Mutes new members until verification and routes suspicious messages through rule-based and Groq checks. |
+| Community voteban | Lets communities vote to ban or forgive by replying with `/voteban`. |
+| Daily AI news | EventBridge-triggered news Lambda summarizes tech news through Gemini/DeepSeek-compatible provider paths. |
+| IT quizzes | Scheduled and on-demand quiz Lambda sends multilingual developer quizzes and tracks scores. |
+| Serverless operations | AWS CDK manages Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM, and alarms. |
 
 ---
 
-## 🏗️ Architecture
-
-The infrastructure consists of three fully independent Lambda functions sharing no code, achieving strict isolation and clean architecture:
+## Architecture
 
 ```mermaid
-graph TD
-    subgraph Telegram
-        TG[Telegram API]
-    end
+flowchart LR
+  TG["Telegram groups"] --> APIGW["HTTP API Gateway"]
+  APIGW --> BOT["Bot Lambda<br/>webhook + SQS worker"]
 
-    subgraph AWS Cloud [AWS Serverless Infrastructure]
-        API[API Gateway]
-        Bot[Bot Lambda<br/>Webhook: Captcha, Voteban, Commands]
-        SQS[SQS Delay Queue<br/>Timeout Tasks]
-        DB[(DynamoDB<br/>Stats, Votes, Quiz Scores)]
+  BOT --> STATS[("DynamoDB<br/>stats / captcha / votes")]
+  BOT --> MEMORY[("DynamoDB<br/>group memory")]
+  BOT --> MAINQ["SQS timeout/tasks queue"]
+  MAINQ --> BOT
 
-        EB1[EventBridge<br/>Daily Cron 04:00]
-        News[News Lambda<br/>AI IT News Digest]
+  BOT --> VQ["SQS vector memory queue"]
+  VQ --> BOT
+  BOT --> S3V["S3 Vectors<br/>semantic memory index"]
 
-        EB2[EventBridge<br/>Daily Cron 08:00]
-        Quiz[Quiz Lambda<br/>Tech Quizzes]
-    end
+  BOT --> GEMINI["Gemini<br/>agent replies / summaries / embeddings"]
+  BOT --> GROQ["Groq<br/>spam checks"]
 
-    subgraph External APIs
-        Gemini[Google Gemini API]
-        QuizAPI[QuizAPI.io]
-    end
+  EB["EventBridge schedules"] --> NEWS["News Lambda"]
+  EB --> QUIZ["Quiz Lambda"]
+  NEWS --> GEMINI
+  QUIZ --> GEMINI
+  NEWS --> TG
+  QUIZ --> TG
 
-    %% Webhook Flow
-    TG -- Webhook --> API
-    API -- Sync Invoke --> Bot
-    Bot -- 60s Deferred Task --> SQS
-    SQS -- Trigger --> Bot
-    Bot <--> DB
-
-    %% News Flow
-    EB1 --> News
-    News -- Fetch & Summarize --> Gemini
-    News -- Send Digest --> TG
-
-    %% Quiz Flow
-    EB2 --> Quiz
-    Quiz -- Fetch Questions --> QuizAPI
-    Quiz <--> DB
-    Quiz -- Send Quiz --> TG
+  LAYER["Shared Lambda layer<br/>zerde_common"] -.-> BOT
+  LAYER -.-> NEWS
+  LAYER -.-> QUIZ
 ```
 
-| Lambda Component | Trigger Source | Purpose |
-|------------------|----------------|---------|
-| `src/bot/` | API Gateway + SQS | Handles Telegram webhooks synchronously. Manages captcha verifications, voteban sessions, quiz scoring, and community stats. |
-| `src/news/` | EventBridge Cron | Runs daily (04:00 UTC). Fetches tech news, summarizes it using AI, and pushes multilingual digests to target chats. |
-| `src/quiz/` | EventBridge Cron | Runs daily (08:00 UTC). Fetches developer quizzes, translates them if necessary, and dispatches them to community chats. |
+| Component | Trigger | Responsibility |
+|-----------|---------|----------------|
+| `src/bot/` | API Gateway + SQS | Telegram webhook, captcha, voteban, spam screening, `/ask`, agent replies, memory writes, vector indexing tasks. |
+| `src/news/` | EventBridge | Scheduled multilingual IT news digest. |
+| `src/quiz/` | EventBridge + bot invoke | Scheduled and on-demand developer quizzes. |
+| `src/shared/python/zerde_common/` | Lambda layer | Shared config, secret loading, logging, redaction, and provider error helpers. |
+| `infra/` | CDK | Serverless infrastructure, queues, tables, vector bucket/index, alarms, and Lambda wiring. |
+
+For the deeper developer map, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ---
 
-## 🤖 Bot Commands
+## Bot Commands
 
 | Command | Who | Description |
 |---------|-----|-------------|
-| `/start` | Everyone | Restart the bot and view instructions |
-| `/help` | Everyone | Show usage guide and rules |
-| `/ping` | Everyone | Health check — confirms bot is alive |
-| `/support` | Everyone | Get developer contact info |
-| `/stats` | Admins | Community statistics and activity level |
-| `/voteban` | Everyone | Reply to a message to start a ban vote |
-| `/quizstats` | Everyone | Your personal quiz score, streak, and rank |
+| `/start` | Everyone | Restart the bot and view instructions. |
+| `/help` | Everyone | Show usage guide and available commands. |
+| `/ping` | Everyone | Health check. |
+| `/support` | Everyone | Developer contact info. |
+| `/stats` | Admins | Community statistics. |
+| `/voteban` | Everyone | Reply to a message to start a ban vote. |
+| `/quizstats` | Everyone | Personal quiz score, streak, and rank. |
+| `/ask <question>` | Everyone in memory-enabled groups | Ask the agent; can be used as a reply to another message. |
+| `/memory on/off/status/forget ...` | Group owner or bot owner for settings | Manage group memory and cleanup. |
+| `/agent on/off/status/why` | Group owner or bot owner for settings | Manage agent participation and inspect why the bot replied. |
 
 ---
 
-## ⚙️ CI/CD Setup (GitHub Actions)
-
-This repository includes a GitHub Actions workflow for automated deployment via OIDC (no long-lived AWS keys).
-
-We provide a setup script to automate the IAM configuration:
+## Development
 
 ```bash
-# Usage: ./scripts/setup_oidc.sh <GITHUB_ORG/REPO>
-./scripts/setup_oidc.sh Bayashat/zerde-serverless-bot
+uv sync --frozen
+uv run pytest tests/ -q
+uv run pre-commit run --all-files
 ```
 
-**What this script does:**
+Infrastructure validation:
 
-- Creates an OIDC Provider in IAM (if missing).
-- Creates an IAM Role (`GitHubAction-Deploy-TelegramBot`) that trusts your specific GitHub repository.
-- Outputs the **AWS_ROLE_ARN** to add as a GitHub Repository Secret.
+```bash
+cd infra
+uv run cdk synth -c env=dev
+uv run cdk diff -c env=dev
+```
 
----
-
-## 🛠️ Contributing
-
-We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup (clone, uv, CDK, pre-commit) and PR process.
-
-For a full walkthrough — AWS account, new bot, token, deploy from scratch — see [Local Testing Guide](docs/LOCAL_TESTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and [docs/LOCAL_TESTING.md](docs/LOCAL_TESTING.md) for a full AWS + Telegram walkthrough.
 
 ---
 
-## 📄 License
+## History
 
-This project is licensed under the **MIT License**.
+Zerde was originally built from the [serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter) template. That starter remains useful for simple serverless Telegram bots. This repository has since grown into a memory-enabled agentic bot with separate news and quiz workloads.
+
+---
+
+## License
+
+This project is licensed under the MIT License.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,161 @@
+# ZerdeBot Architecture
+
+This is the current developer-facing map of ZerdeBot. Keep it updated when changing memory, agent behavior, SQS task routing, DynamoDB schemas, vector retrieval, or CDK wiring.
+
+## Product Direction
+
+ZerdeBot is no longer a simple LLM wrapper. The bot is now a serverless Telegram group-chat agent:
+
+- It observes opted-in group messages and stores recent context.
+- It extracts long-term memories and daily summaries.
+- It embeds long-term memory into S3 Vectors for semantic retrieval.
+- It answers explicit questions with recent context, user profiles, long-term memory, and query-matched vector memory.
+- It can continue reply threads with its own previous answers.
+- It may proactively join a discussion, but only after local gating, model timing judgment, recent-bot-activity penalty, and daily limits.
+
+RAG is one part of the system. The larger system is an agentic bot: it decides whether to answer, what context to use, how long the answer should be, and what to remember afterward.
+
+## Runtime Topology
+
+```mermaid
+flowchart LR
+  TG["Telegram"] --> APIGW["HTTP API Gateway"]
+  APIGW --> BOT["Bot Lambda<br/>src/bot/main.py"]
+  MAINQ["SQS timeout/tasks queue"] --> BOT
+  VQ["SQS vector memory queue"] --> BOT
+
+  BOT --> STATS[("DynamoDB stats table")]
+  BOT --> MEMORY[("DynamoDB memory table")]
+  BOT --> MAINQ
+  BOT --> VQ
+  BOT --> S3V["S3 Vectors index"]
+  BOT --> GEMINI["Gemini API"]
+  BOT --> GROQ["Groq API"]
+
+  EB["EventBridge"] --> NEWS["News Lambda"]
+  EB --> QUIZ["Quiz Lambda"]
+  NEWS --> GEMINI
+  QUIZ --> GEMINI
+  NEWS --> TG
+  QUIZ --> TG
+
+  LAYER["zerde_common Lambda layer"] -.-> BOT
+  LAYER -.-> NEWS
+  LAYER -.-> QUIZ
+```
+
+## Lambda Packages
+
+| Package | Entry | Main responsibilities |
+|---------|-------|-----------------------|
+| `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and SQS worker in one Lambda. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, vector indexing, and cleanup commands. |
+| `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest and Telegram delivery. |
+| `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand multilingual developer quizzes. |
+| `src/shared/python/zerde_common/` | Lambda layer | Shared env helpers, SSM batch secret loading, provider errors, JSON logging, redaction, Telegram update log truncation. |
+
+## Bot Request Flow
+
+1. `webhook.handle_event` verifies the Telegram webhook secret.
+2. Private chats get a fixed response; non-whitelisted groups are ignored.
+3. Spam screening runs before normal handling unless a captcha is pending.
+4. `group_memory.observe_update` stores non-command group messages and queues long-term memory extraction.
+5. Irrelevant group chatter exits early.
+6. Relevant events route to the group agent or the command dispatcher.
+7. `/ask` is queued as `PROCESS_GROUP_ASK` so Telegram webhook latency stays low.
+
+## SQS Tasks
+
+The bot Lambda consumes both real-time and slower background tasks:
+
+| Task type | Queue | Handler |
+|-----------|-------|---------|
+| `CHECK_TIMEOUT` | timeout/tasks queue | Captcha timeout enforcement. |
+| `SPAM_CHECK` | timeout/tasks queue | Groq-based async spam classification. |
+| `PROCESS_GROUP_ASK` | timeout/tasks queue | Async explicit agent answer. |
+| `PROCESS_GROUP_MEMORY` | timeout/tasks queue | Extract one long-term memory item from a stored group message. |
+| `PROCESS_DAILY_GROUP_SUMMARIES` | timeout/tasks queue | Build daily summaries for configured groups. |
+| `PROCESS_VECTOR_MEMORY` | vector memory queue | Embed and index one memory item in S3 Vectors. |
+| `PROCESS_VECTOR_MEMORY_BACKFILL` | vector memory queue | Page through historical vectorizable memory items and enqueue indexing. |
+
+Failures re-raise in `services/sqs_task_router.py` so SQS retry and DLQ semantics apply.
+
+## DynamoDB Memory Table
+
+The table is single-table by chat partition:
+
+| Key pattern | Meaning |
+|-------------|---------|
+| `pk=CHAT#<chat_id>, sk=SETTINGS` | Per-chat `memory_enabled` and `agent_enabled`. |
+| `sk=MSG#<created_at_ms>#<message_id>` | Recent raw group message for prompt context. |
+| `sk=USER#<user_id>` | User profile derived only from that user's own messages. |
+| `sk=EVENT#...` | Time-bound event or operational memory. |
+| `sk=USER_FACT#<user_id>#...` | User-stated preference or recurring personal context. |
+| `sk=GROUP_FACT#...` | Group decision or shared preference. |
+| `sk=JOKE#...` | Possible recurring joke or meme. Use carefully; this is easy to over-retrieve. |
+| `sk=DAILY_SUMMARY#YYYY-MM-DD` | Daily compressed memory for imported or observed messages. |
+| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, and triggering user message for reply-thread continuity. |
+| `sk=VECTOR_BACKFILL` | Last vector backfill status for a chat. |
+| `sk=PROACTIVE#YYYYMMDD` | Daily proactive reply reservation counter. |
+
+Only long-term memory prefixes and daily summaries are vectorizable. Raw `MSG#...` items are prompt context, not vector memory.
+
+## Agent Answer Context
+
+`services.group_agent.answer_group_question` builds these sections:
+
+1. Trusted target-user profile context, only for users explicitly mentioned in the user message.
+2. Semantic memory context from S3 Vectors, query-matched by current user text.
+3. Long-term memory context filtered by current query terms.
+4. Recent group context with speaker metadata.
+5. Reply-thread context when the user replies to the bot's previous answer.
+
+The Gemini prompt instructs the model to treat target-user profiles as higher trust than third-party chatter, to use semantic memory only when relevant, and to avoid turning one-off jokes into permanent facts.
+
+## Agent Timing And Length
+
+Proactive replies are conservative:
+
+- The local prefilter only considers open questions or requests.
+- Bot-meta complaints and stop cues are ignored.
+- Recent bot activity lowers the score.
+- Gemini must return a strong "should reply" decision.
+- `AGENT_DAILY_PROACTIVE_LIMIT` caps per-chat daily proactive responses.
+
+Answer length is explicit:
+
+- Reply-to-bot follow-ups get a short budget.
+- Plain `/ask` explanations get a medium budget.
+- Detailed answers require explicit cues such as "подробно", "толық", or "deep dive".
+- `fit_llm_output` trims overly long responses before Telegram HTML normalization.
+
+## Vector Memory
+
+S3 Vectors is used for semantic retrieval over trusted long-term memory:
+
+- Embedding model: `VECTOR_MEMORY_EMBEDDING_MODEL` (default `gemini-embedding-2`).
+- Dimensions: `VECTOR_MEMORY_DIMENSIONS` (default `768`).
+- Provider: `VECTOR_MEMORY_PROVIDER=s3_vectors`.
+- Vectorizable items: `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, `DAILY_SUMMARY#`.
+- Cleanup commands should delete both DynamoDB memory and associated vector keys when available.
+
+When vector indexing is incomplete, the agent still works with recent context and query-filtered DynamoDB long-term memory. Do not assume vector backfill will fix prompt pollution by itself.
+
+## Important Operational Notes
+
+- Telegram BotFather privacy mode must be disabled, or the bot must be admin, to see full group context.
+- Production uses SSM Parameter Store under `/zerde/<env>/...` for runtime secrets.
+- `.env` is deploy-time CDK input for non-secret config and local/test execution.
+- Do not log full prompts, full model responses, API keys, Telegram files, or user secrets.
+- For production memory cleanup, first export the target DynamoDB items and vector keys to a local backup file, then delete narrowly.
+- Historical plan documents under `docs/superpowers/` are snapshots. Do not treat them as current architecture.
+
+## Documentation Maintenance
+
+When making a large architecture, memory, agent, queue, or infra change, update all of these in the same PR:
+
+- `.codex/skills/zerdebot-development/SKILL.md`
+- `.codex/AGENTS.md`
+- `docs/ARCHITECTURE.md`
+- `README.md`, `docs/README_kk.md`, and `docs/README_ru.md` when user-visible behavior changes
+- `docs/LOCAL_TESTING.md` when env vars, deployment, queues, or setup steps change
+- `docs/telegram_history_import.md` when memory import or vector indexing behavior changes

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -8,7 +8,7 @@ This guide walks you through running Zerde Bot end-to-end: creating an AWS accou
 
 1. Go to [aws.amazon.com](https://aws.amazon.com) and choose **Create an AWS Account**.
 2. Complete sign-up (email, password, account type, payment method, identity verification).
-   **Note:** The AWS Free Tier is sufficient for all three Lambda functions; you will not be charged under normal testing loads.
+   **Note:** The AWS Free Tier is usually sufficient for light testing, but vector memory and LLM calls can create provider-side costs or quotas.
 3. Sign in to the **AWS Management Console**.
 4. (Recommended) Create an IAM user for day-to-day use instead of the root user:
    - **IAM** → **Users** → **Create user** (e.g. `zerde-dev`).
@@ -45,7 +45,7 @@ aws sts get-caller-identity
 
 5. **Save this token** — you will use it as `BOT_TOKEN`. Do not share it or commit it to git.
 
-Optional: Create a test group, add your bot as admin with "Delete messages" and "Restrict members" permissions to test the captcha and kick flows. Add it to a second group to test the quiz.
+Optional: Create a test group, add your bot as admin with "Delete messages" and "Restrict members" permissions to test captcha, kick, and full group-context flows. Disable BotFather privacy mode or keep the bot as admin so it can observe non-command group messages for memory.
 
 ---
 
@@ -53,11 +53,12 @@ Optional: Create a test group, add your bot as admin with "Delete messages" and 
 
 Zerde can use three external APIs beyond Telegram:
 
-### Google Gemini (for News and Quiz translation)
+### Google Gemini (for agent replies, memory summaries, embeddings, news, and quiz)
 
 1. Go to [aistudio.google.com](https://aistudio.google.com) and sign in with a Google account.
 2. Create an API key. Copy it — this is your `GEMINI_API_KEY`.
-3. Free tier is sufficient for daily digest volumes.
+3. Free tier is usually sufficient for small tests.
+4. Optional: use a separate key for `GEMINI_EMBEDDING_API_KEY`; if omitted, the bot can use `GEMINI_API_KEY`.
 
 ### Groq (for async spam checks)
 
@@ -96,6 +97,9 @@ GROQ_API_KEY=<your Groq API key>
 DEEPSEEK_API_KEY=<your DeepSeek API key>
 
 # Optional — configure chat IDs to receive news/quiz
+CHATS_KK=<comma-separated chat IDs for Kazakh/default bot groups>
+CHATS_ZH=<comma-separated chat IDs for Chinese bot groups>
+CHATS_RU=<comma-separated chat IDs for Russian bot groups>
 NEWS_CHATS_KK=<comma-separated chat IDs for Kazakh news>
 NEWS_CHATS_ZH=<comma-separated chat IDs for Chinese news>
 NEWS_CHATS_RU=<comma-separated chat IDs for Russian news>
@@ -104,11 +108,18 @@ QUIZ_CHATS_ZH=<comma-separated chat IDs for Chinese quiz>
 QUIZ_CHATS_RU=<comma-separated chat IDs for Russian quiz>
 
 # Optional — defaults shown
-AI_PROVIDER=gemini
 GEMINI_MODEL=gemini-3.1-flash-lite
-NEWS_GEMINI_MODEL=gemini-3-flash-preview
-QUIZ_GEMINI_MODEL=gemini-3-flash-preview
+NEWS_GEMINI_MODEL=gemini-3.1-flash-lite
+QUIZ_GEMINI_MODEL=gemini-3.1-flash-lite
 DEFAULT_LANG=kk
+
+# Optional — group memory / agent
+GROUP_MEMORY_ENABLED=true
+VECTOR_MEMORY_ENABLED=true
+VECTOR_MEMORY_PROVIDER=s3_vectors
+AGENT_ENABLED=true
+AGENT_BOT_USERNAME=@your_bot_username
+AGENT_RECENT_CONTEXT_LIMIT=100
 ```
 
 **To find a group's chat ID:** Add [@userinfobot](https://t.me/userinfobot) to the group; it will print the chat ID on join.
@@ -123,7 +134,7 @@ Never commit `.env` — it is in `.gitignore`.
 # Synthesize CloudFormation (optional validation step)
 uv run cdk synth -c env=dev
 
-# Deploy all three Lambdas + infrastructure
+# Deploy Lambdas + queues + tables + optional S3 Vectors resources
 uv run cdk deploy -c env=dev
 ```
 
@@ -132,10 +143,12 @@ When prompted to approve IAM changes, type `y`.
 After a successful deploy, the terminal prints an **ApiEndpoint** URL (e.g. `https://xxxx.execute-api.eu-central-1.amazonaws.com/dev/`). Copy it.
 
 The deploy creates:
-- **Bot Lambda** — API Gateway webhook endpoint + SQS queue
+- **Bot Lambda** — API Gateway webhook endpoint + SQS worker for captcha, spam, `/ask`, memory, and vector tasks
 - **News Lambda** — EventBridge rules (only active in `prod` env)
 - **Quiz Lambda** — EventBridge rule at 08:00 UTC + DynamoDB quiz table (only active in `prod` env)
-- **DynamoDB** — stats table (joins/bans) + quiz table (scores/leaderboard)
+- **DynamoDB** — stats table, group-memory table, and quiz table
+- **SQS** — timeout/tasks queue plus vector-memory queue, each with DLQ
+- **S3 Vectors** — vector bucket/index when `VECTOR_MEMORY_ENABLED=true` and provider is `s3_vectors`
 
 > EventBridge schedules are only created when deploying with `-c env=prod`. For local testing, invoke the News and Quiz Lambdas manually from the AWS Console or CLI.
 
@@ -176,6 +189,9 @@ curl -F "url=https://abc123.execute-api.eu-central-1.amazonaws.com/dev/webhook" 
 3. Send `/ping` — confirms the Lambda is reachable.
 4. Add the bot to a test group as admin and trigger a join to test captcha flow.
 5. Reply to any message with `/voteban` to test the vote-to-ban flow.
+6. In a group, run `/memory status` to confirm memory and vector status.
+7. Run `/ask what is this chat discussing?` or reply to a message with `/ask` to test the group agent.
+8. Reply to the bot's answer with a follow-up question to test `AGENT_REPLY#...` thread continuity.
 
 **To test the Quiz Lambda manually:**
 
@@ -215,10 +231,10 @@ curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/deleteWebhook"
 | AWS | Account + IAM user with CLI access (`aws configure`) |
 | Telegram | Bot created via @BotFather, token saved |
 | Gemini | API key from [aistudio.google.com](https://aistudio.google.com) |
-| QuizAPI | API key from [quizapi.io](https://quizapi.io) |
-| Project | Clone, uv, CDK CLI, `uv sync`, `.env` with all required keys |
+| Groq | API key from [console.groq.com](https://console.groq.com/) |
+| Project | Clone, uv, CDK CLI, `uv sync`, `.env` with required keys and chat IDs |
 | Deploy | `uv run cdk deploy -c env=dev` |
 | Webhook | `setWebhook` with API endpoint and same secret as in `.env` |
-| Test | Chat with bot and/or test in a group |
+| Test | Chat with bot, test captcha/voteban, `/memory status`, `/ask`, and reply-to-bot follow-ups |
 
 For contribution workflow (branching, pre-commit, PRs), see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -1,148 +1,138 @@
-# 🛡️ Zerde Bot
+# Zerde Bot
 
-**[English](README.md)** | **[Қазақша](README_kk.md)** | **[Русский](README_ru.md)**
+[English](../README.md) | [Қазақша](README_kk.md) | [Русский](README_ru.md)
 
 ![Python](https://img.shields.io/badge/Python-3.13-blue.svg)
 ![uv](https://img.shields.io/badge/uv-Managed-purple.svg?logo=python)
-![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)
-![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
-![Linted_by: Flake8](https://img.shields.io/badge/Linted_by-Flake8-yellow.svg)
-![AWS CDK](https://img.shields.io/badge/AWS_CDK-v2-orange.svg)
 ![AWS Lambda](https://img.shields.io/badge/AWS_Lambda-Serverless-ff9900.svg?logo=awslambda&logoColor=white)
 ![DynamoDB](https://img.shields.io/badge/Amazon_DynamoDB-NoSQL-4053D6.svg?logo=amazondynamodb&logoColor=white)
+![S3 Vectors](https://img.shields.io/badge/S3_Vectors-RAG_memory-569A31.svg?logo=amazons3&logoColor=white)
 ![Google Gemini](https://img.shields.io/badge/Google_Gemini-AI-8E75B2.svg?logo=googlegemini&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-CI%2FCD-2088FF.svg?logo=githubactions&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 
-![Zerde Bot Architecture](../assets/architecture.png)
+**Zerde** — IT қауымдастықтарына арналған serverless Telegram боты. Бұрын ол қарапайым LLM wrapper және moderation bot болатын; қазіргі бағыты — **RAG жады бар agentic group-chat bot**. Ол `/ask` сұрақтарына жауап береді, reply thread-ті түсінеді, топ контекстін есте сақтайды, ұзақ мерзімді memory-ден релевант ақпарат іздейді және чатқа қашан араласу дұрыс екенін бағалайды.
 
-**Zerde** — бұл IT қауымдастықтарын басқаруға арналған өндіріске дайын, серверсіз Telegram боты. Ол спамға қарсы қорғанысты, қауымдастықтағы дауыс беруді, жасанды интеллект арқылы күнделікті жаңалықтар топтамасын және интерактивті IT викториналарын бірде-бір серверді басқармай-ақ жүзеге асырады.
-
-**Python 3.13** және **AWS CDK v2** арқылы жасалған. AWS Free Tier-де **айына $0** шығынмен 24/7 жұмыс істейді.
+Бот әлі де captcha, anti-spam, voteban, күнделікті AI news digest және IT quiz функцияларын атқарады. Бірақ негізгі жаңа қабат — group memory және agent behavior.
 
 ---
 
-## 🌟 Серверсіз бастапқы шаблон негізінде құрастырылған ($0 Шығын)
+## Не өзгерді?
 
-Серверлерге ақша төлемей, осындай ботты нөлден қалай жасауға болатыны қызық па?
+Zerde енді тек “соңғы хабарламаны LLM-ге жіберетін” бот емес. Қазір онда:
 
-**Zerde Bot** — бұл AWS-те өндірістік деңгейдегі серверсіз Telegram боттарын құруға арналған ашық бастапқы **[serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter)** шаблоны негізінде жасалған нақты мысал.
+- **Recent memory**: command емес топ хабарламалары DynamoDB-де `MSG#...` ретінде сақталады.
+- **User profiles**: әр адамның өз хабарламаларынан алынған жеңіл profile.
+- **Long-term memory**: `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, `DAILY_SUMMARY#...`.
+- **Vector RAG**: long-term memory Gemini embedding арқылы S3 Vectors index-ке түседі.
+- **Agent behavior**: `/ask`, @mention, bot жауабына reply follow-up, proactive reply gating, жауап ұзындығын басқару, `/agent why`.
+- **Memory controls**: `/memory`, `/agent`, `/memory forget me`, owner-only group cleanup.
 
-**Ең үлкен артықшылығы? Ол айына дәл $0 тұрады.** 100% серверсіз архитектураны (API Gateway, Lambda, DynamoDB, SQS, CDK) пайдаланатындықтан, сіз тек пайдаланған ресурстарыңыз үшін ғана төлейсіз. Көптеген Telegram боттары үшін трафик толығымен жомарт AWS Free Tier шегінде қалады.
-
-Егер сіз осындай мықты архитектурасы бар, техникалық қызмет көрсетуді және хостинг ақысын қажет етпейтін жеке ботыңызды жасағыңыз келсе, шаблоннан бастаңыз! Ол сізге дайын конфигурацияны, CI/CD және жоба құрылымын бірден ұсынады.
-
----
-
-## ✨ Негізгі мүмкіндіктер
-
-| Мүмкіндік | Сипаттамасы |
-|---------|-------------|
-| 🛡️ **Ақылды Captcha және Спамға қарсы** | Жаңа мүшелерді кірістірілген түйме арқылы растағанша автоматты түрде бұғаттайды. Расталмаған пайдаланушылар SQS Delay Queue арқылы **60 секундтан** кейін шығарылады. |
-| 🗳️ **Қауымдастық Voteban** | Демократияландырылған модерация. Дауыс беруді бастау үшін хабарламаға `/voteban` деп жауап беріңіз. Пайдаланушыны бұғаттау немесе кешіру үшін қауымдастықтың 7 даусы қажет. |
-| 📰 **Жасанды интеллект негізіндегі күнделікті жаңалықтар** | Күнделікті EventBridge cron Lambda-ны іске қосып, IT жаңалықтарын жинайды, **Google Gemini API** арқылы қазақ, орыс және қытай тілдерінде қысқаша мазмұндайды және топтарға таратады. |
-| 🧠 **Интерактивті IT Викториналар** | QuizAPI-ден алынған автоматтандырылған күнделікті технологиялық викториналар. Бот жеке ұпайларды қадағалайды, күнделікті қатарынан жауап беруді (streak) сақтайды және қауымдастық көшбасшылар тақтасын ұсынады. |
-| 📊 **Қауымдастық аналитикасы** | Әр топ бойынша қосылуларды, растау сәттілігінің деңгейін және модерация статистикасын кешенді қадағалау. |
-| ⚡ **Нөлдік шығынды серверсіз (Zero-Cost Serverless)** | 100% код түріндегі инфрақұрылым (AWS CDK). Өте жылдам суық іске қосу (cold starts) үшін Lambda **SnapStart** пайдаланады. Толығымен AWS Free Tier аясында қалады (айына $0). |
+RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен релевант memory/document іздеу, содан кейін LLM-ге сол контекстпен жауап бергізу. Zerde-де RAG — үлкенірек agentic bot архитектурасының бір қабаты.
 
 ---
 
-## 🏗️ Архитектура
+## Негізгі мүмкіндіктер
 
-Инфрақұрылым ешқандай ортақ коды жоқ үш толық тәуелсіз Lambda функциясынан тұрады, бұл қатаң оқшаулау мен таза архитектураны қамтамасыз етеді:
+| Мүмкіндік | Сипаттама |
+|----------|-----------|
+| Group-chat agent | `/ask`, @mention және bot жауабына reply арқылы қойылған сұрақтарға recent/profile/long-term/semantic memory контекстімен жауап береді. |
+| RAG memory | Group memory DynamoDB-де сақталады, long-term memory S3 Vectors арқылы semantic retrieval үшін индекстеледі. |
+| Reply thread continuity | Bot жауаптары `AGENT_REPLY#...` ретінде сақталады, сондықтан follow-up сұрақтар алдыңғы жауапты біледі. |
+| Social timing | Proactive жауаптар local heuristics, recent bot penalty, Gemini decision және daily limit арқылы өтеді. |
+| Captcha және anti-spam | Жаңа мүшелерді тексеру, rule-based және Groq арқылы spam тексеру. |
+| Community voteban | `/voteban` арқылы қауымдастық дауысымен ban/forgive. |
+| Daily AI news | EventBridge арқылы іске қосылатын news Lambda Gemini/DeepSeek-compatible жолдармен IT news digest жасайды. |
+| IT quizzes | Scheduled және on-demand quiz Lambda көптілді developer quiz жібереді. |
+| Serverless ops | AWS CDK Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM және alarms ресурстарын басқарады. |
+
+---
+
+## Архитектура
 
 ```mermaid
-graph TD
-    subgraph Telegram
-        TG[Telegram API]
-    end
+flowchart LR
+  TG["Telegram groups"] --> APIGW["HTTP API Gateway"]
+  APIGW --> BOT["Bot Lambda<br/>webhook + SQS worker"]
 
-    subgraph AWS Cloud [AWS Serverless Infrastructure]
-        API[API Gateway]
-        Bot[Bot Lambda<br/>Webhook: Captcha, Voteban, Commands]
-        SQS[SQS Delay Queue<br/>Timeout Tasks]
-        DB[(DynamoDB<br/>Stats, Votes, Quiz Scores)]
+  BOT --> STATS[("DynamoDB<br/>stats / captcha / votes")]
+  BOT --> MEMORY[("DynamoDB<br/>group memory")]
+  BOT --> MAINQ["SQS timeout/tasks queue"]
+  MAINQ --> BOT
 
-        EB1[EventBridge<br/>Daily Cron 04:00]
-        News[News Lambda<br/>AI IT News Digest]
+  BOT --> VQ["SQS vector memory queue"]
+  VQ --> BOT
+  BOT --> S3V["S3 Vectors<br/>semantic memory index"]
 
-        EB2[EventBridge<br/>Daily Cron 08:00]
-        Quiz[Quiz Lambda<br/>Tech Quizzes]
-    end
+  BOT --> GEMINI["Gemini<br/>agent replies / summaries / embeddings"]
+  BOT --> GROQ["Groq<br/>spam checks"]
 
-    subgraph External APIs
-        Gemini[Google Gemini API]
-        QuizAPI[QuizAPI.io]
-    end
+  EB["EventBridge schedules"] --> NEWS["News Lambda"]
+  EB --> QUIZ["Quiz Lambda"]
+  NEWS --> GEMINI
+  QUIZ --> GEMINI
+  NEWS --> TG
+  QUIZ --> TG
 
-    %% Webhook Flow
-    TG -- Webhook --> API
-    API -- Sync Invoke --> Bot
-    Bot -- 60s Deferred Task --> SQS
-    SQS -- Trigger --> Bot
-    Bot <--> DB
-
-    %% News Flow
-    EB1 --> News
-    News -- Fetch & Summarize --> Gemini
-    News -- Send Digest --> TG
-
-    %% Quiz Flow
-    EB2 --> Quiz
-    Quiz -- Fetch Questions --> QuizAPI
-    Quiz <--> DB
-    Quiz -- Send Quiz --> TG
+  LAYER["Shared Lambda layer<br/>zerde_common"] -.-> BOT
+  LAYER -.-> NEWS
+  LAYER -.-> QUIZ
 ```
 
-| Lambda компоненті | Іске қосу көзі | Мақсаты |
-|------------------|----------------|---------|
-| `src/bot/` | API Gateway + SQS | Telegram webhook-терін синхронды түрде өңдейді. Captcha растауларын, voteban сессияларын, викторина ұпайларын және қауымдастық статистикасын басқарады. |
-| `src/news/` | EventBridge Cron | Күнделікті жұмыс істейді (04:00 UTC). Технологиялық жаңалықтарды жинайды, AI көмегімен қысқаша мазмұндайды және мақсатты чаттарға көптілді дайджесттер жібереді. |
-| `src/quiz/` | EventBridge Cron | Күнделікті жұмыс істейді (08:00 UTC). Әзірлеушілерге арналған викториналарды жинайды, қажет болса аударады және оларды қауымдастық чаттарына жібереді. |
+| Компонент | Trigger | Міндеті |
+|-----------|---------|---------|
+| `src/bot/` | API Gateway + SQS | Telegram webhook, captcha, voteban, spam screening, `/ask`, agent replies, memory writes, vector indexing tasks. |
+| `src/news/` | EventBridge | Көптілді IT news digest. |
+| `src/quiz/` | EventBridge + bot invoke | Scheduled және on-demand developer quizzes. |
+| `src/shared/python/zerde_common/` | Lambda layer | Ортақ config, secret loading, logging, redaction, provider error helpers. |
+| `infra/` | CDK | Serverless infrastructure, queues, tables, vector bucket/index, alarms, Lambda wiring. |
+
+Толығырақ developer map: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
-## 🤖 Бот командалары
+## Bot командалары
 
-| Команда | Кімге | Сипаттамасы |
-|---------|-----|-------------|
-| `/start` | Барлығына | Ботты қайта іске қосу және нұсқаулықтарды көру |
-| `/help` | Барлығына | Пайдалану нұсқаулығы мен ережелерді көрсету |
-| `/ping` | Барлығына | Денсаулықты тексеру — боттың жұмыс істеп тұрғанын растайды |
-| `/support` | Барлығына | Әзірлеушінің байланыс ақпаратын алу |
-| `/stats` | Әкімшілерге | Қауымдастық статистикасы және белсенділік деңгейі |
-| `/voteban` | Барлығына | Бұғаттауға дауыс беруді бастау үшін хабарламаға жауап ретінде жазу |
-| `/quizstats` | Барлығына | Сіздің жеке викторина ұпайыңыз, қатарынан жауап беруіңіз және рейтингіңіз |
+| Команда | Кімге | Сипаттама |
+|---------|------|-----------|
+| `/start` | Барлығына | Ботты қайта бастау және нұсқаулық көру. |
+| `/help` | Барлығына | Командалар мен ережелер. |
+| `/ping` | Барлығына | Health check. |
+| `/support` | Барлығына | Developer contact. |
+| `/stats` | Admins | Community статистикасы. |
+| `/voteban` | Барлығына | Reply арқылы ban vote бастау. |
+| `/quizstats` | Барлығына | Жеке quiz score, streak, rank. |
+| `/ask <question>` | Memory қосылған топтарда | Agent-ке сұрақ қою; басқа хабарламаға reply ретінде де қолдануға болады. |
+| `/memory on/off/status/forget ...` | Group owner немесе bot owner | Group memory басқару және cleanup. |
+| `/agent on/off/status/why` | Group owner немесе bot owner | Agent participation басқару және bot неге жауап бергенін көру. |
 
 ---
 
-## ⚙️ CI/CD баптауы (GitHub Actions)
-
-Бұл репозиторийде OIDC арқылы автоматты түрде орналастыруға арналған GitHub Actions жұмыс процесі бар (ұзақ мерзімді AWS кілттерін қажет етпейді).
-
-Біз IAM конфигурациясын автоматтандыру үшін орнату сценарийін ұсынамыз:
+## Әзірлеу
 
 ```bash
-# Пайдалану: ./scripts/setup_oidc.sh <GITHUB_ORG/REPO>
-./scripts/setup_oidc.sh Bayashat/zerde-serverless-bot
+uv sync --frozen
+uv run pytest tests/ -q
+uv run pre-commit run --all-files
 ```
 
-**Бұл сценарий не істейді:**
+Infra тексеру:
 
-- IAM-де OIDC провайдерін жасайды (егер жоқ болса).
-- Сіздің нақты GitHub репозиторийіңізге сенім білдіретін IAM рөлін (`GitHubAction-Deploy-TelegramBot`) жасайды.
-- GitHub Repository Secret ретінде қосу үшін **AWS_ROLE_ARN** шығарады.
+```bash
+cd infra
+uv run cdk synth -c env=dev
+uv run cdk diff -c env=dev
+```
 
----
-
-## 🛠️ Үлес қосу
-
-Біз үлес қосуға әрқашан қуаныштымыз. Әзірлеуді баптау (clone, uv, CDK, pre-commit) және PR процесі туралы білу үшін [CONTRIBUTING.md](CONTRIBUTING.md) файлын қараңыз.
-
-Толық нұсқаулық үшін — AWS аккаунты, жаңа бот, токен, нөлден бастап орналастыру — [Жергілікті тестілеу нұсқаулығын](docs/LOCAL_TESTING.md) қараңыз.
+Setup үшін [CONTRIBUTING.md](../CONTRIBUTING.md), толық AWS + Telegram walkthrough үшін [LOCAL_TESTING.md](LOCAL_TESTING.md) қараңыз.
 
 ---
 
-## 📄 Лицензия
+## Тарих
 
-Бұл жоба **MIT License** бойынша лицензияланған.
+Zerde бастапқыда [serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter) негізінде жасалған. Ол starter қарапайым serverless Telegram bot үшін әлі де пайдалы. Бұл репозиторий кейін memory-enabled agentic bot, news және quiz workload-тары бар толық жүйеге айналды.
+
+---
+
+## License
+
+MIT License.

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -1,148 +1,138 @@
-# 🛡️ Zerde Bot
+# Zerde Bot
 
-**[English](README.md)** | **[Қазақша](README_kk.md)** | **[Русский](README_ru.md)**
+[English](../README.md) | [Қазақша](README_kk.md) | [Русский](README_ru.md)
 
 ![Python](https://img.shields.io/badge/Python-3.13-blue.svg)
 ![uv](https://img.shields.io/badge/uv-Managed-purple.svg?logo=python)
-![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)
-![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
-![Linted_by: Flake8](https://img.shields.io/badge/Linted_by-Flake8-yellow.svg)
-![AWS CDK](https://img.shields.io/badge/AWS_CDK-v2-orange.svg)
 ![AWS Lambda](https://img.shields.io/badge/AWS_Lambda-Serverless-ff9900.svg?logo=awslambda&logoColor=white)
 ![DynamoDB](https://img.shields.io/badge/Amazon_DynamoDB-NoSQL-4053D6.svg?logo=amazondynamodb&logoColor=white)
+![S3 Vectors](https://img.shields.io/badge/S3_Vectors-RAG_memory-569A31.svg?logo=amazons3&logoColor=white)
 ![Google Gemini](https://img.shields.io/badge/Google_Gemini-AI-8E75B2.svg?logo=googlegemini&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-CI%2FCD-2088FF.svg?logo=githubactions&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 
-![Zerde Bot Architecture](assets/architecture.png)
+**Zerde** — serverless Telegram-бот для IT-сообществ. Раньше он был простым LLM wrapper и ботом для модерации; сейчас это **agentic group-chat bot с RAG-памятью**. Он отвечает на `/ask`, понимает reply threads, помнит контекст группы, достает релевантные долгосрочные воспоминания и решает, когда уместно вступить в разговор.
 
-**Zerde** — это готовый к использованию в рабочей среде бессерверный Telegram-бот для управления IT-сообществами. Он обрабатывает защиту от спама, голосования сообщества, ежедневные подборки новостей на базе ИИ и интерактивные технические викторины, и всё это без управления серверами.
-
-Создан с использованием **Python 3.13** и **AWS CDK v2**. Работает 24/7 на уровне AWS Free Tier с затратами **$0/мес**.
+Бот по-прежнему поддерживает captcha, anti-spam, voteban, ежедневные AI news digest и IT quizzes. Главный новый слой — group memory и agent behavior.
 
 ---
 
-## 🌟 Создан на базе бессерверного шаблона (Затраты $0)
+## Что изменилось?
 
-Интересно, как создать подобного бота с нуля, не платя за серверы?
+Zerde больше не просто отправляет последнее сообщение в LLM. Сейчас в нем есть:
 
-**Zerde Bot** — это реальная реализация, построенная на базе **[serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter)** — опенсорсного шаблона для создания production-ready бессерверных Telegram-ботов на AWS.
+- **Recent memory**: не-command сообщения группы хранятся в DynamoDB как `MSG#...`.
+- **User profiles**: легкий профиль пользователя, построенный только из его собственных сообщений.
+- **Long-term memory**: `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, `DAILY_SUMMARY#...`.
+- **Vector RAG**: long-term memory эмбеддится через Gemini и индексируется в S3 Vectors.
+- **Agent behavior**: `/ask`, @mention, follow-up через reply на ответ бота, proactive reply gating, контроль длины ответа, `/agent why`.
+- **Memory controls**: `/memory`, `/agent`, `/memory forget me`, owner-only group cleanup.
 
-**Главное преимущество? Это стоит ровно $0 в месяц.** Поскольку используется 100% бессерверная архитектура (API Gateway, Lambda, DynamoDB, SQS, CDK), вы платите только за то, что используете. Для большинства Telegram-ботов трафик полностью укладывается в щедрые рамки AWS Free Tier.
-
-Если вы хотите создать своего собственного бота с такой же надежной архитектурой, отсутствием необходимости в обслуживании и нулевыми затратами на хостинг, начните с этого шаблона! Он предоставляет готовую инфраструктуру, CI/CD и структуру проекта прямо из коробки.
+RAG означает **Retrieval-Augmented Generation**: сначала найти релевантную память или документы, затем дать LLM этот контекст для ответа. В Zerde RAG — один слой внутри более широкой agentic bot архитектуры.
 
 ---
 
-## ✨ Ключевые возможности
+## Ключевые возможности
 
 | Функция | Описание |
-|---------|-------------|
-| 🛡️ **Умная Captcha и антиспам** | Автоматически мутит новых участников, пока они не подтвердят себя через inline-кнопку. Неподтвержденные пользователи удаляются через **60 секунд** с помощью очереди задержки SQS. |
-| 🗳️ **Общественный Voteban** | Демократизированная модерация. Ответьте на сообщение командой `/voteban`, чтобы начать голосование. Требуется 7 голосов сообщества, чтобы забанить или простить пользователя. |
-| 📰 **Ежедневные новости на базе ИИ** | Ежедневный cron EventBridge запускает Lambda для сбора IT-новостей, делает их краткую сводку через **Google Gemini API** на казахском, русском и китайском языках и рассылает по группам. |
-| 🧠 **Интерактивные IT-викторины** | Автоматизированные ежедневные технические викторины из QuizAPI. Бот отслеживает индивидуальные баллы, серии ответов и ведет таблицу лидеров сообщества. |
-| 📊 **Аналитика сообщества** | Комплексное отслеживание присоединений, уровня успешных верификаций и статистики модерации по группам. |
-| ⚡ **Zero-Cost Serverless** | 100% Infrastructure as Code (AWS CDK). Использует Lambda **SnapStart** для сверхбыстрого холодного запуска. Полностью остается в рамках AWS Free Tier ($0/мес). |
+|---------|----------|
+| Group-chat agent | Отвечает на `/ask`, @mentions и replies на сообщения бота с учетом recent/profile/long-term/semantic memory. |
+| RAG memory | Group memory хранится в DynamoDB, long-term memory индексируется в S3 Vectors для semantic retrieval. |
+| Reply thread continuity | Ответы бота сохраняются как `AGENT_REPLY#...`, поэтому follow-up вопросы знают предыдущий ответ. |
+| Social timing | Proactive replies проходят local heuristics, штраф за недавнюю активность бота, Gemini decision и daily limit. |
+| Captcha и anti-spam | Проверка новых участников, rule-based spam screening и Groq checks. |
+| Community voteban | `/voteban` позволяет сообществу голосовать за ban/forgive. |
+| Daily AI news | News Lambda по EventBridge делает IT news digest через Gemini/DeepSeek-compatible paths. |
+| IT quizzes | Scheduled и on-demand quiz Lambda отправляет multilingual developer quizzes. |
+| Serverless ops | AWS CDK управляет Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM и alarms. |
 
 ---
 
-## 🏗️ Архитектура
-
-Инфраструктура состоит из трех полностью независимых функций Lambda, не имеющих общего кода, что обеспечивает строгую изоляцию и чистую архитектуру:
+## Архитектура
 
 ```mermaid
-graph TD
-    subgraph Telegram
-        TG[Telegram API]
-    end
+flowchart LR
+  TG["Telegram groups"] --> APIGW["HTTP API Gateway"]
+  APIGW --> BOT["Bot Lambda<br/>webhook + SQS worker"]
 
-    subgraph AWS Cloud [AWS Serverless Infrastructure]
-        API[API Gateway]
-        Bot[Bot Lambda<br/>Webhook: Captcha, Voteban, Commands]
-        SQS[SQS Delay Queue<br/>Timeout Tasks]
-        DB[(DynamoDB<br/>Stats, Votes, Quiz Scores)]
+  BOT --> STATS[("DynamoDB<br/>stats / captcha / votes")]
+  BOT --> MEMORY[("DynamoDB<br/>group memory")]
+  BOT --> MAINQ["SQS timeout/tasks queue"]
+  MAINQ --> BOT
 
-        EB1[EventBridge<br/>Daily Cron 04:00]
-        News[News Lambda<br/>AI IT News Digest]
+  BOT --> VQ["SQS vector memory queue"]
+  VQ --> BOT
+  BOT --> S3V["S3 Vectors<br/>semantic memory index"]
 
-        EB2[EventBridge<br/>Daily Cron 08:00]
-        Quiz[Quiz Lambda<br/>Tech Quizzes]
-    end
+  BOT --> GEMINI["Gemini<br/>agent replies / summaries / embeddings"]
+  BOT --> GROQ["Groq<br/>spam checks"]
 
-    subgraph External APIs
-        Gemini[Google Gemini API]
-        QuizAPI[QuizAPI.io]
-    end
+  EB["EventBridge schedules"] --> NEWS["News Lambda"]
+  EB --> QUIZ["Quiz Lambda"]
+  NEWS --> GEMINI
+  QUIZ --> GEMINI
+  NEWS --> TG
+  QUIZ --> TG
 
-    %% Webhook Flow
-    TG -- Webhook --> API
-    API -- Sync Invoke --> Bot
-    Bot -- 60s Deferred Task --> SQS
-    SQS -- Trigger --> Bot
-    Bot <--> DB
-
-    %% News Flow
-    EB1 --> News
-    News -- Fetch & Summarize --> Gemini
-    News -- Send Digest --> TG
-
-    %% Quiz Flow
-    EB2 --> Quiz
-    Quiz -- Fetch Questions --> QuizAPI
-    Quiz <--> DB
-    Quiz -- Send Quiz --> TG
+  LAYER["Shared Lambda layer<br/>zerde_common"] -.-> BOT
+  LAYER -.-> NEWS
+  LAYER -.-> QUIZ
 ```
 
-| Компонент Lambda | Источник триггера | Назначение |
-|------------------|----------------|---------|
-| `src/bot/` | API Gateway + SQS | Синхронно обрабатывает вебхуки Telegram. Управляет верификацией капчи, сессиями voteban, подсчетом очков в викторинах и статистикой сообщества. |
-| `src/news/` | EventBridge Cron | Запускается ежедневно (04:00 UTC). Собирает новости технологий, делает их сводку с помощью ИИ и отправляет мультиязычные дайджесты в целевые чаты. |
-| `src/quiz/` | EventBridge Cron | Запускается ежедневно (08:00 UTC). Собирает викторины для разработчиков, при необходимости переводит их и рассылает в чаты сообщества. |
+| Компонент | Trigger | Ответственность |
+|-----------|---------|-----------------|
+| `src/bot/` | API Gateway + SQS | Telegram webhook, captcha, voteban, spam screening, `/ask`, agent replies, memory writes, vector indexing tasks. |
+| `src/news/` | EventBridge | Мультиязычный IT news digest. |
+| `src/quiz/` | EventBridge + bot invoke | Scheduled и on-demand developer quizzes. |
+| `src/shared/python/zerde_common/` | Lambda layer | Общие config, secret loading, logging, redaction, provider error helpers. |
+| `infra/` | CDK | Serverless infrastructure, queues, tables, vector bucket/index, alarms, Lambda wiring. |
+
+Подробная карта для разработки: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
-## 🤖 Команды бота
+## Команды бота
 
 | Команда | Для кого | Описание |
-|---------|-----|-------------|
-| `/start` | Для всех | Перезапустить бота и просмотреть инструкции |
-| `/help` | Для всех | Показать руководство по использованию и правила |
-| `/ping` | Для всех | Проверка работоспособности — подтверждает, что бот активен |
-| `/support` | Для всех | Получить контактную информацию разработчика |
-| `/stats` | Админы | Статистика сообщества и уровень активности |
-| `/voteban` | Для всех | Ответить на сообщение, чтобы начать голосование за бан |
-| `/quizstats` | Для всех | Ваш личный счет в викторинах, серия и рейтинг |
+|---------|----------|----------|
+| `/start` | Все | Перезапустить бота и показать инструкции. |
+| `/help` | Все | Команды и правила. |
+| `/ping` | Все | Health check. |
+| `/support` | Все | Контакты разработчика. |
+| `/stats` | Admins | Статистика сообщества. |
+| `/voteban` | Все | Начать голосование за ban, ответив на сообщение. |
+| `/quizstats` | Все | Личный quiz score, streak и rank. |
+| `/ask <question>` | В memory-enabled группах | Задать вопрос agent-у; можно использовать reply на сообщение. |
+| `/memory on/off/status/forget ...` | Group owner или bot owner | Управление group memory и cleanup. |
+| `/agent on/off/status/why` | Group owner или bot owner | Управление участием agent-а и объяснение, почему бот ответил. |
 
 ---
 
-## ⚙️ Настройка CI/CD (GitHub Actions)
-
-Этот репозиторий включает рабочий процесс GitHub Actions для автоматического развертывания через OIDC (без долгоживущих ключей AWS).
-
-Мы предоставляем скрипт настройки для автоматизации конфигурации IAM:
+## Разработка
 
 ```bash
-# Использование: ./scripts/setup_oidc.sh <GITHUB_ORG/REPO>
-./scripts/setup_oidc.sh Bayashat/zerde-serverless-bot
+uv sync --frozen
+uv run pytest tests/ -q
+uv run pre-commit run --all-files
 ```
 
-**Что делает этот скрипт:**
+Проверка infra:
 
-- Создает провайдер OIDC в IAM (если отсутствует).
-- Создает роль IAM (`GitHubAction-Deploy-TelegramBot`), которая доверяет вашему конкретному репозиторию GitHub.
-- Выводит **AWS_ROLE_ARN** для добавления в качестве секрета репозитория (Repository Secret) на GitHub.
+```bash
+cd infra
+uv run cdk synth -c env=dev
+uv run cdk diff -c env=dev
+```
 
----
-
-## 🛠️ Участие в разработке
-
-Мы приветствуем ваш вклад. Ознакомьтесь с [CONTRIBUTING.md](CONTRIBUTING.md) для настройки среды разработки (clone, uv, CDK, pre-commit) и процессом создания PR.
-
-Для полного пошагового руководства — аккаунт AWS, новый бот, токен, развертывание с нуля — см. [Руководство по локальному тестированию](docs/LOCAL_TESTING.md).
+Setup описан в [CONTRIBUTING.md](../CONTRIBUTING.md), полный AWS + Telegram walkthrough — в [LOCAL_TESTING.md](LOCAL_TESTING.md).
 
 ---
 
-## 📄 Лицензия
+## История
 
-Этот проект лицензирован в соответствии с **MIT License**.
+Zerde изначально был построен на базе [serverless-tg-bot-starter](https://github.com/Bayashat/serverless-tg-bot-starter). Starter все еще полезен для простых serverless Telegram-ботов. Этот репозиторий вырос в memory-enabled agentic bot с отдельными news и quiz workloads.
+
+---
+
+## License
+
+MIT License.

--- a/docs/telegram_history_import.md
+++ b/docs/telegram_history_import.md
@@ -1,6 +1,8 @@
 # Telegram History Import
 
-Use this for one-time import of Telegram Desktop JSON exports into ZerdeBot group memory.
+Use this for one-time import of Telegram Desktop JSON exports into ZerdeBot group memory and RAG retrieval.
+
+The importer is for bootstrapping memory when Telegram cannot give the bot old group history. It writes DynamoDB memory items first, then optionally enqueues vector indexing so the agent can retrieve relevant historical facts through S3 Vectors.
 
 ## Export
 
@@ -25,7 +27,7 @@ uv run python dev/tools/import_telegram_history.py \
   --since 2026-01-01
 ```
 
-The report shows parsed messages, skipped sensitive/command/service messages, estimated long-term memories, daily summaries, and vector tasks.
+The report shows parsed messages, skipped sensitive/command/service messages, estimated long-term memories, daily summaries, and vector tasks. Review this before writing because imported memory can influence future agent answers.
 
 ## Import
 
@@ -45,12 +47,14 @@ Repeat once per group/export file.
 
 ## What Gets Imported
 
-- `MSG#...` raw text records for non-sensitive messages, with user profile updates.
+- `MSG#...` raw text records for non-sensitive messages, with `USER#...` profile updates derived from the speaker's own text.
 - `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, and `JOKE#...` long-term memory items.
 - `DAILY_SUMMARY#YYYY-MM-DD` summaries for each imported day.
 - `PROCESS_VECTOR_MEMORY` tasks for each long-term memory and daily summary.
 
 The importer skips commands, empty/system messages, and secret/sensitive-looking content. It does not embed every raw message directly; only long-term memory items and daily summaries go to S3 Vectors.
+
+Imported long-term memory is later used by `/ask` and proactive agent replies through a mix of query-filtered DynamoDB reads and semantic vector retrieval. Keep joke-like or sarcastic memories narrow; a one-off roast should not become a permanent user fact.
 
 ## Useful Options
 
@@ -60,3 +64,15 @@ The importer skips commands, empty/system messages, and secret/sensitive-looking
 - `--no-raw-messages` to skip raw `MSG#...` records and user profile updates.
 - `--no-long-term` to skip event/fact/joke extraction.
 - `--no-daily-summaries` to skip daily summaries.
+
+If you import with `--no-vector-enqueue`, run a vector backfill later before expecting semantic retrieval to find that history.
+
+## Cleanup And Pollution Control
+
+Before importing a large group, do a small `--max-messages` dry run and inspect whether user facts, group facts, and jokes look trustworthy. If polluted records are written, clean both sides of memory:
+
+- Delete the narrow DynamoDB keys for bad `USER#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, or `DAILY_SUMMARY#...` items.
+- Delete matching vector keys for vectorized long-term memory and daily summaries.
+- Back up the exact items and vector keys before production cleanup.
+
+Do not rely on vector backfill to fix bad source data. If DynamoDB memory is polluted, the agent can still retrieve it through non-vector long-term context.

--- a/src/bot/services/ai/gemini_client.py
+++ b/src/bot/services/ai/gemini_client.py
@@ -112,6 +112,8 @@ class GeminiClient:
         long_term_memory_context: str = "",
         semantic_memory_context: str = "",
         user_profile_context: str = "",
+        reply_instructions: str = "",
+        max_output_tokens: int = 320,
         lang: str = "kk",
     ) -> tuple[str, int]:
         """Generate a context-aware reply for an explicitly bot-directed group message."""
@@ -149,12 +151,13 @@ class GeminiClient:
             "for normal questions, stay natural, concise, and conversational like a group member. "
             "Answer naturally and directly; do not add disclaimers about not being able to characterize people. "
             "If the context is insufficient, say so briefly. "
+            "Respect the response length instructions exactly; short follow-ups should stay short. "
             "Keep replies concise, natural, and in the group's language. "
             "Avoid mentioning that you are using stored memory unless asked."
         )
         generation_config: dict[str, Any] = {
             "temperature": 0.75,
-            "maxOutputTokens": 450,
+            "maxOutputTokens": max(80, min(700, int(max_output_tokens))),
         }
         thinking_config = _thinking_config_for_model(self._model)
         if thinking_config is not None:
@@ -172,6 +175,8 @@ class GeminiClient:
             "Each context line includes speaker metadata. Use it to distinguish a person's own messages "
             "from another user's opinion about them.\n"
             f"{recent_context or '(no recent context available)'}\n\n"
+            "Response length and style instructions:\n"
+            f"{reply_instructions or 'Answer in 2-5 concise sentences unless the user asks for more detail.'}\n\n"
             "Current message directed at you:\n"
             f"{user_message}\n\n"
             "Reply to the current message."

--- a/src/bot/services/ai/telegram_html.py
+++ b/src/bot/services/ai/telegram_html.py
@@ -10,6 +10,27 @@ _CODE_RE = re.compile(r"`([^`]+)`")
 _BULLET_RE = re.compile(r"^\s*[-*]\s+")
 
 
+def fit_llm_output(text: str, *, max_chars: int) -> str:
+    """Trim model text before Telegram HTML normalization."""
+    cleaned = (text or "").strip()
+    if max_chars <= 0 or len(cleaned) <= max_chars:
+        return cleaned
+
+    suffix = "..."
+    cut_limit = max(1, max_chars - len(suffix))
+    boundary = max(
+        cleaned.rfind("\n\n", 0, cut_limit),
+        cleaned.rfind(". ", 0, cut_limit),
+        cleaned.rfind("! ", 0, cut_limit),
+        cleaned.rfind("? ", 0, cut_limit),
+    )
+    if boundary < cut_limit * 0.55:
+        boundary = cleaned.rfind(" ", 0, cut_limit)
+    if boundary < cut_limit * 0.55:
+        boundary = cut_limit
+    return cleaned[:boundary].rstrip() + suffix
+
+
 def normalize_llm_output_for_telegram_html(text: str) -> str:
     """Convert common markdown-like fragments into Telegram-safe HTML subset."""
     lines = text.splitlines()

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -21,7 +21,7 @@ from core.config import (
 from core.logger import LoggerAdapter, get_logger
 from core.translations import get_translated_text
 from services.ai.gemini_client import GeminiClient, GeminiRPDExhaustedError, GeminiUnavailableError
-from services.ai.telegram_html import normalize_llm_output_for_telegram_html
+from services.ai.telegram_html import fit_llm_output, normalize_llm_output_for_telegram_html
 from services.group_memory import (
     extract_message_text,
     format_long_term_memory_context,
@@ -41,6 +41,13 @@ _agent_gemini: GeminiClient | None = None
 class ProactiveReplyScore:
     score: float
     reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReplyPolicy:
+    instructions: str
+    max_output_tokens: int
+    max_chars: int
 
 
 def _get_gemini() -> GeminiClient | None:
@@ -73,6 +80,124 @@ def _replies_to_bot(message: dict[str, Any]) -> bool:
         return False
     sender = reply.get("from") or {}
     return bool(sender.get("is_bot"))
+
+
+def _reply_text(message: dict[str, Any]) -> str:
+    reply = message.get("reply_to_message")
+    if not isinstance(reply, dict):
+        return ""
+    return extract_message_text(reply)
+
+
+def _agent_reply_thread_context(
+    repo: GroupMemoryRepository,
+    chat_id: int | str,
+    *,
+    bot_message_id: int | str,
+    telegram_reply_text: str,
+) -> str:
+    try:
+        item = repo.get_agent_reply_explanation(chat_id, bot_message_id=bot_message_id)
+    except Exception:
+        logger.exception("Failed to load previous agent reply context", extra={"chat_id": chat_id})
+        item = {}
+    if not isinstance(item, dict):
+        item = {}
+    previous_user = str(item.get("user_message") or "").strip()
+    previous_answer = str(item.get("answer_text") or telegram_reply_text or "").strip()
+    parts = ["The user is continuing a thread with this previous bot answer:"]
+    if previous_user:
+        parts.append(f"Previous user request:\n{previous_user[:1200]}")
+    if previous_answer:
+        parts.append(f"Previous bot answer:\n{previous_answer[:1800]}")
+    elif telegram_reply_text:
+        parts.append(f"Previous bot answer from Telegram reply:\n{telegram_reply_text[:1800]}")
+    return "\n\n".join(parts)
+
+
+def _explicit_user_text(repo: GroupMemoryRepository, chat_id: int | str, message: dict[str, Any]) -> str:
+    text = extract_message_text(message)
+    replied_text = _reply_text(message)
+    if _replies_to_bot(message):
+        reply = message.get("reply_to_message") or {}
+        thread_context = _agent_reply_thread_context(
+            repo,
+            chat_id,
+            bot_message_id=reply.get("message_id") or 0,
+            telegram_reply_text=replied_text,
+        )
+        return f"{thread_context}\n\nUser follow-up:\n{text}"
+    return text
+
+
+def _reply_policy(user_text: str) -> ReplyPolicy:
+    lowered = user_text.lower()
+    explicit_long = any(
+        cue in lowered
+        for cue in (
+            "подробно",
+            "толық",
+            "детально",
+            "развернуто",
+            "deep dive",
+            "explain in detail",
+            "详细",
+            "展开",
+        )
+    )
+    explicit_short = any(
+        cue in lowered
+        for cue in (
+            "қысқа",
+            "қысқаша",
+            "короче",
+            "кратко",
+            "short",
+            "brief",
+            "tl;dr",
+            "tldr",
+            "总结",
+            "简短",
+        )
+    )
+    continuation = "user is continuing a thread with this previous bot answer" in lowered
+    ask_without_question = "wants you to explain it or answer based on it" in lowered
+
+    if explicit_long:
+        return ReplyPolicy(
+            instructions=(
+                "The user asked for detail. Answer with the minimum useful detail, up to 5 short paragraphs "
+                "or 6 bullets. Avoid repeating the full context."
+            ),
+            max_output_tokens=460,
+            max_chars=2600,
+        )
+    if explicit_short or continuation:
+        return ReplyPolicy(
+            instructions=(
+                "This is a short follow-up. Answer directly in 1-3 short sentences. "
+                "Do not recap the whole previous answer unless the user asks."
+            ),
+            max_output_tokens=180,
+            max_chars=900,
+        )
+    if ask_without_question:
+        return ReplyPolicy(
+            instructions=(
+                "The user asked about a replied-to message without a specific question. "
+                "Give the main point in 3-5 concise sentences or at most 3 bullets."
+            ),
+            max_output_tokens=260,
+            max_chars=1400,
+        )
+    return ReplyPolicy(
+        instructions=(
+            "Answer in 2-5 concise sentences. Use bullets only when they make the answer easier to scan. "
+            "Do not write an essay by default."
+        ),
+        max_output_tokens=300,
+        max_chars=1800,
+    )
 
 
 def _looks_like_open_question(text: str) -> bool:
@@ -250,7 +375,7 @@ def handle_update(
         bot=bot,
         chat_id=chat_id,
         reply_to_message_id=message_id,
-        user_text=extract_message_text(message),
+        user_text=_explicit_user_text(repo, chat_id, message),
         lang=get_chat_lang(chat_id),
     )
     if handled:
@@ -276,7 +401,7 @@ def maybe_answer_proactively(
         return False
 
     recent_context = format_recent_context(repo, chat_id, limit=AGENT_RECENT_CONTEXT_LIMIT)
-    long_term_memory_context = format_long_term_memory_context(repo, chat_id)
+    long_term_memory_context = format_long_term_memory_context(repo, chat_id, query_text=user_text)
     raw_recent_bot_replies = repo.count_recent_agent_replies(chat_id, since_epoch=int(time.time()) - 60 * 60)
     recent_bot_replies = int(raw_recent_bot_replies) if isinstance(raw_recent_bot_replies, Number) else 0
     reply_score = score_proactive_reply(
@@ -336,7 +461,8 @@ def maybe_answer_proactively(
         )
         return False
 
-    answer_html = normalize_llm_output_for_telegram_html(decision.reply_text)
+    answer_text = fit_llm_output(decision.reply_text, max_chars=900)
+    answer_html = normalize_llm_output_for_telegram_html(answer_text)
     sent = bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
     bot_message_id = sent.get("message_id") if isinstance(sent, dict) else None
     if bot_message_id:
@@ -349,6 +475,8 @@ def maybe_answer_proactively(
                 f"{decision.reason or 'I judged this as a useful moment to answer.'} "
                 f"reply_score={reply_score.score:.2f}; signals={', '.join(reply_score.reasons)}"
             ),
+            answer_text=answer_text,
+            user_message=user_text,
             confidence=final_score,
         )
     logger.info(
@@ -382,7 +510,7 @@ def answer_group_question(
         return False
 
     recent_context = format_recent_context(repo, chat_id, limit=AGENT_RECENT_CONTEXT_LIMIT)
-    long_term_memory_context = format_long_term_memory_context(repo, chat_id)
+    long_term_memory_context = format_long_term_memory_context(repo, chat_id, query_text=user_text)
     semantic_memory_context = format_semantic_memory_context(
         retrieve_relevant_memories(chat_id, user_text, limit=8),
     )
@@ -393,6 +521,7 @@ def answer_group_question(
         user_text=user_text,
         ignored_usernames=ignored_usernames,
     )
+    reply_policy = _reply_policy(user_text)
 
     try:
         answer, _ = gemini.group_chat_reply(
@@ -401,6 +530,8 @@ def answer_group_question(
             long_term_memory_context=long_term_memory_context,
             semantic_memory_context=semantic_memory_context,
             user_profile_context=user_profile_context,
+            reply_instructions=reply_policy.instructions,
+            max_output_tokens=reply_policy.max_output_tokens,
             lang=lang,
         )
     except GeminiRPDExhaustedError:
@@ -421,7 +552,8 @@ def answer_group_question(
             raise
         return False
 
-    answer_html = normalize_llm_output_for_telegram_html(answer)
+    answer_text = fit_llm_output(answer, max_chars=reply_policy.max_chars)
+    answer_html = normalize_llm_output_for_telegram_html(answer_text)
     sent = bot.send_message(chat_id, answer_html, reply_to_message_id=reply_to_message_id)
     bot_message_id = sent.get("message_id") if isinstance(sent, dict) else None
     if bot_message_id:
@@ -434,5 +566,7 @@ def answer_group_question(
                 "I was mentioned, replied to, or called through /ask, "
                 "so I answered with recent, semantic, and trusted memory context."
             ),
+            answer_text=answer_text,
+            user_message=user_text,
         )
     return True

--- a/src/bot/services/group_memory.py
+++ b/src/bot/services/group_memory.py
@@ -13,6 +13,49 @@ from services.repositories.sqs import SQSClient
 logger = LoggerAdapter(get_logger(__name__), {})
 
 _USERNAME_RE = re.compile(r"@([A-Za-z0-9_]{3,32})")
+_RELEVANCE_TERM_RE = re.compile(r"[0-9a-zа-яәғқңөұүһіё][0-9a-zа-яәғқңөұүһіё+#._-]{2,}", re.IGNORECASE)
+_RELEVANCE_STOPWORDS = {
+    "about",
+    "and",
+    "any",
+    "are",
+    "bot",
+    "chat",
+    "for",
+    "from",
+    "how",
+    "the",
+    "this",
+    "what",
+    "who",
+    "why",
+    "zerde",
+    "бот",
+    "бро",
+    "его",
+    "как",
+    "кто",
+    "меня",
+    "нету",
+    "про",
+    "что",
+    "чат",
+    "это",
+    "бар",
+    "бір",
+    "деп",
+    "кім",
+    "мен",
+    "неге",
+    "не",
+    "ол",
+    "осы",
+    "сол",
+    "үшін",
+    "什么",
+    "怎么",
+    "这个",
+}
 
 
 def extract_message_text(message: dict[str, Any]) -> str:
@@ -126,12 +169,49 @@ def format_recent_context(repo: GroupMemoryRepository, chat_id: int | str, *, li
     return "\n".join(lines)
 
 
-def format_long_term_memory_context(repo: GroupMemoryRepository, chat_id: int | str, *, limit: int = 12) -> str:
+def _relevance_terms(text: str) -> set[str]:
+    terms: set[str] = set()
+    for raw in _RELEVANCE_TERM_RE.findall((text or "").lower()):
+        term = raw.lstrip("@")
+        if term and term not in _RELEVANCE_STOPWORDS and not term.isdigit():
+            terms.add(term)
+    return terms
+
+
+def _memory_matches_query(item: dict[str, Any], query_terms: set[str]) -> bool:
+    if not query_terms:
+        return True
+    fields = [
+        item.get("summary"),
+        item.get("text"),
+        item.get("topics"),
+        item.get("notable_events"),
+        item.get("inside_jokes"),
+        item.get("tension_points"),
+        item.get("display_name"),
+        item.get("username"),
+    ]
+    searchable = " ".join(
+        str(part) for value in fields for part in (value if isinstance(value, list) else [value]) if part
+    ).lower()
+    return any(term in searchable for term in query_terms)
+
+
+def format_long_term_memory_context(
+    repo: GroupMemoryRepository,
+    chat_id: int | str,
+    *,
+    limit: int = 12,
+    query_text: str | None = None,
+) -> str:
     """Render recent important memories extracted by the async memory processor."""
     daily_summaries = repo.get_recent_daily_summaries(chat_id, limit=GROUP_MEMORY_DAILY_SUMMARY_DAYS)
     memories = repo.get_recent_long_term_memories(chat_id, limit=limit)
+    query_terms = _relevance_terms(query_text or "")
     lines: list[str] = []
     for item in daily_summaries:
+        if not _memory_matches_query(item, query_terms):
+            continue
         summary_date = str(item.get("summary_date") or "").strip()
         summary = str(item.get("summary") or "").replace("\n", " ").strip()
         topics = item.get("topics") if isinstance(item.get("topics"), list) else []
@@ -140,6 +220,8 @@ def format_long_term_memory_context(repo: GroupMemoryRepository, chat_id: int | 
             topic_suffix = f" topics={topic_text}" if topic_text else ""
             lines.append(f"[daily_summary date={summary_date}{topic_suffix}] {summary[:900]}")
     for item in memories:
+        if not _memory_matches_query(item, query_terms):
+            continue
         kind = str(item.get("kind") or "memory")
         name = str(item.get("display_name") or item.get("username") or item.get("user_id") or "Unknown")
         summary = str(item.get("summary") or item.get("text") or "").replace("\n", " ").strip()

--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -712,6 +712,8 @@ class GroupMemoryRepository:
         trigger_message_id: int | str,
         trigger_kind: str,
         reason: str,
+        answer_text: str | None = None,
+        user_message: str | None = None,
         confidence: float | None = None,
     ) -> None:
         now = int(time.time())
@@ -728,6 +730,10 @@ class GroupMemoryRepository:
             "created_at": now,
             "ttl": ttl,
         }
+        if answer_text:
+            item["answer_text"] = answer_text[:3000]
+        if user_message:
+            item["user_message"] = user_message[:1500]
         if confidence is not None:
             item["confidence"] = Decimal(str(max(0.0, min(1.0, confidence))))
         self.table.put_item(Item=item)

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -236,6 +236,46 @@ def test_format_long_term_memory_context_includes_daily_summaries(monkeypatch):
     assert "[daily_summary date=2026-06-10 topics=aws, memory]" in context
 
 
+def test_format_long_term_memory_context_can_filter_by_current_query():
+    repo = MagicMock()
+    repo.get_recent_daily_summaries.return_value = [
+        {
+            "summary_date": "2026-06-10",
+            "summary": "The group discussed Claude subscriptions and Nurlan fullstack work.",
+            "topics": ["claude", "fullstack"],
+        },
+        {
+            "summary_date": "2026-06-11",
+            "summary": "The group discussed OpenSearch vector indexing.",
+            "topics": ["opensearch", "vectors"],
+        },
+    ]
+    repo.get_recent_long_term_memories.return_value = [
+        {
+            "kind": "user_fact",
+            "display_name": "Nurlan",
+            "summary": "Nurlan is a fullstack developer.",
+            "reason": "user stated background",
+        },
+        {
+            "kind": "event",
+            "display_name": "Ada",
+            "summary": "OpenSearch vector indexing needs a backfill.",
+            "reason": "time-bound event",
+        },
+    ]
+
+    context = group_memory.format_long_term_memory_context(
+        repo,
+        -100123,
+        query_text="does anyone know how OpenSearch indexing works?",
+    )
+
+    assert "OpenSearch vector indexing" in context
+    assert "Nurlan" not in context
+    assert "fullstack" not in context
+
+
 def test_classify_long_term_memory_detects_user_preference():
     result = classify_long_term_memory("I prefer OpenSearch for AWS-native memory retrieval")
 
@@ -454,6 +494,36 @@ def test_agent_should_answer_mention_when_enabled(monkeypatch):
     monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
 
     assert group_agent.should_answer(_group_update("hey @ZerdeBot what did we decide?")) is True
+
+
+def test_agent_reply_to_bot_includes_replied_bot_message_context(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = True
+    repo.get_agent_reply_explanation.return_value = {
+        "user_message": "The user asked about a replied-to group message.",
+        "answer_text": "The previous answer explained that infra engineers are still needed.",
+    }
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    update = _group_update("Поделись по братский")
+    update["message"]["reply_to_message"] = {
+        "message_id": 10,
+        "text": "Кто такой, о ком речь? Рассказывай, просвещусь.",
+        "from": {"id": 999, "is_bot": True, "username": "zerdebot"},
+    }
+
+    handled = group_agent.handle_update(repo=repo, bot=bot, update=update)
+
+    assert handled is True
+    user_text = answer.call_args.kwargs["user_text"]
+    assert "continuing a thread" in user_text
+    assert "infra engineers are still needed" in user_text
+    assert "The user asked about a replied-to group message" in user_text
+    assert "Поделись по братский" in user_text
 
 
 def test_agent_should_not_answer_plain_chatter(monkeypatch):
@@ -679,7 +749,9 @@ def test_group_chat_reply_prompt_resists_third_party_profile_poisoning(monkeypat
     assert "Decide the answer style from the user's wording" in system_prompt
     assert "do not use a fixed angry persona by default" in system_prompt
     assert "do not add disclaimers" in system_prompt
+    assert "Respect the response length instructions exactly" in system_prompt
     assert "Trusted target-user profile context:" in user_prompt
+    assert "Response length and style instructions:" in user_prompt
     assert "own_topic_terms: opensearch, python" in user_prompt
     assert "distinguish a person's own messages from another user's opinion" in user_prompt
     assert "username=@bayashat" in user_prompt
@@ -688,6 +760,7 @@ def test_group_chat_reply_prompt_resists_third_party_profile_poisoning(monkeypat
 def test_answer_group_question_passes_target_profile_context(monkeypatch):
     repo = MagicMock()
     bot = MagicMock()
+    bot.send_message.return_value = {"message_id": 1000}
     gemini = MagicMock()
     gemini.group_chat_reply.return_value = ("Баяшат OpenSearch жайлы жиі жазады.", 1)
     monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
@@ -721,6 +794,11 @@ def test_answer_group_question_passes_target_profile_context(monkeypatch):
         long_term_memory_context="",
         semantic_memory_context="[semantic_memory kind=event] OpenSearch was too expensive",
         user_profile_context="Trusted profile: username=@bayashat own_topic_terms: opensearch",
+        reply_instructions=(
+            "Answer in 2-5 concise sentences. Use bullets only when they make the answer easier to scan. "
+            "Do not write an essay by default."
+        ),
+        max_output_tokens=300,
         lang="kk",
     )
     bot.send_message.assert_called_once_with(
@@ -728,6 +806,39 @@ def test_answer_group_question_passes_target_profile_context(monkeypatch):
         "Баяшат OpenSearch жайлы жиі жазады.",
         reply_to_message_id=99,
     )
+    repo.record_agent_reply.assert_called_once()
+    assert repo.record_agent_reply.call_args.kwargs["answer_text"] == "Баяшат OpenSearch жайлы жиі жазады."
+    assert repo.record_agent_reply.call_args.kwargs["user_message"] == "@zerde_kz_bot @bayashat кім"
+
+
+def test_answer_group_question_uses_brief_budget_for_followup(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    bot.send_message.return_value = {"message_id": 1000}
+    gemini = MagicMock()
+    gemini.group_chat_reply.return_value = ("Қысқасы, негізгі ой сол.", 1)
+    monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
+    monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "retrieve_relevant_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(group_agent, "format_user_profile_context", lambda *args, **kwargs: "")
+
+    handled = group_agent.answer_group_question(
+        repo=repo,
+        bot=bot,
+        chat_id=-100123,
+        reply_to_message_id=99,
+        user_text=(
+            "The user is continuing a thread with this previous bot answer:\n"
+            "Previous bot answer:\nA long answer.\n\n"
+            "User follow-up:\nне айтқың келді?"
+        ),
+        lang="kk",
+    )
+
+    assert handled is True
+    assert gemini.group_chat_reply.call_args.kwargs["max_output_tokens"] == 180
+    assert "1-3 short sentences" in gemini.group_chat_reply.call_args.kwargs["reply_instructions"]
 
 
 def test_handle_ask_enqueues_group_context_answer():

--- a/tests/test_telegram_html.py
+++ b/tests/test_telegram_html.py
@@ -1,4 +1,4 @@
-from services.ai.telegram_html import normalize_llm_output_for_telegram_html
+from services.ai.telegram_html import fit_llm_output, normalize_llm_output_for_telegram_html
 
 
 def test_markdown_bold_italic_code_to_html() -> None:
@@ -13,3 +13,13 @@ def test_markdown_bullets_to_dot_bullets() -> None:
     text = "- first\n* second\n  - third"
     out = normalize_llm_output_for_telegram_html(text)
     assert out.splitlines() == ["• first", "• second", "• third"]
+
+
+def test_fit_llm_output_trims_at_readable_boundary() -> None:
+    text = "First sentence. Second sentence is useful. Third sentence is too much."
+
+    out = fit_llm_output(text, max_chars=40)
+
+    assert len(out) <= 40
+    assert out.endswith("...")
+    assert "Third sentence" not in out


### PR DESCRIPTION
## What changed

- Store bot agent replies as `AGENT_REPLY#...` records with answer text and triggering user message so reply-to-bot follow-ups can include the bot's previous answer.
- Add reply-length budgeting for `/ask` and follow-up flows, plus Telegram-safe output trimming before HTML normalization.
- Tighten group memory prompt assembly so target-user profile and long-term context are more query-aware.
- Update Codex project guidance and public/internal docs to describe the current agentic bot + RAG memory architecture.
- Add `docs/ARCHITECTURE.md` as the current architecture source of truth and refresh README, Kazakh/Russian READMEs, local testing, history import, contributing, and `.env.example`.

## Why

The bot has moved beyond a simple LLM wrapper. It now uses recent context, DynamoDB memory, vector retrieval, stored agent replies, and proactive reply gating. The docs and Codex skill needed to match that reality so future changes do not accidentally regress back to wrapper-style behavior.

This also addresses the `/ask` follow-up issue where replying to the bot's latest answer lacked the bot's own previous message in context, and the response-length issue where short follow-ups could receive overly long answers.

## Validation

- `python /Users/bayashat/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/bayashat/DEV/05_AWS/Projects/ZerdeBot/.codex/skills/zerdebot-development`
- `uv run pytest tests/ -q` (`210 passed`)
- `uv run pre-commit run --all-files`

## Notes

Created from the updated `main` after PR #95 was merged. The local `tmp/` backup directory was intentionally left untracked and is not part of this PR.