### PR TITLE
fix: improve agent reply thread handling

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -38,6 +38,7 @@ ZerdeBot started as a simple serverless Telegram bot and LLM wrapper. It is now 
 - It stores recent context, user profiles, long-term memory, daily summaries, and agent reply metadata in DynamoDB.
 - It indexes long-term memory in S3 Vectors for semantic RAG retrieval.
 - It answers `/ask`, @mentions, and reply-to-bot follow-ups with requester, profile, recent, long-term, and semantic context.
+- Reply-thread follow-ups carry the captured quoted source message, previous user request, and previous bot answer when available.
 - It may proactively answer only after conservative local and LLM social-timing gates.
 - It still supports captcha, anti-spam, voteban, daily news, and quizzes.
 
@@ -96,7 +97,7 @@ Single table partitioned by `pk=CHAT#<chat_id>`:
 - `USER#<user_id>` — profile from the user's own messages only.
 - `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...` — long-term memories.
 - `DAILY_SUMMARY#YYYY-MM-DD` — compressed daily group memory.
-- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering user message, requester metadata, and reason for reply-thread continuity and `/agent why`.
+- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, and reason for reply-thread continuity and `/agent why`.
 - `VECTOR_BACKFILL` — vector backfill status.
 - `PROACTIVE#YYYYMMDD` — daily proactive reply reservation counter.
 
@@ -129,7 +130,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Vector retrieval discipline**: use chat metadata filters, requester filters for self-reference when available, and distance cutoffs before adding semantic memories to prompts.
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
-- **Reply length control**: follow-up replies should stay short unless the user explicitly asks for detail.
+- **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.
 - **Structured logging**: use `zerde_common` and avoid logging full prompts, model responses, API keys, Telegram files, or user secrets.
 - **Vector observability**: retrieval and indexing success paths emit INFO logs with counts, filters, distance cutoffs, and vector dimensions; do not rely only on ERROR logs to confirm vector health.
 

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -56,6 +56,8 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Raw `MSG#...` records may keep audit context, but unsafe messages must not update profile samples/topics, long-term memory, daily summaries, vectors, or agent prompt context.
 - Vector retrieval and indexing success paths should emit structured INFO logs with counts, filters, distance cutoffs, and vector dimensions. Avoid logging full prompts, full memory text, vectors, or secrets.
 - Reply-to-bot follow-ups must include prior `AGENT_REPLY#...` answer context when available.
+- Reply-to-bot follow-ups should include the captured quoted source message, previous user request, previous bot answer, and current follow-up when available.
+- Do not answer every reply to a bot message; pure reactions, thanks, laughter, and short comments should be locally skipped unless the user explicitly mentions the bot.
 - Store useful bot answer metadata in `AGENT_REPLY#...` so `/agent why` and thread continuation work.
 - Keep proactive participation conservative: local open-question prefilter, bot-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
 - Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ ZerdeBot is no longer a simple LLM wrapper. The bot is now a serverless Telegram
 - It extracts long-term memories and daily summaries.
 - It embeds long-term memory into S3 Vectors for semantic retrieval.
 - It answers explicit questions with requester identity, recent context, user profiles, long-term memory, and query-matched vector memory.
-- It can continue reply threads with its own previous answers.
+- It can continue reply threads with its own previous answers and the original quoted source message when that context was captured.
 - It may proactively join a discussion, but only after local gating, model timing judgment, recent-bot-activity penalty, and daily limits.
 
 RAG is one part of the system. The larger system is an agentic bot: it decides whether to answer, what context to use, how long the answer should be, and what to remember afterward.
@@ -93,7 +93,7 @@ The table is single-table by chat partition:
 | `sk=GROUP_FACT#...` | Group decision or shared preference. |
 | `sk=JOKE#...` | Possible recurring joke or meme. Use carefully; this is easy to over-retrieve. |
 | `sk=DAILY_SUMMARY#YYYY-MM-DD` | Daily compressed memory for imported or observed messages. |
-| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering user message, and requester metadata for reply-thread continuity. |
+| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, parent bot message id, and requester metadata for reply-thread continuity. |
 | `sk=VECTOR_BACKFILL` | Last vector backfill status for a chat. |
 | `sk=PROACTIVE#YYYYMMDD` | Daily proactive reply reservation counter. |
 
@@ -108,7 +108,7 @@ Only long-term memory prefixes and daily summaries are vectorizable. Raw `MSG#..
 3. Semantic memory context from S3 Vectors, query-matched by current user text and optionally requester-filtered for self-reference.
 4. Long-term memory context filtered by current query terms.
 5. Recent group context with speaker metadata.
-6. Reply-thread context when the user replies to the bot's previous answer.
+6. Reply-thread context when the user replies to the bot's previous answer, including the captured original quoted message, previous user request, previous bot answer, and current follow-up when available.
 
 The Gemini prompt instructs the model to treat requester profiles as highest trust for self-reference, target-user profiles as higher trust than third-party chatter, semantic memory as lower trust than profiles, and to avoid turning one-off jokes into permanent facts. If a query has no usable relevance terms, lexical long-term memory is not injected into the answer path.
 
@@ -127,6 +127,7 @@ Proactive replies are conservative:
 Answer length is explicit:
 
 - Reply-to-bot follow-ups get a short budget.
+- Reply-to-bot follow-ups must pass a conservative local gate; clear questions or requests continue the thread, while pure reactions, thanks, laughter, and short comments stay silent.
 - Plain `/ask` explanations get a medium budget.
 - Detailed answers require explicit cues such as "подробно", "толық", or "deep dive".
 - `fit_llm_output` trims overly long responses before Telegram HTML normalization.

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -26,6 +26,7 @@ from services.group_memory import (
     display_name,
     extract_message_text,
     format_long_term_memory_context,
+    format_message_reference,
     format_recent_context,
     format_requester_profile_context,
     format_user_profile_context,
@@ -75,6 +76,14 @@ class ReplyPolicy:
     max_chars: int
 
 
+@dataclass(frozen=True)
+class ExplicitQuestionContext:
+    user_text: str
+    current_user_message: str
+    source_message_context: str = ""
+    parent_bot_message_id: int | None = None
+
+
 def _get_gemini() -> GeminiClient | None:
     global _agent_gemini
     if get_gemini_api_key() and _agent_gemini is None:
@@ -120,23 +129,31 @@ def _reply_text(message: dict[str, Any]) -> str:
     return extract_message_text(reply)
 
 
-def _agent_reply_thread_context(
+def _load_agent_reply_context(
     repo: GroupMemoryRepository,
     chat_id: int | str,
     *,
     bot_message_id: int | str,
-    telegram_reply_text: str,
-) -> str:
+) -> dict[str, Any]:
     try:
         item = repo.get_agent_reply_explanation(chat_id, bot_message_id=bot_message_id)
     except Exception:
         logger.exception("Failed to load previous agent reply context", extra={"chat_id": chat_id})
-        item = {}
-    if not isinstance(item, dict):
-        item = {}
-    previous_user = str(item.get("user_message") or "").strip()
+        return {}
+    return item if isinstance(item, dict) else {}
+
+
+def _agent_reply_thread_context(
+    item: dict[str, Any],
+    *,
+    telegram_reply_text: str,
+) -> str:
+    source_context = str(item.get("source_message_context") or "").strip()
+    previous_user = str(item.get("current_user_message") or item.get("user_message") or "").strip()
     previous_answer = str(item.get("answer_text") or telegram_reply_text or "").strip()
     parts = ["The user is continuing a thread with this previous bot answer:"]
+    if source_context:
+        parts.append(f"Original source message for the previous answer:\n{source_context[:1800]}")
     if previous_user:
         parts.append(f"Previous user request:\n{previous_user[:1200]}")
     if previous_answer:
@@ -146,19 +163,111 @@ def _agent_reply_thread_context(
     return "\n\n".join(parts)
 
 
-def _explicit_user_text(repo: GroupMemoryRepository, chat_id: int | str, message: dict[str, Any]) -> str:
-    text = extract_message_text(message)
-    replied_text = _reply_text(message)
+def build_explicit_question_context(
+    repo: GroupMemoryRepository,
+    chat_id: int | str,
+    message: dict[str, Any],
+    *,
+    current_text: str | None = None,
+) -> ExplicitQuestionContext:
+    text = (current_text if current_text is not None else extract_message_text(message)).strip()
+    reply = message.get("reply_to_message")
+    if not isinstance(reply, dict):
+        return ExplicitQuestionContext(user_text=text, current_user_message=text)
+
     if _replies_to_bot(message):
-        reply = message.get("reply_to_message") or {}
-        thread_context = _agent_reply_thread_context(
+        replied_text = _reply_text(message)
+        parent_bot_message_id = reply.get("message_id")
+        item = _load_agent_reply_context(
             repo,
             chat_id,
-            bot_message_id=reply.get("message_id") or 0,
+            bot_message_id=parent_bot_message_id or 0,
+        )
+        thread_context = _agent_reply_thread_context(
+            item,
             telegram_reply_text=replied_text,
         )
-        return f"{thread_context}\n\nUser follow-up:\n{text}"
-    return text
+        source_context = str(item.get("source_message_context") or "").strip()
+        followup = text or "The user replied to the previous bot answer and wants an explanation or continuation."
+        return ExplicitQuestionContext(
+            user_text=f"{thread_context}\n\nUser follow-up:\n{followup}",
+            current_user_message=text,
+            source_message_context=source_context,
+            parent_bot_message_id=int(parent_bot_message_id) if parent_bot_message_id is not None else None,
+        )
+
+    source_context = format_message_reference(reply)
+    if not source_context:
+        return ExplicitQuestionContext(user_text=text, current_user_message=text)
+    if text:
+        user_text = (
+            "The user is asking about this replied-to group message:\n"
+            f"{source_context}\n\n"
+            "User question:\n"
+            f"{text}"
+        )
+    else:
+        user_text = (
+            "The user replied to this group message and wants you to explain it or answer based on it:\n"
+            f"{source_context}"
+        )
+    return ExplicitQuestionContext(
+        user_text=user_text,
+        current_user_message=text,
+        source_message_context=source_context,
+    )
+
+
+def _clear_reply_to_bot_request(text: str) -> bool:
+    lowered = " ".join((text or "").lower().split())
+    if not lowered:
+        return False
+    if "?" in text or "？" in text:
+        return True
+    if re.search(
+        r"\b(why|how|what|who|where|when|explain|expand|elaborate|detail|details|more|example|examples)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        (
+            r"(^|\s)(қалай|неге|не|кім|түсіндір|толық|толығырақ|мысал|как|что|кто|почему|зачем|"
+            r"объясни|расскажи|подробнее|поделись)(\s|$|[?.!,])"
+        ),
+        lowered,
+    ):
+        return True
+    return any(cue in lowered for cue in ("怎么", "为什么", "什么", "谁", "解释", "详细", "展开", "举例"))
+
+
+def _reply_to_bot_followup_skip_reason(text: str) -> str | None:
+    lowered = " ".join((text or "").lower().split())
+    if not lowered:
+        return "empty_followup"
+    if _clear_reply_to_bot_request(text):
+        return None
+    reaction_cues = (
+        "haha",
+        "lol",
+        "lmao",
+        "хаха",
+        "ахах",
+        "哈哈",
+        "thanks",
+        "thank you",
+        "спасибо",
+        "рахмет",
+        "ок",
+        "okay",
+        "interesting",
+        "nice",
+        "cool",
+        "қызық",
+        "круто",
+    )
+    if any(cue in lowered for cue in reaction_cues):
+        return "reaction_or_ack"
+    return "no_clear_question_or_request"
 
 
 def _reply_policy(user_text: str) -> ReplyPolicy:
@@ -388,11 +497,33 @@ def _trigger_kind(update: dict[str, Any]) -> str | None:
         return None
     message = update["message"]
     text = extract_message_text(message)
-    if _mentions_bot(text) or _replies_to_bot(message):
+    if _mentions_bot(text):
+        return "explicit"
+    if _replies_to_bot(message) and _reply_to_bot_followup_skip_reason(text) is None:
         return "explicit"
     if _local_proactive_candidate(text):
         return "proactive"
     return None
+
+
+def _log_skipped_reply_to_bot_followup(update: dict[str, Any]) -> None:
+    if not AGENT_ENABLED or not _is_plain_text_message(update):
+        return
+    message = update["message"]
+    text = extract_message_text(message)
+    if not _replies_to_bot(message) or _mentions_bot(text):
+        return
+    skip_reason = _reply_to_bot_followup_skip_reason(text)
+    if not skip_reason:
+        return
+    logger.info(
+        "Group agent reply-to-bot follow-up skipped",
+        extra={
+            "chat_id": (message.get("chat") or {}).get("id"),
+            "message_id": message.get("message_id"),
+            "skip_reason": skip_reason,
+        },
+    )
 
 
 def should_answer(update: dict[str, Any]) -> bool:
@@ -412,7 +543,10 @@ def handle_update(
     continue routing it as a plain message.
     """
     trigger_kind = _trigger_kind(update)
-    if repo is None or trigger_kind is None:
+    if trigger_kind is None:
+        _log_skipped_reply_to_bot_followup(update)
+        return False
+    if repo is None:
         return False
 
     message = update["message"]
@@ -430,16 +564,20 @@ def handle_update(
             lang=get_chat_lang(chat_id),
         )
 
+    question_context = build_explicit_question_context(repo, chat_id, message)
     handled = answer_group_question(
         repo=repo,
         bot=bot,
         chat_id=chat_id,
         reply_to_message_id=message_id,
-        user_text=_explicit_user_text(repo, chat_id, message),
+        user_text=question_context.user_text,
         lang=get_chat_lang(chat_id),
         requester_user_id=(message.get("from") or {}).get("id"),
         requester_username=(message.get("from") or {}).get("username"),
         requester_display_name=display_name(message.get("from") or {}),
+        current_user_message=question_context.current_user_message,
+        source_message_context=question_context.source_message_context,
+        parent_bot_message_id=question_context.parent_bot_message_id,
     )
     if handled:
         logger.info(
@@ -547,6 +685,7 @@ def maybe_answer_proactively(
             ),
             answer_text=answer_text,
             user_message=user_text,
+            current_user_message=user_text,
             confidence=final_score,
         )
     logger.info(
@@ -575,9 +714,13 @@ def answer_group_question(
     requester_user_id: int | str | None = None,
     requester_username: str | None = None,
     requester_display_name: str | None = None,
+    current_user_message: str | None = None,
+    source_message_context: str | None = None,
+    parent_bot_message_id: int | str | None = None,
     raise_on_unavailable: bool = False,
 ) -> bool:
     """Generate and send a group-context reply for an explicit question."""
+    current_user_message = user_text if current_user_message is None else current_user_message
     guarded_answer = _guardrail_reply(user_text, lang)
     if guarded_answer:
         answer_html = normalize_llm_output_for_telegram_html(guarded_answer)
@@ -592,6 +735,9 @@ def answer_group_question(
                 reason="Guardrail blocked a subjective ranking or persistent future-answer directive.",
                 answer_text=guarded_answer,
                 user_message=user_text,
+                current_user_message=current_user_message,
+                source_message_context=source_message_context,
+                parent_bot_message_id=parent_bot_message_id,
             )
         return True
 
@@ -695,6 +841,9 @@ def answer_group_question(
             ),
             answer_text=answer_text,
             user_message=user_text,
+            current_user_message=current_user_message,
+            source_message_context=source_message_context,
+            parent_bot_message_id=parent_bot_message_id,
             requester_user_id=requester_user_id,
             requester_username=requester_username,
             requester_display_name=requester_display_name,

--- a/src/bot/services/group_memory.py
+++ b/src/bot/services/group_memory.py
@@ -83,6 +83,42 @@ def display_name(user: dict[str, Any]) -> str:
     return str(user.get("id") or "Unknown")
 
 
+def format_message_reference(
+    message: dict[str, Any],
+    *,
+    heading: str = "Original replied-to message",
+    max_text_chars: int = 1600,
+) -> str:
+    """Format a Telegram message as compact quoted context for agent prompts."""
+    if not isinstance(message, dict):
+        return ""
+    text = extract_message_text(message)
+    if not text:
+        return ""
+
+    sender = message.get("from") if isinstance(message.get("from"), dict) else {}
+    sender_chat = message.get("sender_chat") if isinstance(message.get("sender_chat"), dict) else {}
+    actor = sender or sender_chat
+
+    metadata: list[str] = []
+    actor_id = actor.get("id")
+    if actor_id is not None:
+        metadata.append(f"user_id={actor_id}")
+    username = (actor.get("username") or "").strip()
+    if username:
+        metadata.append(f"username=@{username}")
+    name = (actor.get("title") or "").strip() if sender_chat and not sender else display_name(actor)
+    if name:
+        metadata.append(f"name={name[:80]}")
+    message_id = message.get("message_id")
+    if message_id is not None:
+        metadata.append(f"message_id={message_id}")
+
+    speaker = f"[speaker {' '.join(metadata)}]" if metadata else "[speaker unknown]"
+    clipped_text = text[:max_text_chars]
+    return f"{heading}:\n{speaker} {clipped_text}"
+
+
 def is_storable_group_message(update: dict[str, Any]) -> bool:
     message = update.get("message")
     if not isinstance(message, dict):

--- a/src/bot/services/handlers/commands.py
+++ b/src/bot/services/handlers/commands.py
@@ -12,7 +12,7 @@ from core.config import (
 from core.dispatcher import Context
 from core.logger import LoggerAdapter, get_logger
 from core.translations import get_translated_text
-from services.group_agent import answer_group_question
+from services.group_agent import answer_group_question, build_explicit_question_context
 from services.group_memory import display_name
 from services.handlers.quiz import react_genquiz_processing
 from services.vector_memory import (
@@ -83,28 +83,11 @@ def _normalized_subcommand(args: str) -> str:
     return " ".join(args.replace("_", " ").lower().split())
 
 
-def _reply_text(ctx: Context) -> str:
-    if not isinstance(ctx.reply_to_message, dict):
-        return ""
-    return (ctx.reply_to_message.get("text") or ctx.reply_to_message.get("caption") or "").strip()
-
-
-def _build_ask_user_text(ctx: Context) -> str:
-    question = _command_args(ctx.text)
-    replied_text = _reply_text(ctx)
-    if question and replied_text:
-        return (
-            "The user is asking about this replied-to group message:\n"
-            f"{replied_text}\n\n"
-            "User question:\n"
-            f"{question}"
-        )
-    if replied_text:
-        return (
-            "The user replied to this group message and wants you to explain it or answer based on it:\n"
-            f"{replied_text}"
-        )
-    return question
+def _message_for_ask_context(ctx: Context, question: str) -> dict:
+    message = dict(ctx.message) if isinstance(ctx.message, dict) else {"text": question}
+    if isinstance(ctx.reply_to_message, dict):
+        message["reply_to_message"] = ctx.reply_to_message
+    return message
 
 
 def _parse_genquiz_args(text: str, chat_id: int | str) -> tuple[str, str, str] | None:
@@ -342,8 +325,14 @@ def handle_ask(ctx: Context) -> None:
     if not ctx.sqs_repo:
         ctx.reply(get_translated_text("ask_agent_unavailable", ctx.lang_code), ctx.message_id)
         return
-    question = _build_ask_user_text(ctx)
-    if not question:
+    question = _command_args(ctx.text)
+    question_context = build_explicit_question_context(
+        ctx.memory_repo,
+        ctx.chat_id,
+        _message_for_ask_context(ctx, question),
+        current_text=question,
+    )
+    if not question_context.user_text:
         ctx.reply(get_translated_text("ask_usage", ctx.lang_code), ctx.message_id)
         return
     if not ctx.memory_repo.is_memory_enabled(ctx.chat_id):
@@ -361,11 +350,14 @@ def handle_ask(ctx: Context) -> None:
             update_id=ctx.update_id or ctx.message_id or 0,
             chat_id=ctx.chat_id,
             reply_to_message_id=ctx.message_id,
-            user_text=question,
+            user_text=question_context.user_text,
             lang=ctx.lang_code,
             requester_user_id=ctx.user_id,
             requester_username=ctx.username,
             requester_display_name=display_name(ctx.user_data),
+            current_user_message=question_context.current_user_message,
+            source_message_context=question_context.source_message_context,
+            parent_bot_message_id=question_context.parent_bot_message_id,
         )
     except Exception:
         logger.exception("Failed to enqueue /ask task", extra={"chat_id": ctx.chat_id, "message_id": ctx.message_id})
@@ -398,6 +390,9 @@ def process_group_ask_task(
         requester_user_id=requester_user_id,
         requester_username=str(body.get("requester_username") or "") or None,
         requester_display_name=str(body.get("requester_display_name") or "") or None,
+        current_user_message=str(body.get("current_user_message") or "") or None,
+        source_message_context=str(body.get("source_message_context") or "") or None,
+        parent_bot_message_id=body.get("parent_bot_message_id"),
         raise_on_unavailable=True,
     )
     if not handled:

--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -758,6 +758,9 @@ class GroupMemoryRepository:
         reason: str,
         answer_text: str | None = None,
         user_message: str | None = None,
+        current_user_message: str | None = None,
+        source_message_context: str | None = None,
+        parent_bot_message_id: int | str | None = None,
         confidence: float | None = None,
         requester_user_id: int | str | None = None,
         requester_username: str | None = None,
@@ -781,6 +784,12 @@ class GroupMemoryRepository:
             item["answer_text"] = answer_text[:3000]
         if user_message:
             item["user_message"] = user_message[:1500]
+        if current_user_message:
+            item["current_user_message"] = current_user_message[:1500]
+        if source_message_context:
+            item["source_message_context"] = source_message_context[:2200]
+        if parent_bot_message_id is not None:
+            item["parent_bot_message_id"] = int(parent_bot_message_id)
         if confidence is not None:
             item["confidence"] = Decimal(str(max(0.0, min(1.0, confidence))))
         if requester_user_id is not None:

--- a/src/bot/services/repositories/sqs.py
+++ b/src/bot/services/repositories/sqs.py
@@ -77,6 +77,9 @@ class SQSClient:
         requester_user_id: int | str | None = None,
         requester_username: str | None = None,
         requester_display_name: str | None = None,
+        current_user_message: str | None = None,
+        source_message_context: str | None = None,
+        parent_bot_message_id: int | str | None = None,
     ) -> None:
         """Enqueue an explicit /ask request for async group-agent answering."""
         payload: dict[str, object] = {
@@ -93,6 +96,12 @@ class SQSClient:
             payload["requester_username"] = requester_username
         if requester_display_name:
             payload["requester_display_name"] = requester_display_name
+        if current_user_message:
+            payload["current_user_message"] = current_user_message
+        if source_message_context:
+            payload["source_message_context"] = source_message_context
+        if parent_bot_message_id is not None:
+            payload["parent_bot_message_id"] = parent_bot_message_id
         try:
             self.sqs_client.send_message(
                 QueueUrl=self.queue_url,

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -654,6 +654,29 @@ def test_sqs_client_sends_group_ask_task_with_requester(monkeypatch):
     assert payload["requester_display_name"] == "Ada"
 
 
+def test_sqs_client_sends_group_ask_task_with_thread_context(monkeypatch):
+    fake_client = MagicMock()
+    monkeypatch.setattr(sqs_module, "_SQS_CLIENT", fake_client)
+    sqs = SQSClient.__new__(SQSClient)
+    sqs.queue_url = "queue-url"
+
+    sqs.send_group_ask_task(
+        update_id=123,
+        chat_id=-100123,
+        reply_to_message_id=99,
+        user_text="thread prompt",
+        lang="en",
+        current_user_message="why?",
+        source_message_context="Original replied-to message:\n[speaker user_id=7] Python is slow?",
+        parent_bot_message_id=555,
+    )
+
+    payload = json.loads(fake_client.send_message.call_args.kwargs["MessageBody"])
+    assert payload["current_user_message"] == "why?"
+    assert "Python is slow" in payload["source_message_context"]
+    assert payload["parent_bot_message_id"] == 555
+
+
 def test_sqs_client_sends_vector_memory_task(monkeypatch):
     fake_client = MagicMock()
     monkeypatch.setattr(sqs_module, "_SQS_CLIENT", fake_client)
@@ -705,7 +728,11 @@ def test_agent_reply_to_bot_includes_replied_bot_message_context(monkeypatch):
     repo = MagicMock()
     repo.is_agent_enabled.return_value = True
     repo.get_agent_reply_explanation.return_value = {
-        "user_message": "The user asked about a replied-to group message.",
+        "current_user_message": "Who is the original author talking about?",
+        "source_message_context": (
+            "Original replied-to message:\n"
+            "[speaker user_id=7 username=@nurt name=Nurt message_id=8] We still need infra engineers."
+        ),
         "answer_text": "The previous answer explained that infra engineers are still needed.",
     }
     bot = MagicMock()
@@ -726,11 +753,118 @@ def test_agent_reply_to_bot_includes_replied_bot_message_context(monkeypatch):
     assert handled is True
     user_text = answer.call_args.kwargs["user_text"]
     assert "continuing a thread" in user_text
+    assert "Original source message for the previous answer" in user_text
+    assert "We still need infra engineers" in user_text
     assert "infra engineers are still needed" in user_text
-    assert "The user asked about a replied-to group message" in user_text
+    assert "Who is the original author talking about?" in user_text
     assert "Поделись по братский" in user_text
+    assert answer.call_args.kwargs["current_user_message"] == "Поделись по братский"
+    assert "We still need infra engineers" in answer.call_args.kwargs["source_message_context"]
+    assert answer.call_args.kwargs["parent_bot_message_id"] == 10
     assert answer.call_args.kwargs["requester_user_id"] == 42
     assert answer.call_args.kwargs["requester_username"] == "ada"
+
+
+def test_agent_mention_reply_to_non_bot_includes_source_message(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = True
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    update = _group_update("@ZerdeBot is he joking?")
+    update["message"]["reply_to_message"] = {
+        "message_id": 8,
+        "text": "Sure, deploying on Friday evening is always a great idea.",
+        "from": {"id": 7, "is_bot": False, "first_name": "Nurt", "username": "nurt"},
+    }
+
+    handled = group_agent.handle_update(repo=repo, bot=bot, update=update)
+
+    assert handled is True
+    user_text = answer.call_args.kwargs["user_text"]
+    assert "Original replied-to message" in user_text
+    assert "message_id=8" in user_text
+    assert "deploying on Friday evening" in user_text
+    assert "@ZerdeBot is he joking?" in user_text
+    assert answer.call_args.kwargs["current_user_message"] == "@ZerdeBot is he joking?"
+    assert "deploying on Friday evening" in answer.call_args.kwargs["source_message_context"]
+
+
+def test_agent_reply_to_bot_reaction_is_skipped(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = True
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    update = _group_update("haha, interesting")
+    update["message"]["reply_to_message"] = {
+        "message_id": 10,
+        "text": "Python is a general-purpose language.",
+        "from": {"id": 999, "is_bot": True, "username": "zerdebot"},
+    }
+
+    handled = group_agent.handle_update(repo=repo, bot=bot, update=update)
+
+    assert handled is False
+    answer.assert_not_called()
+
+
+def test_agent_reply_to_bot_clear_followup_still_answers(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = True
+    repo.get_agent_reply_explanation.return_value = {
+        "current_user_message": "What is Python?",
+        "answer_text": "Python is a general-purpose language.",
+    }
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    update = _group_update("why?")
+    update["message"]["reply_to_message"] = {
+        "message_id": 10,
+        "text": "Python is a general-purpose language.",
+        "from": {"id": 999, "is_bot": True, "username": "zerdebot"},
+    }
+
+    handled = group_agent.handle_update(repo=repo, bot=bot, update=update)
+
+    assert handled is True
+    assert "why?" in answer.call_args.kwargs["user_text"]
+
+
+def test_agent_reply_to_bot_with_explicit_mention_overrides_gate(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = True
+    repo.get_agent_reply_explanation.return_value = {
+        "current_user_message": "What is Python?",
+        "answer_text": "Python is a general-purpose language.",
+    }
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    update = _group_update("@ZerdeBot haha")
+    update["message"]["reply_to_message"] = {
+        "message_id": 10,
+        "text": "Python is a general-purpose language.",
+        "from": {"id": 999, "is_bot": True, "username": "zerdebot"},
+    }
+
+    handled = group_agent.handle_update(repo=repo, bot=bot, update=update)
+
+    assert handled is True
+    assert "@ZerdeBot haha" in answer.call_args.kwargs["user_text"]
 
 
 def test_agent_should_not_answer_plain_chatter(monkeypatch):
@@ -901,6 +1035,31 @@ def test_proactive_reservation_escapes_ttl_attribute():
     kwargs = repo.table.update_item.call_args.kwargs
     assert "#ttl = :ttl" in kwargs["UpdateExpression"]
     assert kwargs["ExpressionAttributeNames"]["#ttl"] == "ttl"
+
+
+def test_record_agent_reply_persists_thread_metadata():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+
+    repo.record_agent_reply(
+        chat_id=-100123,
+        bot_message_id=555,
+        trigger_message_id=99,
+        trigger_kind="explicit",
+        reason="answered a reply-thread question",
+        answer_text="Python is a language.",
+        user_message="full prompt with source",
+        current_user_message="why?",
+        source_message_context="Original replied-to message:\n[speaker user_id=7] What is Python?",
+        parent_bot_message_id=444,
+    )
+
+    item = repo.table.put_item.call_args.kwargs["Item"]
+    assert item["sk"] == "AGENT_REPLY#0000000000555"
+    assert item["user_message"] == "full prompt with source"
+    assert item["current_user_message"] == "why?"
+    assert "What is Python" in item["source_message_context"]
+    assert item["parent_bot_message_id"] == 444
 
 
 def test_group_chat_reply_prompt_resists_third_party_profile_poisoning(monkeypatch):
@@ -1208,6 +1367,9 @@ def test_handle_ask_enqueues_group_context_answer():
         requester_user_id=42,
         requester_username="ada",
         requester_display_name="Ada",
+        current_user_message="what happened yesterday?",
+        source_message_context="",
+        parent_bot_message_id=None,
     )
     ctx.react.assert_called_once_with("👀")
     ctx.reply.assert_not_called()
@@ -1235,7 +1397,11 @@ def test_handle_ask_reply_with_question_enqueues_replied_text_and_question():
     ctx.chat_id = -100123
     ctx.message_id = 99
     ctx.lang_code = "en"
-    ctx.reply_to_message = {"text": "Sure, deploying on Friday evening is always a great idea."}
+    ctx.reply_to_message = {
+        "message_id": 8,
+        "text": "Sure, deploying on Friday evening is always a great idea.",
+        "from": {"id": 7, "is_bot": False, "first_name": "Nurt", "username": "nurt"},
+    }
     ctx.user_id = 42
     ctx.username = "ada"
     ctx.user_data = {"id": 42, "first_name": "Ada", "username": "ada"}
@@ -1246,7 +1412,36 @@ def test_handle_ask_reply_with_question_enqueues_replied_text_and_question():
     user_text = ctx.sqs_repo.send_group_ask_task.call_args.kwargs["user_text"]
     assert "deploying on Friday evening" in user_text
     assert "is he being sarcastic?" in user_text
+    assert "message_id=8" in ctx.sqs_repo.send_group_ask_task.call_args.kwargs["source_message_context"]
+    assert ctx.sqs_repo.send_group_ask_task.call_args.kwargs["current_user_message"] == "is he being sarcastic?"
     ctx.reply.assert_not_called()
+
+
+def test_process_group_ask_task_passes_thread_context_to_agent(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(commands, "answer_group_question", answer)
+
+    commands.process_group_ask_task(
+        repo=repo,
+        bot=bot,
+        body={
+            "chat_id": -100123,
+            "reply_to_message_id": 99,
+            "user_text": "thread prompt",
+            "lang": "en",
+            "requester_user_id": 42,
+            "current_user_message": "why?",
+            "source_message_context": "Original replied-to message:\n[speaker user_id=7] What is Python?",
+            "parent_bot_message_id": 555,
+        },
+    )
+
+    answer.assert_called_once()
+    assert answer.call_args.kwargs["current_user_message"] == "why?"
+    assert "What is Python" in answer.call_args.kwargs["source_message_context"]
+    assert answer.call_args.kwargs["parent_bot_message_id"] == 555
 
 
 def _command_ctx(*, user_id: int = 42, status: str = "member") -> MagicMock:


### PR DESCRIPTION
## Summary
- preserve quoted source-message context in agent prompts and AGENT_REPLY metadata
- continue reply-to-bot threads with source message, previous user request, previous bot answer, and current follow-up
- add conservative reply-to-bot gating so reactions/thanks/laughter do not trigger another answer unless the bot is explicitly mentioned
- carry thread metadata through /ask SQS payloads and keep old queued payloads compatible

## Validation
- uv run pytest tests/test_group_memory_agent.py -q
- uv run pytest tests/ -q
- uv run pre-commit run --all-files