### PR TITLE
fix: handle empty Gemini candidate responses

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -132,6 +132,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
 - **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.
 - **Proactive prefiltering**: suppress bot-behavior meta chatter and stop cues, but do not treat generic technical/product mentions of "bot"/"бот" as bot-meta. Score multilingual technical, suggestion, and group-request cues across Kazakh, Russian, English, and Chinese, and log structured local prefilter skips for open-question candidates.
+- **Gemini empty responses**: HTTP 200 responses without candidate text are non-retryable for interactive `/ask`; log safe response-shape fields such as block reason, finish reason, and candidate counts, then notify the user without requeueing.
 - **Structured logging**: use `zerde_common` and avoid logging full prompts, model responses, API keys, Telegram files, or user secrets.
 - **Vector observability**: retrieval and indexing success paths emit INFO logs with counts, filters, distance cutoffs, and vector dimensions; do not rely only on ERROR logs to confirm vector health.
 

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -113,6 +113,7 @@ Treat AI behavior as user-facing reliability work:
 - Prefer fast fallback for interactive commands and `/ask` paths over long primary-provider retries.
 - Keep scheduled/batch paths allowed to retry longer than interactive user commands.
 - Map provider transport, 429, 5xx, and parse failures into consistent error types where the codebase already has that pattern.
+- Treat Gemini HTTP 200 responses with no candidate text as non-retryable for interactive `/ask`; log safe response-shape metadata such as block reason, finish reason, and candidate counts without logging full model responses.
 - Do not log full prompts, model responses, API keys, Telegram file contents, or user secrets.
 
 ## Implementation Guidance

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,6 +133,7 @@ Answer length is explicit:
 - Plain `/ask` explanations get a medium budget.
 - Detailed answers require explicit cues such as "подробно", "толық", or "deep dive".
 - `fit_llm_output` trims overly long responses before Telegram HTML normalization.
+- Gemini `200 OK` responses with no candidate text are logged with safe response-shape metadata and treated as non-retryable for interactive `/ask` SQS work; the user gets the normal unavailable notice instead of a noisy retry loop.
 
 ## Vector Memory
 

--- a/src/bot/services/ai/gemini_client.py
+++ b/src/bot/services/ai/gemini_client.py
@@ -71,6 +71,19 @@ class GeminiUnavailableError(Exception):
     the daily-quota user notice.
     """
 
+    retryable = True
+
+
+class GeminiEmptyResponseError(GeminiUnavailableError):
+    """Gemini returned HTTP 200 but no usable candidate text.
+
+    This usually means the response was blocked or otherwise completed without
+    text. Retrying the same interactive SQS task is unlikely to help and can
+    create noisy Lambda errors.
+    """
+
+    retryable = False
+
 
 def _elapsed_ms(started_at: float) -> int:
     return int((time.monotonic() - started_at) * 1000)
@@ -84,6 +97,75 @@ def _redact(text: str, api_key: str) -> str:
 
 def _decode_preview(data: bytes, *, limit: int = 300) -> str:
     return data.decode("utf-8", errors="replace")[:limit]
+
+
+def _extract_gemini_text(data: dict[str, Any], *, operation: str, model: str) -> str:
+    """Extract the first text part from a Gemini response with useful empty-shape logging."""
+    candidates = data.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        _raise_empty_response(data, operation=operation, model=model, empty_reason="missing_candidates")
+
+    candidate = candidates[0]
+    if not isinstance(candidate, dict):
+        raise TypeError("candidate is not an object")
+
+    content = candidate.get("content")
+    parts = content.get("parts") if isinstance(content, dict) else None
+    if isinstance(parts, list):
+        for part in parts:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+
+    _raise_empty_response(
+        data,
+        operation=operation,
+        model=model,
+        empty_reason="missing_text",
+        finish_reason=str(candidate.get("finishReason") or ""),
+        candidate_safety_count=len(candidate.get("safetyRatings") or []),
+    )
+    raise AssertionError("_raise_empty_response should always raise")
+
+
+def _raise_empty_response(
+    data: dict[str, Any],
+    *,
+    operation: str,
+    model: str,
+    empty_reason: str,
+    finish_reason: str = "",
+    candidate_safety_count: int = 0,
+) -> None:
+    prompt_feedback = data.get("promptFeedback")
+    prompt_feedback = prompt_feedback if isinstance(prompt_feedback, dict) else {}
+    prompt_safety = prompt_feedback.get("safetyRatings")
+    candidates = data.get("candidates")
+    candidates_count = len(candidates) if isinstance(candidates, list) else 0
+    prompt_block_reason = str(prompt_feedback.get("blockReason") or "")
+    prompt_block_message = str(prompt_feedback.get("blockReasonMessage") or "")
+    logger.warning(
+        "Gemini response had no candidate text",
+        extra={
+            "operation": operation,
+            "model": model,
+            "empty_reason": empty_reason,
+            "response_keys": ",".join(sorted(str(key) for key in data.keys())),
+            "candidates_count": candidates_count,
+            "finish_reason": finish_reason,
+            "prompt_block_reason": prompt_block_reason,
+            "prompt_block_message": prompt_block_message[:300],
+            "prompt_safety_ratings_count": len(prompt_safety) if isinstance(prompt_safety, list) else 0,
+            "candidate_safety_ratings_count": candidate_safety_count,
+        },
+    )
+    details = [empty_reason]
+    if prompt_block_reason:
+        details.append(f"prompt_block_reason={prompt_block_reason}")
+    if finish_reason:
+        details.append(f"finish_reason={finish_reason}")
+    raise GeminiEmptyResponseError("Gemini response had no candidate text: " + "; ".join(details))
 
 
 @dataclass(frozen=True)
@@ -312,10 +394,13 @@ class GeminiClient:
 
         try:
             data = json.loads(resp_data.decode("utf-8"))
-            candidate = data["candidates"][0]
-            text = candidate["content"]["parts"][0]["text"].strip()
+            if not isinstance(data, dict):
+                raise TypeError("Gemini response JSON was not an object")
+            text = _extract_gemini_text(data, operation="group_chat_reply", model=self._model)
             _record_success()
             return text, count
+        except GeminiEmptyResponseError:
+            raise
         except (KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
             logger.warning(
                 "Gemini group agent response parse failed",
@@ -415,8 +500,9 @@ class GeminiClient:
 
         try:
             data = json.loads(resp_data.decode("utf-8"))
-            candidate = data["candidates"][0]
-            text = candidate["content"]["parts"][0]["text"].strip()
+            if not isinstance(data, dict):
+                raise TypeError("Gemini response JSON was not an object")
+            text = _extract_gemini_text(data, operation="group_chat_proactive_decision", model=self._model)
             raw_decision = json.loads(text)
             decision = GroupAgentDecision(
                 should_reply=bool(raw_decision.get("should_reply")),
@@ -426,6 +512,8 @@ class GeminiClient:
             )
             _record_success()
             return decision, count
+        except GeminiEmptyResponseError:
+            raise
         except (KeyError, IndexError, json.JSONDecodeError, TypeError, ValueError) as exc:
             logger.warning(
                 "Gemini group agent decision response parse failed",
@@ -515,11 +603,14 @@ class GeminiClient:
 
         try:
             data = json.loads(resp_data.decode("utf-8"))
-            candidate = data["candidates"][0]
-            text = candidate["content"]["parts"][0]["text"].strip()
+            if not isinstance(data, dict):
+                raise TypeError("Gemini response JSON was not an object")
+            text = _extract_gemini_text(data, operation="group_daily_summary", model=self._model)
             summary = json.loads(text)
             _record_success()
             return summary if isinstance(summary, dict) else {}, count
+        except GeminiEmptyResponseError:
+            raise
         except (KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
             logger.warning(
                 "Gemini daily summary response parse failed",

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -20,7 +20,12 @@ from core.config import (
 )
 from core.logger import LoggerAdapter, get_logger
 from core.translations import get_translated_text
-from services.ai.gemini_client import GeminiClient, GeminiRPDExhaustedError, GeminiUnavailableError
+from services.ai.gemini_client import (
+    GeminiClient,
+    GeminiEmptyResponseError,
+    GeminiRPDExhaustedError,
+    GeminiUnavailableError,
+)
 from services.ai.telegram_html import fit_llm_output, normalize_llm_output_for_telegram_html
 from services.group_memory import (
     display_name,
@@ -927,6 +932,7 @@ def answer_group_question(
         )
         return True
     except GeminiUnavailableError as exc:
+        retryable = getattr(exc, "retryable", True)
         logger.warning(
             "Group agent Gemini call unavailable",
             extra={
@@ -934,9 +940,10 @@ def answer_group_question(
                 "reply_to_message_id": reply_to_message_id,
                 "error_type": exc.__class__.__name__,
                 "error_message": str(exc)[:500],
+                "retryable": retryable,
             },
         )
-        if raise_on_unavailable:
+        if raise_on_unavailable and retryable and not isinstance(exc, GeminiEmptyResponseError):
             raise
         bot.send_message(
             chat_id,

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -2,6 +2,7 @@ import json
 from decimal import Decimal
 from unittest.mock import MagicMock
 
+import pytest
 from services import group_agent, group_memory
 from services.ai import gemini_client
 from services.ai.gemini_client import GeminiClient, GroupAgentDecision
@@ -1222,6 +1223,42 @@ def test_group_chat_reply_prompt_resists_third_party_profile_poisoning(monkeypat
     assert "username=@bayashat" in user_prompt
 
 
+def test_group_chat_reply_raises_nonretryable_empty_response(monkeypatch):
+    class FakeHttp:
+        def request(self, method, url, body, headers, retries):
+            return MagicMock(
+                status=200,
+                data=json.dumps(
+                    {
+                        "promptFeedback": {
+                            "blockReason": "SAFETY",
+                            "blockReasonMessage": "No candidate was returned.",
+                            "safetyRatings": [{"category": "HARM_CATEGORY_DANGEROUS_CONTENT"}],
+                        }
+                    }
+                ).encode("utf-8"),
+            )
+
+    monkeypatch.setattr(gemini_client, "_http", FakeHttp())
+    monkeypatch.setattr(gemini_client, "_circuit_open_until", 0.0)
+
+    client = GeminiClient.__new__(GeminiClient)
+    client._api_key = "test-key"
+    client._model = "test-gemini-model"
+    client._rate_repo = MagicMock(rpd_limit=1000)
+    client._rate_repo.increment_and_check.return_value = (1, True)
+
+    with pytest.raises(gemini_client.GeminiEmptyResponseError) as exc_info:
+        client.group_chat_reply(
+            user_message="/ask Бауырым, плов қалай жасайд?",
+            recent_context="",
+            lang="kk",
+        )
+
+    assert exc_info.value.retryable is False
+    assert "prompt_block_reason=SAFETY" in str(exc_info.value)
+
+
 def test_answer_group_question_passes_target_profile_context(monkeypatch):
     repo = MagicMock()
     bot = MagicMock()
@@ -1392,6 +1429,68 @@ def test_answer_group_question_notifies_when_gemini_unavailable(monkeypatch):
         "😵 AI agent қазір қолжетімсіз.",
         reply_to_message_id=99,
     )
+    repo.record_agent_reply.assert_not_called()
+
+
+def test_answer_group_question_notifies_for_empty_gemini_response_without_sqs_retry(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    gemini = MagicMock()
+    gemini.group_chat_reply.side_effect = gemini_client.GeminiEmptyResponseError(
+        "Gemini response had no candidate text: missing_candidates; prompt_block_reason=SAFETY"
+    )
+    monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
+    monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "retrieve_relevant_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(group_agent, "format_user_profile_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_requester_profile_context", lambda *args, **kwargs: "")
+
+    handled = group_agent.answer_group_question(
+        repo=repo,
+        bot=bot,
+        chat_id=-100123,
+        reply_to_message_id=99,
+        user_text="/ask Бауырым, плов қалай жасайд?",
+        lang="kk",
+        raise_on_unavailable=True,
+    )
+
+    assert handled is True
+    bot.send_message.assert_called_once_with(
+        -100123,
+        "😵 AI agent қазір қолжетімсіз.",
+        reply_to_message_id=99,
+    )
+    repo.record_agent_reply.assert_not_called()
+
+
+def test_answer_group_question_reraises_retryable_unavailable_for_sqs(monkeypatch):
+    repo = MagicMock()
+    bot = MagicMock()
+    gemini = MagicMock()
+    gemini.group_chat_reply.side_effect = gemini_client.GeminiUnavailableError(
+        "Gemini transport ReadTimeoutError: read timed out"
+    )
+    monkeypatch.setattr(group_agent, "_get_gemini", lambda: gemini)
+    monkeypatch.setattr(group_agent, "format_recent_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_long_term_memory_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "retrieve_relevant_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(group_agent, "format_user_profile_context", lambda *args, **kwargs: "")
+    monkeypatch.setattr(group_agent, "format_requester_profile_context", lambda *args, **kwargs: "")
+
+    with pytest.raises(gemini_client.GeminiUnavailableError):
+        group_agent.answer_group_question(
+            repo=repo,
+            bot=bot,
+            chat_id=-100123,
+            reply_to_message_id=99,
+            user_text="@zerde_kz_bot не білесің?",
+            lang="kk",
+            raise_on_unavailable=True,
+        )
+
+    bot.send_message.assert_not_called()
     repo.record_agent_reply.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- classify Gemini HTTP 200 responses with no usable candidate text as a non-retryable `GeminiEmptyResponseError`
- log safe response-shape metadata for empty Gemini responses, including response keys, candidate count, prompt block reason, finish reason, and safety rating counts
- keep `/ask` SQS retries for retryable Gemini failures such as transport/timeouts, but notify the user and finish the task for non-retryable empty-candidate responses
- document the behavior and add regression coverage for both non-retryable empty responses and retryable transport errors

## Root Cause
A production `/ask` request received HTTP 200 from Gemini, but the response body had no `candidates` key. The parser raised `KeyError('candidates')`, `answer_group_question(..., raise_on_unavailable=True)` re-raised it, and the SQS worker logged a critical Lambda error/retry instead of sending a user-visible unavailable notice.

## Validation
- `uv run pytest tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`