### PR TITLE
fix: improve multilingual proactive question gating

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -131,6 +131,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
 - **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.
+- **Proactive prefiltering**: suppress bot-behavior meta chatter and stop cues, but do not treat generic technical/product mentions of "bot"/"бот" as bot-meta. Log structured local prefilter skips for open-question candidates.
 - **Structured logging**: use `zerde_common` and avoid logging full prompts, model responses, API keys, Telegram files, or user secrets.
 - **Vector observability**: retrieval and indexing success paths emit INFO logs with counts, filters, distance cutoffs, and vector dimensions; do not rely only on ERROR logs to confirm vector health.
 

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -59,7 +59,8 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Reply-to-bot follow-ups should include the captured quoted source message, previous user request, previous bot answer, and current follow-up when available.
 - Do not answer every reply to a bot message; pure reactions, thanks, laughter, and short comments should be locally skipped unless the user explicitly mentions the bot.
 - Store useful bot answer metadata in `AGENT_REPLY#...` so `/agent why` and thread continuation work.
-- Keep proactive participation conservative: local open-question prefilter, bot-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
+- Keep proactive participation conservative: local open-question prefilter, bot-behavior-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
+- Do not suppress proactive technical/product questions merely because they mention "bot"/"бот"; local prefilter skips for open-question candidates should log structured reasons.
 - Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.
 - If cleaning production memory, first back up exact DynamoDB items and vector keys locally, then delete narrowly.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,7 +119,8 @@ Memory safety filters apply before context reaches the model. Raw `MSG#...` item
 Proactive replies are conservative:
 
 - The local prefilter only considers open questions or requests.
-- Bot-meta complaints and stop cues are ignored.
+- Bot-behavior meta complaints and stop cues are ignored, but generic technical/product mentions of "bot"/"бот" are still allowed through scoring.
+- Local prefilter skips for open-question candidates are logged with a structured skip reason before score/model gating.
 - Recent bot activity lowers the score.
 - Gemini must return a strong "should reply" decision.
 - `AGENT_DAILY_PROACTIVE_LIMIT` caps per-chat daily proactive responses.

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -387,34 +387,63 @@ def _looks_like_open_question(text: str) -> bool:
     return len(text) >= 12 and (question_mark or any(word in lowered for word in cue_words))
 
 
-def _local_proactive_candidate(text: str) -> bool:
-    """Cheap social prefilter before spending an LLM call on timing judgment."""
+_PROACTIVE_STOP_CUES = (
+    "болды",
+    "жазба",
+    "жетеді",
+    "stop",
+    "don't reply",
+    "не отвечай",
+    "хватит",
+    "не пиши",
+    "别说",
+    "不要说",
+    "尴尬",
+)
+
+_PROACTIVE_BOT_META_CUES = (
+    "zerde",
+    "зерде",
+    "оқитын болған",
+    "оқып отыр",
+    "тыңдап отыр",
+    "читает чат",
+    "читает все",
+    "читает любые",
+    "слушает чат",
+    "reading every",
+    "reads every",
+    "listening to everything",
+    "why is the bot replying",
+    "bot keeps replying",
+    "бот жауап беріп жатыр",
+    "бот отвечает",
+)
+
+
+def _looks_like_bot_behavior_meta(text: str) -> bool:
+    """Return True for bot-behavior meta chatter, not generic bot-building questions."""
+    lowered = " ".join((text or "").lower().split())
+    return any(cue in lowered for cue in _PROACTIVE_BOT_META_CUES)
+
+
+def _local_proactive_skip_reason(text: str) -> str | None:
+    """Explain why a message is rejected before proactive score/model gating."""
     lowered = text.lower().strip()
     if not _looks_like_open_question(text):
-        return False
+        return "not_open_question"
     if len(text) > 500:
-        return False
-    awkward_cues = (
-        "болды",
-        "жазба",
-        "жетеді",
-        "stop",
-        "don't reply",
-        "не отвечай",
-        "хватит",
-        "не пиши",
-        "别说",
-        "不要说",
-        "尴尬",
-    )
-    if any(cue in lowered for cue in awkward_cues):
-        return False
-    # Meta questions about the bot's behavior are usually better left to humans
-    # unless the bot is explicitly addressed.
-    bot_meta_cues = ("bot", "бот", "zerde", "оқитын болған", "читает", "тыңдап отыр")
-    if any(cue in lowered for cue in bot_meta_cues):
-        return False
-    return True
+        return "too_long"
+    if any(cue in lowered for cue in _PROACTIVE_STOP_CUES):
+        return "stop_or_awkward_cue"
+    if _looks_like_bot_behavior_meta(text):
+        return "bot_meta"
+    return None
+
+
+def _local_proactive_candidate(text: str) -> bool:
+    """Cheap social prefilter before spending an LLM call on timing judgment."""
+    return _local_proactive_skip_reason(text) is None
 
 
 def score_proactive_reply(
@@ -440,7 +469,12 @@ def score_proactive_reply(
         "lambda",
         "python",
         "telegram",
+        "телеграм",
         "bot",
+        "бот",
+        "техникалық",
+        "стэк",
+        "стек",
         "infra",
         "deploy",
         "api",
@@ -526,6 +560,27 @@ def _log_skipped_reply_to_bot_followup(update: dict[str, Any]) -> None:
     )
 
 
+def _log_skipped_proactive_prefilter(update: dict[str, Any]) -> None:
+    if not AGENT_ENABLED or not _is_plain_text_message(update):
+        return
+    message = update["message"]
+    text = extract_message_text(message)
+    if _mentions_bot(text) or _replies_to_bot(message):
+        return
+    skip_reason = _local_proactive_skip_reason(text)
+    if not skip_reason or skip_reason == "not_open_question":
+        return
+    logger.info(
+        "Group agent proactive candidate skipped by local prefilter",
+        extra={
+            "chat_id": (message.get("chat") or {}).get("id"),
+            "message_id": message.get("message_id"),
+            "skip_reason": skip_reason,
+            "text_chars": len(text),
+        },
+    )
+
+
 def should_answer(update: dict[str, Any]) -> bool:
     """Return True when the agent policy allows considering an answer."""
     return _trigger_kind(update) is not None
@@ -545,6 +600,7 @@ def handle_update(
     trigger_kind = _trigger_kind(update)
     if trigger_kind is None:
         _log_skipped_reply_to_bot_followup(update)
+        _log_skipped_proactive_prefilter(update)
         return False
     if repo is None:
         return False

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -881,11 +881,50 @@ def test_agent_can_consider_open_question_when_enabled(monkeypatch):
     assert group_agent.should_answer(_group_update("does anyone know how OpenSearch pricing works?")) is True
 
 
+def test_agent_can_consider_telegram_bot_stack_question_when_enabled(monkeypatch):
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+
+    text = (
+        "Маған идея керек, бір жаңа телеграм бот жасауым керек, "
+        "соған нақты техникалық стэк керек болып тұр, қандай ұсына аласыздар???"
+    )
+
+    assert group_agent._local_proactive_skip_reason(text) is None
+    assert group_agent.should_answer(_group_update(text)) is True
+    score = group_agent.score_proactive_reply(
+        user_text=text, recent_context="Ada: context", long_term_memory_context=""
+    )
+    assert "technical_relevance" in score.reasons
+
+
 def test_agent_does_not_consider_bot_meta_question_for_proactive_reply(monkeypatch):
     monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
     monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
 
+    assert group_agent._local_proactive_skip_reason("қазір кез келген хатты оқитын болған ба?") == "bot_meta"
     assert group_agent.should_answer(_group_update("қазір кез келген хатты оқитын болған ба?")) is False
+
+
+def test_agent_logs_local_proactive_prefilter_skip(monkeypatch):
+    repo = MagicMock()
+    info = MagicMock()
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent.logger, "info", info)
+
+    handled = group_agent.handle_update(
+        repo=repo,
+        bot=MagicMock(),
+        update=_group_update("қазір кез келген хатты оқитын болған ба?"),
+    )
+
+    assert handled is False
+    assert any(
+        call.args[0] == "Group agent proactive candidate skipped by local prefilter"
+        and call.kwargs["extra"]["skip_reason"] == "bot_meta"
+        for call in info.call_args_list
+    )
 
 
 def test_agent_does_not_consider_stop_cue_for_proactive_reply(monkeypatch):


### PR DESCRIPTION
## Summary
- allow proactive technical/product questions that mention generic `bot`/`бот` to reach scoring/model gating
- add multilingual proactive scoring cues for technical, suggestion/idea, and group-request intents across Kazakh, Russian, English, and Chinese
- keep true bot-behavior meta chatter and stop cues suppressed by the local prefilter
- add structured local prefilter skip logs for open-question candidates rejected before reply scoring
- document the proactive prefilter/scoring rules and add regression coverage for Telegram bot stack plus multilingual idea-request questions

## Root Cause
The local proactive path had two gaps:

1. It treated any occurrence of `bot`/`бот` as bot-meta chatter, so legitimate technical questions about building Telegram bots were rejected before scoring.
2. The reply scorer recognized mostly English/software cues. A clear Kazakh/Russian-style suggestion request like `Дипломдық проектіме идея... Қандай идея қоса аласыңдар?` only received `open_question + has_recent_context = 0.42`, below the `0.62` threshold, so Gemini social timing was never called.

## User Impact
Open multilingual advice/idea requests now pass local scoring when they clearly ask for suggestions, while ordinary chatter still stays below threshold and reply-to-bot reaction gating remains conservative.

## Validation
- `uv run pytest tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`
