### PR TITLE
FIX: clarify agent off ask semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For the deeper developer map, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 | `/quizstats` | Everyone | Personal quiz score, streak, and rank. |
 | `/ask <question>` | Everyone in memory-enabled groups | Ask the agent; can be used as a reply to another message and understands “who am I” from requester identity. |
 | `/memory on/off/status/forget ...` | Group owner or bot owner for settings | Manage group memory and cleanup, including user-related vectors and matching daily summaries. |
-| `/agent on/off/status/why` | Group owner or bot owner for settings | Manage agent participation and inspect why the bot replied. |
+| `/agent on/off/status/why` | Group owner or bot owner for settings | Manage agent participation and inspect why the bot replied. `/agent off` disables proactive, mention, and reply-thread participation; `/ask` remains available if memory is on. |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,6 +62,7 @@ flowchart LR
 5. Irrelevant group chatter exits early.
 6. Relevant events route to the group agent or the command dispatcher.
 7. `/ask` is queued as `PROCESS_GROUP_ASK` with requester metadata so Telegram webhook latency stays low and self-reference questions are grounded.
+8. `agent_enabled` gates non-command group agent participation: proactive replies, @mentions, and reply-to-bot follow-ups. Explicit `/ask` remains available while `memory_enabled` is true.
 
 ## SQS Tasks
 
@@ -115,6 +116,8 @@ The Gemini prompt instructs the model to treat requester profiles as highest tru
 Memory safety filters apply before context reaches the model. Raw `MSG#...` items can remain in DynamoDB for audit/recent history, but messages that look like future-answer directives ("when someone asks X, answer Y"), self-promotion, or subjective people rankings ("best in the chat", "strongest developer", "ең мықты") are excluded from profile learning, long-term memory classification, daily summaries, vector indexing, recent prompt context, and semantic prompt context.
 
 ## Agent Timing And Length
+
+`/agent off` disables proactive, mention, and reply-to-bot participation only. It does not disable explicit `/ask`; use `/memory off` when the group should stop memory-backed explicit answers too.
 
 Proactive replies are conservative:
 

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -103,7 +103,7 @@ flowchart LR
 | `/quizstats` | Барлығына | Жеке quiz score, streak, rank. |
 | `/ask <question>` | Memory қосылған топтарда | Agent-ке сұрақ қою; басқа хабарламаға reply ретінде де қолдануға болады және “мен кіммін” сияқты сұрақтарды requester identity арқылы түсінеді. |
 | `/memory on/off/status/forget ...` | Group owner немесе bot owner | Group memory басқару және user-related vectors/matching daily summaries cleanup. |
-| `/agent on/off/status/why` | Group owner немесе bot owner | Agent participation басқару және bot неге жауап бергенін көру. |
+| `/agent on/off/status/why` | Group owner немесе bot owner | Agent participation басқару және bot неге жауап бергенін көру. `/agent off` proactive, mention және reply-thread қатысуын өшіреді; жад қосулы болса, `/ask` қолжетімді. |
 
 ---
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -103,7 +103,7 @@ flowchart LR
 | `/quizstats` | Все | Личный quiz score, streak и rank. |
 | `/ask <question>` | В memory-enabled группах | Задать вопрос agent-у; можно использовать reply на сообщение, включая self-reference вроде “кто я”. |
 | `/memory on/off/status/forget ...` | Group owner или bot owner | Управление group memory и cleanup, включая user-related vectors и matching daily summaries. |
-| `/agent on/off/status/why` | Group owner или bot owner | Управление участием agent-а и объяснение, почему бот ответил. |
+| `/agent on/off/status/why` | Group owner или bot owner | Управление участием agent-а и объяснение, почему бот ответил. `/agent off` выключает proactive, mention и reply-thread участие; `/ask` остается доступен, если память включена. |
 
 ---
 

--- a/src/bot/core/translations.py
+++ b/src/bot/core/translations.py
@@ -121,7 +121,7 @@ TRANSLATIONS = {
         "agent_usage": (
             "🤖 <b>Agent mode</b>\n\n"
             "• <code>/agent on</code> — let me answer and occasionally join in\n"
-            "• <code>/agent off</code> — stop agent participation\n"
+            "• <code>/agent off</code> — stop proactive, mention, and reply-thread participation\n"
             "• <code>/agent status</code> — show agent and memory status\n"
             "• <code>/agent why</code> — explain why I replied"
         ),
@@ -137,7 +137,11 @@ TRANSLATIONS = {
             "🧠 Group memory is now off. Existing stored memory is kept until TTL or /memory forget group."
         ),
         "agent_enabled": "🤖 Group agent is now on. I can answer when asked and join in when it is useful.",
-        "agent_disabled": "🤖 Group agent is now off. Memory can remain on for /ask and future context.",
+        "agent_disabled": (
+            "🤖 Agent participation is disabled.\n"
+            "I will not proactively join conversations or respond to mentions/replies.\n"
+            "Explicit /ask remains available while memory is enabled."
+        ),
         "memory_status_message": (
             "🧠 <b>Group memory:</b> {memory}\n"
             "🤖 <b>Group agent:</b> {agent}\n"
@@ -335,7 +339,7 @@ TRANSLATIONS = {
         "agent_usage": (
             "🤖 <b>Agent режимі</b>\n\n"
             "• <code>/agent on</code> — жауап беруге және қажет жерде чатқа қосылуға рұқсат беру\n"
-            "• <code>/agent off</code> — agent қатысуын өшіру\n"
+            "• <code>/agent off</code> — proactive, mention және reply-thread қатысуын өшіру\n"
             "• <code>/agent status</code> — agent пен жад күйін көрсету\n"
             "• <code>/agent why</code> — неге жауап бергенімді түсіндіру"
         ),
@@ -349,7 +353,11 @@ TRANSLATIONS = {
         "memory_enabled": "🧠 Топ жады қосылды. Контекст үшін соңғы command емес хабарламаларды есте сақтаймын.",
         "memory_disabled": "🧠 Топ жады өшірілді. Бар жад TTL біткенше немесе /memory forget group дейін сақталады.",
         "agent_enabled": "🤖 Agent режимі қосылды. Сұрағанда жауап беремін, пайдалы кезде чатқа қосыла аламын.",
-        "agent_disabled": "🤖 Agent режимі өшірілді. Жад /ask және болашақ контекст үшін қала алады.",
+        "agent_disabled": (
+            "🤖 Agent қатысуы өшірілді.\n"
+            "Мен proactive түрде чатқа қосылмаймын және mention/reply хабарламаларына жауап бермеймін.\n"
+            "Жад қосулы болса, explicit /ask қолжетімді болып қалады."
+        ),
         "memory_status_message": (
             "🧠 <b>Топ жады:</b> {memory}\n"
             "🤖 <b>Agent режимі:</b> {agent}\n"
@@ -541,7 +549,7 @@ TRANSLATIONS = {
         "agent_usage": (
             "🤖 <b>Agent 模式</b>\n\n"
             "• <code>/agent on</code> — 允许我回答并在合适时加入聊天\n"
-            "• <code>/agent off</code> — 关闭 agent 参与\n"
+            "• <code>/agent off</code> — 关闭主动、mention 和 reply-thread 参与\n"
             "• <code>/agent status</code> — 查看 agent 和记忆状态\n"
             "• <code>/agent why</code> — 解释我为什么回复"
         ),
@@ -555,7 +563,11 @@ TRANSLATIONS = {
         "memory_enabled": "🧠 群记忆已开启。我会记住近期非命令消息，用于上下文。",
         "memory_disabled": "🧠 群记忆已关闭。已有记忆会保留到 TTL 到期，或直到执行 /memory forget group。",
         "agent_enabled": "🤖 Agent 模式已开启。有人问我时我会回答，也会在有帮助的时候加入聊天。",
-        "agent_disabled": "🤖 Agent 模式已关闭。记忆仍可用于 /ask 和未来上下文。",
+        "agent_disabled": (
+            "🤖 Agent 参与已关闭。\n"
+            "我不会主动加入对话，也不会响应 mention/reply。\n"
+            "只要群记忆开启，显式 /ask 仍然可用。"
+        ),
         "memory_status_message": (
             "🧠 <b>群记忆：</b>{memory}\n"
             "🤖 <b>群 agent：</b>{agent}\n"
@@ -744,7 +756,7 @@ TRANSLATIONS = {
         "agent_usage": (
             "🤖 <b>Agent-режим</b>\n\n"
             "• <code>/agent on</code> — разрешить мне отвечать и иногда подключаться к чату\n"
-            "• <code>/agent off</code> — выключить участие agent-а\n"
+            "• <code>/agent off</code> — выключить proactive, mention и reply-thread участие\n"
             "• <code>/agent status</code> — показать статус agent-а и памяти\n"
             "• <code>/agent why</code> — объяснить, почему я ответил"
         ),
@@ -760,7 +772,11 @@ TRANSLATIONS = {
             "🧠 Память группы выключена. Уже сохраненная память останется до TTL или /memory forget group."
         ),
         "agent_enabled": "🤖 Agent-режим включен. Я могу отвечать по запросу и подключаться, когда это полезно.",
-        "agent_disabled": "🤖 Agent-режим выключен. Память может оставаться для /ask и будущего контекста.",
+        "agent_disabled": (
+            "🤖 Участие agent-а выключено.\n"
+            "Я не буду proactive вступать в разговоры или отвечать на mentions/replies.\n"
+            "Явный /ask остается доступен, пока включена память."
+        ),
         "memory_status_message": (
             "🧠 <b>Память группы:</b> {memory}\n"
             "🤖 <b>Agent-режим:</b> {agent}\n"

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -666,7 +666,11 @@ def handle_update(
     bot: TelegramClient,
     update: dict[str, Any],
 ) -> bool:
-    """Answer an explicit group chat prompt with recent group context.
+    """Answer non-/ask group prompts when agent participation is enabled.
+
+    ``agent_enabled`` gates proactive, @mention, and reply-to-bot
+    participation. Explicit ``/ask`` requests are handled by the command path
+    and remain available while group memory is enabled.
 
     Returns True when the agent handled the update and the dispatcher should not
     continue routing it as a plain message.

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -725,6 +725,27 @@ def test_agent_should_answer_mention_when_enabled(monkeypatch):
     assert group_agent.should_answer(_group_update("hey @ZerdeBot what did we decide?")) is True
 
 
+def test_agent_off_does_not_answer_mentions(monkeypatch):
+    repo = MagicMock()
+    repo.is_agent_enabled.return_value = False
+    bot = MagicMock()
+    answer = MagicMock(return_value=True)
+    monkeypatch.setattr(group_agent, "AGENT_ENABLED", True)
+    monkeypatch.setattr(group_agent, "AGENT_BOT_USERNAME", "zerdebot")
+    monkeypatch.setattr(group_agent, "answer_group_question", answer)
+
+    handled = group_agent.handle_update(
+        repo=repo,
+        bot=bot,
+        update=_group_update("hey @ZerdeBot what did we decide?"),
+    )
+
+    assert handled is False
+    repo.is_agent_enabled.assert_called_once_with(-100123)
+    answer.assert_not_called()
+    bot.send_message.assert_not_called()
+
+
 def test_agent_reply_to_bot_includes_replied_bot_message_context(monkeypatch):
     repo = MagicMock()
     repo.is_agent_enabled.return_value = True
@@ -1562,6 +1583,47 @@ def test_handle_ask_enqueues_group_context_answer():
     )
     ctx.react.assert_called_once_with("👀")
     ctx.reply.assert_not_called()
+
+
+def test_handle_ask_still_enqueues_when_agent_off():
+    ctx = MagicMock()
+    ctx.text = "/ask what happened yesterday?"
+    ctx.update_id = 12345
+    ctx.chat_id = -100123
+    ctx.message_id = 99
+    ctx.lang_code = "en"
+    ctx.reply_to_message = None
+    ctx.user_id = 42
+    ctx.username = "ada"
+    ctx.user_data = {"id": 42, "first_name": "Ada", "username": "ada"}
+    ctx.memory_repo.is_memory_enabled.return_value = True
+    ctx.memory_repo.is_agent_enabled.return_value = False
+
+    handle_ask(ctx)
+
+    ctx.sqs_repo.send_group_ask_task.assert_called_once()
+    assert ctx.sqs_repo.send_group_ask_task.call_args.kwargs["user_text"] == "what happened yesterday?"
+    ctx.memory_repo.is_memory_enabled.assert_called_once_with(-100123)
+    ctx.memory_repo.is_agent_enabled.assert_not_called()
+    ctx.reply.assert_not_called()
+
+
+def test_handle_ask_rejects_when_memory_off():
+    ctx = MagicMock()
+    ctx.text = "/ask what happened yesterday?"
+    ctx.update_id = 12345
+    ctx.chat_id = -100123
+    ctx.message_id = 99
+    ctx.lang_code = "en"
+    ctx.reply_to_message = None
+    ctx.memory_repo.is_memory_enabled.return_value = False
+
+    handle_ask(ctx)
+
+    ctx.memory_repo.is_memory_enabled.assert_called_once_with(-100123)
+    ctx.sqs_repo.send_group_ask_task.assert_not_called()
+    ctx.react.assert_not_called()
+    assert "Group memory is off" in ctx.reply.call_args.args[0]
 
 
 def test_handle_ask_usage_message_has_no_html_tag():


### PR DESCRIPTION
## Summary
- Clarify that `/agent off` disables proactive, mention, and reply-to-bot participation only.
- Keep explicit `/ask` available while group memory is enabled and document `/memory off` as the way to stop memory-backed explicit answers.
- Add focused regression coverage for agent-off mentions, agent-off `/ask`, and memory-off `/ask`.

## Validation
- `uv run pytest tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`