### PR TITLE
fix: add multilingual proactive scoring cues

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -131,7 +131,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
 - **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.
-- **Proactive prefiltering**: suppress bot-behavior meta chatter and stop cues, but do not treat generic technical/product mentions of "bot"/"бот" as bot-meta. Log structured local prefilter skips for open-question candidates.
+- **Proactive prefiltering**: suppress bot-behavior meta chatter and stop cues, but do not treat generic technical/product mentions of "bot"/"бот" as bot-meta. Score multilingual technical, suggestion, and group-request cues across Kazakh, Russian, English, and Chinese, and log structured local prefilter skips for open-question candidates.
 - **Structured logging**: use `zerde_common` and avoid logging full prompts, model responses, API keys, Telegram files, or user secrets.
 - **Vector observability**: retrieval and indexing success paths emit INFO logs with counts, filters, distance cutoffs, and vector dimensions; do not rely only on ERROR logs to confirm vector health.
 

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -60,7 +60,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Do not answer every reply to a bot message; pure reactions, thanks, laughter, and short comments should be locally skipped unless the user explicitly mentions the bot.
 - Store useful bot answer metadata in `AGENT_REPLY#...` so `/agent why` and thread continuation work.
 - Keep proactive participation conservative: local open-question prefilter, bot-behavior-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
-- Do not suppress proactive technical/product questions merely because they mention "bot"/"бот"; local prefilter skips for open-question candidates should log structured reasons.
+- Do not suppress proactive technical/product questions merely because they mention "bot"/"бот"; score multilingual technical, suggestion, and group-request cues across Kazakh, Russian, English, and Chinese; local prefilter skips for open-question candidates should log structured reasons.
 - Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.
 - If cleaning production memory, first back up exact DynamoDB items and vector keys locally, then delete narrowly.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,6 +120,7 @@ Proactive replies are conservative:
 
 - The local prefilter only considers open questions or requests.
 - Bot-behavior meta complaints and stop cues are ignored, but generic technical/product mentions of "bot"/"бот" are still allowed through scoring.
+- The reply score recognizes multilingual technical, suggestion, and group-request cues in Kazakh, Russian, English, and Chinese.
 - Local prefilter skips for open-question candidates are logged with a structured skip reason before score/model gating.
 - Recent bot activity lowers the score.
 - Gemini must return a strong "should reply" decision.

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -376,12 +376,27 @@ def _looks_like_open_question(text: str) -> bool:
         "how ",
         "why ",
         "what ",
+        "which ",
         "кто",
         "как",
+        "что",
+        "какой",
+        "какая",
+        "какие",
+        "где",
+        "когда",
+        "зачем",
         "почему",
         "怎么",
         "为什么",
+        "什么",
+        "哪",
         "қалай",
+        "қандай",
+        "қайсы",
+        "қайда",
+        "қашан",
+        "кім",
         "неге",
     )
     return len(text) >= 12 and (question_mark or any(word in lowered for word in cue_words))
@@ -418,6 +433,79 @@ _PROACTIVE_BOT_META_CUES = (
     "bot keeps replying",
     "бот жауап беріп жатыр",
     "бот отвечает",
+)
+
+_PROACTIVE_TECHNICAL_CUES = (
+    "aws",
+    "opensearch",
+    "dynamodb",
+    "lambda",
+    "python",
+    "telegram",
+    "телеграм",
+    "bot",
+    "бот",
+    "техникалық",
+    "стэк",
+    "стек",
+    "infra",
+    "deploy",
+    "api",
+    "database",
+    "serverless",
+    "llm",
+    "gemini",
+    "deepseek",
+    "groq",
+)
+
+_PROACTIVE_SUGGESTION_CUES = (
+    "idea",
+    "ideas",
+    "suggest",
+    "recommend",
+    "advice",
+    "topic",
+    "project idea",
+    "идея",
+    "идеи",
+    "идею",
+    "посовет",
+    "предлож",
+    "совет",
+    "тема",
+    "диплом",
+    "ұсын",
+    "кеңес",
+    "тақырып",
+    "жоба",
+    "проект",
+    "қоса аласың",
+    "毕业",
+    "论文",
+    "课题",
+    "建议",
+    "推荐",
+    "想法",
+)
+
+_PROACTIVE_GROUP_REQUEST_CUES = (
+    "anyone",
+    "any ideas",
+    "does anyone",
+    "what do you all",
+    "what would you",
+    "кто-нибудь",
+    "что посоветуете",
+    "какие идеи",
+    "біреу",
+    "ұсына аласыңдар",
+    "қоса аласыңдар",
+    "не дейсіңдер",
+    "有什么建议",
+    "有推荐",
+    "大家",
+    "有人",
 )
 
 
@@ -462,32 +550,13 @@ def score_proactive_reply(
         score += 0.34
         reasons.append("open_question")
 
-    technical_cues = (
-        "aws",
-        "opensearch",
-        "dynamodb",
-        "lambda",
-        "python",
-        "telegram",
-        "телеграм",
-        "bot",
-        "бот",
-        "техникалық",
-        "стэк",
-        "стек",
-        "infra",
-        "deploy",
-        "api",
-        "database",
-        "serverless",
-        "llm",
-        "gemini",
-        "deepseek",
-        "groq",
-    )
-    if any(cue in lowered for cue in technical_cues):
+    if any(cue in lowered for cue in _PROACTIVE_TECHNICAL_CUES):
         score += 0.22
         reasons.append("technical_relevance")
+
+    if any(cue in lowered for cue in _PROACTIVE_SUGGESTION_CUES):
+        score += 0.22
+        reasons.append("asks_for_suggestions")
 
     if long_term_memory_context:
         memory_terms = {
@@ -510,7 +579,7 @@ def score_proactive_reply(
         score += 0.05
         reasons.append("substantial_question")
 
-    if any(cue in lowered for cue in ("anyone", "кто-нибудь", "біреу", "有人", "does anyone")):
+    if any(cue in lowered for cue in _PROACTIVE_GROUP_REQUEST_CUES):
         score += 0.08
         reasons.append("asks_group")
 

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -898,6 +898,57 @@ def test_agent_can_consider_telegram_bot_stack_question_when_enabled(monkeypatch
     assert "technical_relevance" in score.reasons
 
 
+def test_proactive_score_recognizes_multilingual_suggestion_requests():
+    cases = (
+        (
+            "Дипломдық проектіме идея іздеп жүрмін, тақырып ядролық физикаға жақын болу керек. "
+            "Қандай идея қоса аласыңдар?"
+        ),
+        "Подскажите, какие идеи можно взять для дипломного проекта по ядерной физике?",
+        "Any ideas for a graduation project close to nuclear physics?",
+        "毕业设计想做核物理方向，有什么建议？",
+    )
+
+    for text in cases:
+        score = group_agent.score_proactive_reply(
+            user_text=text,
+            recent_context="Ada: previous context",
+            long_term_memory_context="",
+        )
+
+        assert score.score >= group_agent.AGENT_PROACTIVE_SCORE_THRESHOLD
+        assert "asks_for_suggestions" in score.reasons
+
+
+def test_proactive_agent_considers_kazakh_idea_request(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    gemini = MagicMock()
+    gemini.group_chat_proactive_decision.return_value = (
+        GroupAgentDecision(False, 0.8, "useful ideation request, but humans may answer first", ""),
+        1,
+    )
+    monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
+    monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "Ada: previous context")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
+
+    handled = group_agent.maybe_answer_proactively(
+        repo=repo,
+        bot=bot,
+        chat_id=-100123,
+        reply_to_message_id=11,
+        user_text=(
+            "Дипломдық проектіме идея іздеп жүрмін, тақырып ядролық физикаға жақын болу керек. "
+            "Қандай идея қоса аласыңдар?"
+        ),
+        lang="kk",
+    )
+
+    assert handled is False
+    gemini.group_chat_proactive_decision.assert_called_once()
+    repo.try_reserve_proactive_reply.assert_not_called()
+
+
 def test_agent_does_not_consider_bot_meta_question_for_proactive_reply(monkeypatch):
     monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
     monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")


### PR DESCRIPTION
## Summary
- add multilingual proactive scoring cues for technical, suggestion/idea, and group-request intents across Kazakh, Russian, English, and Chinese
- expand open-question cue recognition for Kazakh, Russian, English, and Chinese question words
- keep the global proactive threshold conservative while allowing clear advice/idea requests to reach Gemini social timing
- document the multilingual scoring rule and add regression coverage for Kazakh/Russian/English/Chinese suggestion requests

## Root Cause
The proactive scorer recognized mostly English/software cues. A clear Kazakh/Russian-style suggestion request like `Дипломдық проектіме идея... Қандай идея қоса аласыңдар?` only received `open_question + has_recent_context = 0.42`, below the `0.62` threshold, so Gemini social timing was never called.

## User Impact
Open multilingual advice/idea requests now pass local scoring when they clearly ask for suggestions, while ordinary chatter still stays below threshold and reply-to-bot reaction gating remains conservative.

## Validation
- `uv run pytest tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`