### PR TITLE
fix: sanitize news Telegram HTML

### DIFF
--- a/src/news/services/news_fetcher.py
+++ b/src/news/services/news_fetcher.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from typing import Optional
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import feedparser
 import urllib3
@@ -14,6 +15,19 @@ from core.logger import LoggerAdapter, get_logger
 logger = LoggerAdapter(get_logger(__name__), {})
 
 http = urllib3.PoolManager(timeout=urllib3.Timeout(total=10))
+
+
+def normalize_url(url: str) -> str:
+    """Return a request-safe URL, repairing common RSS whitespace glitches."""
+    cleaned = " ".join((url or "").strip().split())
+    if not cleaned:
+        return ""
+    parts = urlsplit(cleaned)
+    path = re.sub(r"\s+", "-", parts.path) if parts.netloc.endswith("aws.amazon.com") else parts.path
+    path = quote(path, safe="/:%")
+    query = quote(parts.query, safe="=&?/:,+%")
+    fragment = quote(parts.fragment, safe="=&?/:,+%")
+    return urlunsplit((parts.scheme, parts.netloc, path, query, fragment))
 
 
 class NewsFetcher:
@@ -72,7 +86,7 @@ class NewsFetcher:
                     local_news.append(
                         {
                             "title": entry.get("title", "No title"),
-                            "link": entry.get("link", ""),
+                            "link": normalize_url(entry.get("link", "")),
                             "summary": entry.get("summary", "")[:250],
                         }
                     )
@@ -97,6 +111,7 @@ class NewsFetcher:
 
     def fetch_deep_article_data(self, url: str) -> dict:
         """Scrape the article page for og:image (or first img) and main paragraph text."""
+        url = normalize_url(url)
         headers = {
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",

--- a/src/news/services/telegram.py
+++ b/src/news/services/telegram.py
@@ -22,12 +22,29 @@ def sanitize_html(text: str) -> str:
     """Sanitize text for Telegram HTML parse mode without double-escaping."""
     if not text:
         return ""
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
     text = re.sub(r"&(?!\w+;|#[0-9]+;|#x[0-9a-fA-F]+;)", "&amp;", text)
     text = text.replace("<", "&lt;")
     text = text.replace(">", "&gt;")
-    for tag in ["b", "/b", "blockquote", "/blockquote"]:
+    for tag in [
+        "b",
+        "/b",
+        "i",
+        "/i",
+        "u",
+        "/u",
+        "s",
+        "/s",
+        "code",
+        "/code",
+        "pre",
+        "/pre",
+        "blockquote",
+        "/blockquote",
+    ]:
         text = text.replace(f"&lt;{tag}&gt;", f"<{tag}>")
     text = re.sub(r"&lt;a\s+href=\"([^\"]*)\"&gt;", r'<a href="\1">', text)
+    text = re.sub(r"&lt;a\s+href='([^']*)'&gt;", r'<a href="\1">', text)
     text = text.replace("&lt;/a&gt;", "</a>")
     return text
 
@@ -54,7 +71,7 @@ class TelegramSender:
     ) -> tuple[bool, Optional[int]]:
         """Send a message with truncation and exponential-backoff retry."""
         url = f"{self._base_url}/sendMessage"
-        safe_text = truncate_message(text)
+        safe_text = truncate_message(sanitize_html(text) if parse_mode == "HTML" else text)
         payload: dict = {
             "chat_id": chat_id,
             "text": safe_text,
@@ -124,7 +141,7 @@ class TelegramSender:
             return self.send_message(chat_id, message)[0]
 
         url = f"{self._base_url}/sendPhoto"
-        caption = truncate_message(message, TELEGRAM_CAPTION_MAX_LENGTH)
+        caption = truncate_message(sanitize_html(message), TELEGRAM_CAPTION_MAX_LENGTH)
         payload: dict = {
             "chat_id": chat_id,
             "photo": image_url,

--- a/tests/test_news_delivery.py
+++ b/tests/test_news_delivery.py
@@ -1,0 +1,91 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NEWS_ROOT = ROOT / "src" / "news"
+
+
+def _load_news_module(name: str, relative_path: str):
+    sys.path.insert(0, str(NEWS_ROOT))
+    try:
+        spec = importlib.util.spec_from_file_location(name, NEWS_ROOT / relative_path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.pop(0)
+
+
+class FakeResponse:
+    def __init__(self, status: int = 200, data: bytes = b'{"ok":true}') -> None:
+        self.status = status
+        self.data = data
+
+
+class FakeHttp:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def request(self, method: str, url: str, **kwargs):
+        self.requests.append({"method": method, "url": url, **kwargs})
+        return FakeResponse()
+
+
+def test_news_sanitize_html_converts_br_and_escapes_unknown_tags():
+    telegram = _load_news_module("news_telegram_test", "services/telegram.py")
+
+    result = telegram.sanitize_html(
+        '<b>Title</b><br/>Body <script>alert(1)</script> <a href="https://example.com?a=1&b=2">Read</a>'
+    )
+
+    assert "<br" not in result
+    assert "<b>Title</b>\nBody" in result
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in result
+    assert '<a href="https://example.com?a=1&amp;b=2">Read</a>' in result
+
+
+def test_news_sender_sanitizes_send_message_payload(monkeypatch):
+    telegram = _load_news_module("news_telegram_send_test", "services/telegram.py")
+    fake_http = FakeHttp()
+    monkeypatch.setattr(telegram, "http", fake_http)
+
+    ok, _ = telegram.TelegramSender("token").send_message("chat", "<b>Title</b><br>Body <foo>bad</foo>")
+
+    payload = json.loads(fake_http.requests[0]["body"].decode("utf-8"))
+    assert ok is True
+    assert payload["parse_mode"] == "HTML"
+    assert payload["text"] == "<b>Title</b>\nBody &lt;foo&gt;bad&lt;/foo&gt;"
+
+
+def test_news_sender_sanitizes_photo_caption_payload(monkeypatch):
+    telegram = _load_news_module("news_telegram_photo_test", "services/telegram.py")
+    fake_http = FakeHttp()
+    monkeypatch.setattr(telegram, "http", fake_http)
+
+    ok = telegram.TelegramSender("token").send_message_with_photo(
+        "chat",
+        "<b>Title</b><br><i>Body</i>",
+        "https://example.com/image.png",
+    )
+
+    payload = json.loads(fake_http.requests[0]["body"])
+    assert ok is True
+    assert payload["parse_mode"] == "HTML"
+    assert payload["caption"] == "<b>Title</b>\n<i>Body</i>"
+
+
+def test_news_fetcher_normalizes_rss_urls_with_whitespace():
+    news_fetcher = _load_news_module("news_fetcher_test", "services/news_fetcher.py")
+
+    assert (
+        news_fetcher.normalize_url(
+            "https://aws.amazon.com/about-aws/whats-new/2026/06/cloudwatch-supports infrastructure-logs/"
+        )
+        == "https://aws.amazon.com/about-aws/whats-new/2026/06/cloudwatch-supports-infrastructure-logs/"
+    )
+    assert news_fetcher.normalize_url("https://example.com/a path/?q=hello world") == (
+        "https://example.com/a%20path/?q=hello%20world"
+    )


### PR DESCRIPTION
## Summary
- sanitize News Lambda Telegram HTML before sending messages and photo captions
- convert unsupported <br> tags to newlines and escape unsupported raw tags
- normalize whitespace-damaged news URLs, including AWS whats-new links

## Validation
- uv run pytest tests/ -q
- uv run pre-commit run --all-files
- deployed prod News Lambda; post-deploy CloudWatch parse-entities check returned 0 events since 2026-06-12T09:30:00Z