### PR TITLE
fix: improve group agent Gemini failure handling

### DIFF
--- a/src/bot/services/ai/gemini_client.py
+++ b/src/bot/services/ai/gemini_client.py
@@ -72,6 +72,20 @@ class GeminiUnavailableError(Exception):
     """
 
 
+def _elapsed_ms(started_at: float) -> int:
+    return int((time.monotonic() - started_at) * 1000)
+
+
+def _redact(text: str, api_key: str) -> str:
+    if api_key:
+        text = text.replace(api_key, "[REDACTED]")
+    return text[:500]
+
+
+def _decode_preview(data: bytes, *, limit: int = 300) -> str:
+    return data.decode("utf-8", errors="replace")[:limit]
+
+
 @dataclass(frozen=True)
 class GroupAgentDecision:
     """LLM decision for whether ZerdeBot should proactively join a group chat."""
@@ -103,6 +117,78 @@ class GeminiClient:
     @property
     def rpd_limit(self) -> int:
         return self._rate_repo.rpd_limit
+
+    def _post_generate_content(
+        self,
+        *,
+        operation: str,
+        url: str,
+        body: str,
+        headers: dict[str, str],
+    ) -> bytes:
+        started_at = time.monotonic()
+        try:
+            resp = _http.request("POST", url, body=body, headers=headers, retries=False)
+        except (HTTPError, OSError) as exc:
+            _record_transient_failure()
+            error_message = _redact(str(exc), self._api_key)
+            logger.warning(
+                "Gemini request transport failed",
+                extra={
+                    "operation": operation,
+                    "model": self._model,
+                    "latency_ms": _elapsed_ms(started_at),
+                    "error_type": exc.__class__.__name__,
+                    "error_message": error_message,
+                },
+            )
+            raise GeminiUnavailableError(f"Gemini transport {exc.__class__.__name__}: {error_message}") from exc
+
+        latency_ms = _elapsed_ms(started_at)
+        response_chars = len(resp.data or b"")
+        if resp.status == 429 or resp.status >= 500:
+            _record_transient_failure()
+            preview = _redact(_decode_preview(resp.data or b""), self._api_key)
+            logger.warning(
+                "Gemini request failed",
+                extra={
+                    "operation": operation,
+                    "model": self._model,
+                    "error_type": "http_status",
+                    "status_code": resp.status,
+                    "latency_ms": latency_ms,
+                    "response_chars": response_chars,
+                    "response_preview": preview,
+                },
+            )
+            raise GeminiUnavailableError(f"Gemini API {resp.status}: {preview}")
+        if resp.status >= 400:
+            preview = _redact(_decode_preview(resp.data or b""), self._api_key)
+            logger.warning(
+                "Gemini request rejected",
+                extra={
+                    "operation": operation,
+                    "model": self._model,
+                    "error_type": "http_status",
+                    "status_code": resp.status,
+                    "latency_ms": latency_ms,
+                    "response_chars": response_chars,
+                    "response_preview": preview,
+                },
+            )
+            raise GeminiUnavailableError(f"Gemini API {resp.status}: {preview}")
+
+        logger.info(
+            "Gemini request completed",
+            extra={
+                "operation": operation,
+                "model": self._model,
+                "status_code": resp.status,
+                "latency_ms": latency_ms,
+                "response_chars": response_chars,
+            },
+        )
+        return resp.data or b""
 
     def group_chat_reply(
         self,
@@ -217,25 +303,29 @@ class GeminiClient:
                 "rpd_limit": self.rpd_limit,
             },
         )
-        try:
-            resp = _http.request("POST", url, body=body, headers=headers, retries=False)
-        except (HTTPError, OSError) as exc:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini unreachable: {exc}") from exc
-
-        if resp.status == 429 or resp.status >= 500:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
-        if resp.status >= 400:
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
+        resp_data = self._post_generate_content(
+            operation="group_chat_reply",
+            url=url,
+            body=body,
+            headers=headers,
+        )
 
         try:
-            data = json.loads(resp.data.decode("utf-8"))
+            data = json.loads(resp_data.decode("utf-8"))
             candidate = data["candidates"][0]
             text = candidate["content"]["parts"][0]["text"].strip()
             _record_success()
             return text, count
         except (KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
+            logger.warning(
+                "Gemini group agent response parse failed",
+                extra={
+                    "operation": "group_chat_reply",
+                    "model": self._model,
+                    "error_type": exc.__class__.__name__,
+                    "error_message": str(exc)[:300],
+                },
+            )
             raise GeminiUnavailableError(f"Bad Gemini response: {exc}") from exc
 
     def group_chat_proactive_decision(
@@ -316,20 +406,15 @@ class GeminiClient:
                 "rpd_limit": self.rpd_limit,
             },
         )
-        try:
-            resp = _http.request("POST", url, body=body, headers=headers, retries=False)
-        except (HTTPError, OSError) as exc:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini unreachable: {exc}") from exc
-
-        if resp.status == 429 or resp.status >= 500:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
-        if resp.status >= 400:
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
+        resp_data = self._post_generate_content(
+            operation="group_chat_proactive_decision",
+            url=url,
+            body=body,
+            headers=headers,
+        )
 
         try:
-            data = json.loads(resp.data.decode("utf-8"))
+            data = json.loads(resp_data.decode("utf-8"))
             candidate = data["candidates"][0]
             text = candidate["content"]["parts"][0]["text"].strip()
             raw_decision = json.loads(text)
@@ -342,6 +427,15 @@ class GeminiClient:
             _record_success()
             return decision, count
         except (KeyError, IndexError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Gemini group agent decision response parse failed",
+                extra={
+                    "operation": "group_chat_proactive_decision",
+                    "model": self._model,
+                    "error_type": exc.__class__.__name__,
+                    "error_message": str(exc)[:300],
+                },
+            )
             raise GeminiUnavailableError(f"Bad Gemini decision response: {exc}") from exc
 
     def group_daily_summary(
@@ -412,24 +506,28 @@ class GeminiClient:
                 "rpd_limit": self.rpd_limit,
             },
         )
-        try:
-            resp = _http.request("POST", url, body=body, headers=headers, retries=False)
-        except (HTTPError, OSError) as exc:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini unreachable: {exc}") from exc
-
-        if resp.status == 429 or resp.status >= 500:
-            _record_transient_failure()
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
-        if resp.status >= 400:
-            raise GeminiUnavailableError(f"Gemini API {resp.status}: {resp.data.decode('utf-8')[:200]}")
+        resp_data = self._post_generate_content(
+            operation="group_daily_summary",
+            url=url,
+            body=body,
+            headers=headers,
+        )
 
         try:
-            data = json.loads(resp.data.decode("utf-8"))
+            data = json.loads(resp_data.decode("utf-8"))
             candidate = data["candidates"][0]
             text = candidate["content"]["parts"][0]["text"].strip()
             summary = json.loads(text)
             _record_success()
             return summary if isinstance(summary, dict) else {}, count
         except (KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
+            logger.warning(
+                "Gemini daily summary response parse failed",
+                extra={
+                    "operation": "group_daily_summary",
+                    "model": self._model,
+                    "error_type": exc.__class__.__name__,
+                    "error_message": str(exc)[:300],
+                },
+            )
             raise GeminiUnavailableError(f"Bad Gemini daily summary response: {exc}") from exc

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -495,8 +495,15 @@ def maybe_answer_proactively(
     except GeminiRPDExhaustedError:
         logger.info("Group agent proactive decision skipped by Gemini RPD limit", extra={"chat_id": chat_id})
         return False
-    except GeminiUnavailableError:
-        logger.warning("Group agent proactive decision unavailable", extra={"chat_id": chat_id})
+    except GeminiUnavailableError as exc:
+        logger.warning(
+            "Group agent proactive decision unavailable",
+            extra={
+                "chat_id": chat_id,
+                "error_type": exc.__class__.__name__,
+                "error_message": str(exc)[:500],
+            },
+        )
         return False
     except Exception:
         logger.exception("Group agent proactive decision failed", extra={"chat_id": chat_id})
@@ -648,11 +655,24 @@ def answer_group_question(
             reply_to_message_id=reply_to_message_id,
         )
         return True
-    except GeminiUnavailableError:
-        logger.warning("Group agent Gemini call unavailable", extra={"chat_id": chat_id})
+    except GeminiUnavailableError as exc:
+        logger.warning(
+            "Group agent Gemini call unavailable",
+            extra={
+                "chat_id": chat_id,
+                "reply_to_message_id": reply_to_message_id,
+                "error_type": exc.__class__.__name__,
+                "error_message": str(exc)[:500],
+            },
+        )
         if raise_on_unavailable:
             raise
-        return False
+        bot.send_message(
+            chat_id,
+            get_translated_text("ask_agent_unavailable", lang),
+            reply_to_message_id=reply_to_message_id,
+        )
+        return True
     except Exception:
         logger.exception("Group agent failed", extra={"chat_id": chat_id})
         if raise_on_unavailable:

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -1114,6 +1114,38 @@ def test_answer_group_question_uses_brief_budget_for_followup(monkeypatch):
     assert "1-3 short sentences" in gemini.group_chat_reply.call_args.kwargs["reply_instructions"]
 
 
+def test_answer_group_question_notifies_when_gemini_unavailable(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    gemini = MagicMock()
+    gemini.group_chat_reply.side_effect = gemini_client.GeminiUnavailableError(
+        "Gemini transport ReadTimeoutError: read timed out"
+    )
+    monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
+    monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "retrieve_relevant_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(group_agent, "format_user_profile_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_requester_profile_context", lambda *args, **kwargs: "")
+
+    handled = group_agent.answer_group_question(
+        repo=repo,
+        bot=bot,
+        chat_id=-100123,
+        reply_to_message_id=99,
+        user_text="@zerde_kz_bot не білесің?",
+        lang="kk",
+    )
+
+    assert handled is True
+    bot.send_message.assert_called_once_with(
+        -100123,
+        "😵 AI agent қазір қолжетімсіз.",
+        reply_to_message_id=99,
+    )
+    repo.record_agent_reply.assert_not_called()
+
+
 def test_answer_group_question_scopes_self_reference_to_requester(monkeypatch):
     repo = MagicMock()
     bot = MagicMock()


### PR DESCRIPTION
## Summary
- log Gemini generateContent success/failure with safe structured fields: operation, model, latency_ms, status_code/error_type, response size/preview
- include GeminiUnavailableError details in group-agent warnings
- make explicit @bot failures reply with the localized agent-unavailable message instead of silently falling through

## Investigation
- 2026-06-12T10:13:04Z vector retrieval completed successfully for chat -1001244628965
- Gemini group_chat_reply then returned as unavailable at 2026-06-12T10:13:14Z after roughly the 10s read-timeout window
- the old log swallowed the underlying exception, so CloudWatch only showed "Group agent Gemini call unavailable"

## Validation
- uv run pytest tests/test_group_memory_agent.py -q
- uv run pytest tests/ -q
- uv run pre-commit run --all-files
- cdk diff -c env=prod showed Bot Lambda code plus News Lambda code drift; no full-stack deploy from this branch to avoid reverting PR #99 news sanitizer