### PR TITLE
FIX: skip imported daily summary vectors by default

### DIFF
--- a/dev/tools/import_telegram_history.py
+++ b/dev/tools/import_telegram_history.py
@@ -65,6 +65,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--no-long-term", action="store_true", help="Do not extract EVENT/USER_FACT/GROUP_FACT/JOKE.")
     parser.add_argument("--no-daily-summaries", action="store_true", help="Do not create DAILY_SUMMARY items.")
     parser.add_argument("--no-vector-enqueue", action="store_true", help="Do not enqueue vector indexing tasks.")
+    parser.add_argument(
+        "--vectorize-daily-summaries",
+        action="store_true",
+        help="Also enqueue imported DAILY_SUMMARY items for vector indexing after inspecting summary quality.",
+    )
     return parser.parse_args()
 
 
@@ -102,6 +107,7 @@ def main() -> int:
         extract_long_term=not args.no_long_term,
         create_daily_summaries=not args.no_daily_summaries,
         enqueue_vectors=not args.no_vector_enqueue,
+        vectorize_daily_summaries=args.vectorize_daily_summaries,
         max_messages=args.max_messages,
     )
 

--- a/docs/telegram_history_import.md
+++ b/docs/telegram_history_import.md
@@ -50,9 +50,11 @@ Repeat once per group/export file.
 - `MSG#...` raw text records for non-sensitive messages, with `USER#...` profile updates derived from the speaker's own text.
 - `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, and `JOKE#...` long-term memory items.
 - `DAILY_SUMMARY#YYYY-MM-DD` summaries for each imported day.
-- `PROCESS_VECTOR_MEMORY` tasks for each long-term memory and daily summary.
+- `PROCESS_VECTOR_MEMORY` tasks for each long-term memory item.
 
-The importer skips commands, empty/system messages, and secret/sensitive-looking content. It does not embed every raw message directly; only long-term memory items and daily summaries go to S3 Vectors.
+The importer skips commands, empty/system messages, and secret/sensitive-looking content. It does not embed every raw message directly; only long-term memory items go to S3 Vectors by default.
+
+By default, imported `DAILY_SUMMARY#...` items are stored in DynamoDB but not vectorized, because generic import summaries are low-information retrieval candidates. Use `--vectorize-daily-summaries` only after inspecting summary quality.
 
 Imported long-term memory is later used by `/ask` and proactive agent replies through a mix of query-filtered DynamoDB reads and semantic vector retrieval. Keep joke-like or sarcastic memories narrow; a one-off roast should not become a permanent user fact.
 
@@ -61,18 +63,19 @@ Imported long-term memory is later used by `/ask` and proactive agent replies th
 - `--max-messages 1000` for a small smoke test.
 - `--until YYYY-MM-DD` to limit the date range.
 - `--no-vector-enqueue` to import DynamoDB memory without queueing embeddings.
+- `--vectorize-daily-summaries` to also enqueue imported `DAILY_SUMMARY#...` items for embeddings after inspection.
 - `--no-raw-messages` to skip raw `MSG#...` records and user profile updates.
 - `--no-long-term` to skip event/fact/joke extraction.
 - `--no-daily-summaries` to skip daily summaries.
 
-If you import with `--no-vector-enqueue`, run a vector backfill later before expecting semantic retrieval to find that history.
+If you import with `--no-vector-enqueue`, run a vector backfill later before expecting semantic retrieval to find long-term history. Imported daily summaries should stay out of semantic retrieval unless you have inspected them and decided they are useful.
 
 ## Cleanup And Pollution Control
 
 Before importing a large group, do a small `--max-messages` dry run and inspect whether user facts, group facts, and jokes look trustworthy. If polluted records are written, clean both sides of memory:
 
 - Delete the narrow DynamoDB keys for bad `USER#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, or `DAILY_SUMMARY#...` items.
-- Delete matching vector keys for vectorized long-term memory and daily summaries.
+- Delete matching vector keys for vectorized long-term memory and any explicitly vectorized daily summaries.
 - Back up the exact items and vector keys before production cleanup.
 
 Do not rely on vector backfill to fix bad source data. If DynamoDB memory is polluted, the agent can still retrieve it through non-vector long-term context.

--- a/src/bot/services/history_import.py
+++ b/src/bot/services/history_import.py
@@ -110,6 +110,7 @@ class HistoryImportOptions:
     extract_long_term: bool = True
     create_daily_summaries: bool = True
     enqueue_vectors: bool = True
+    vectorize_daily_summaries: bool = False
     max_messages: int | None = None
 
 
@@ -381,7 +382,8 @@ def import_telegram_history(
                 message_count=len(by_day[summary_date]),
                 source=daily["source"],
             )
-            _enqueue_vector(options, vector_enqueue, item["sk"], stats)
+            if options.vectorize_daily_summaries:
+                _enqueue_vector(options, vector_enqueue, item["sk"], stats)
 
     first_day = min(by_day) if by_day else None
     last_day = max(by_day) if by_day else None

--- a/tests/test_history_import.py
+++ b/tests/test_history_import.py
@@ -13,6 +13,8 @@ from services.history_import import (
 )
 from services.repositories.group_memory import GroupMemoryRepository
 
+from dev.tools import import_telegram_history as import_tool
+
 
 def _ts(day: str, hour: int = 12) -> int:
     year, month, date_day = (int(part) for part in day.split("-"))
@@ -111,6 +113,25 @@ def test_build_history_daily_summary_uses_all_messages_and_classifications():
     assert summary["notable_events"] == ["We decided to use S3 Vectors"]
 
 
+def test_import_cli_parses_vectorize_daily_summaries_flag(monkeypatch):
+    monkeypatch.setattr(
+        import_tool.sys,
+        "argv",
+        [
+            "import_telegram_history.py",
+            "--chat-id",
+            "-100123",
+            "--export",
+            "result.json",
+            "--vectorize-daily-summaries",
+        ],
+    )
+
+    args = import_tool._parse_args()
+
+    assert args.vectorize_daily_summaries is True
+
+
 def test_import_telegram_history_dry_run_does_not_write(tmp_path):
     export_path = tmp_path / "result.json"
     export_path.write_text(
@@ -182,7 +203,47 @@ def test_import_telegram_history_writes_memory_and_enqueues_vectors(tmp_path):
     assert repo.store_message.call_args_list[0].kwargs["skip_if_exists"] is True
     assert repo.store_long_term_memory.call_count == 2
     assert repo.store_daily_summary.call_args.kwargs["source"] == "telegram_export_import"
-    assert vector_enqueue.call_count == 3
+    assert [call.kwargs["source_sk"] for call in vector_enqueue.call_args_list] == [
+        "GROUP_FACT#1#1",
+        "USER_FACT#43#2#2",
+    ]
+    assert result.stats.vector_tasks == 2
+
+
+def test_import_telegram_history_vectorizes_daily_summary_when_enabled(tmp_path):
+    export_path = tmp_path / "result.json"
+    export_path.write_text(
+        (
+            '{"messages":['
+            '{"id":1,"type":"message","date_unixtime":"1767272400","from":"Ada","from_id":"user42",'
+            '"text":"We decided to use S3 Vectors tomorrow"}'
+            "]}"
+        ),
+        encoding="utf-8",
+    )
+    repo = MagicMock()
+    repo.store_message.return_value = True
+    repo.store_long_term_memory.return_value = {"sk": "GROUP_FACT#1#1"}
+    repo.store_daily_summary.return_value = {"sk": "DAILY_SUMMARY#2026-01-01"}
+    vector_enqueue = MagicMock()
+
+    result = import_telegram_history(
+        HistoryImportOptions(
+            chat_id=-100123,
+            export_path=export_path,
+            since=date(2026, 1, 1),
+            dry_run=False,
+            vectorize_daily_summaries=True,
+        ),
+        repo=repo,
+        vector_enqueue=vector_enqueue,
+    )
+
+    assert [call.kwargs["source_sk"] for call in vector_enqueue.call_args_list] == [
+        "GROUP_FACT#1#1",
+        "DAILY_SUMMARY#2026-01-01",
+    ]
+    assert result.stats.vector_tasks == 2
 
 
 def test_store_message_skip_if_exists_does_not_touch_profile():

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -220,6 +220,37 @@ def test_index_memory_item_puts_gemini_embedding_to_vector_store(monkeypatch):
     assert repo.mark_vector_status.call_args.kwargs["status"] == "indexed"
 
 
+def test_index_memory_item_still_supports_explicit_daily_summary_vectorization(monkeypatch):
+    monkeypatch.setattr(vector_memory, "vector_memory_configured", lambda: True)
+    repo = MagicMock()
+    repo.get_memory_item.return_value = {
+        "sk": "DAILY_SUMMARY#2026-01-01",
+        "kind": "daily_summary",
+        "summary_date": "2026-01-01",
+        "summary": "The group decided to use S3 Vectors for memory retrieval.",
+        "topics": ["s3", "vectors"],
+        "notable_events": ["S3 Vectors was selected"],
+    }
+    embedding = MagicMock()
+    embedding.embed.return_value = [0.1] * 768
+    vector_repo = MagicMock()
+
+    indexed = vector_memory.index_memory_item(
+        -100123,
+        "DAILY_SUMMARY#2026-01-01",
+        repo=repo,
+        vector_repo=vector_repo,
+        embedding_client=embedding,
+    )
+
+    assert indexed is True
+    embedding.embed.assert_called_once()
+    assert "Daily group memory summary for 2026-01-01" in embedding.embed.call_args.args[0]
+    put_kwargs = vector_repo.put_memory_vector.call_args.kwargs
+    assert put_kwargs["metadata"]["source_sk"] == "DAILY_SUMMARY#2026-01-01"
+    assert put_kwargs["metadata"]["memory_kind"] == "daily_summary"
+
+
 def test_retrieve_relevant_memories_uses_query_embedding(monkeypatch):
     monkeypatch.setattr(vector_memory, "vector_memory_configured", lambda: True)
     embedding = MagicMock()


### PR DESCRIPTION
## Summary
- Default Telegram history imports now store `DAILY_SUMMARY#...` items in DynamoDB without enqueueing vector indexing tasks for them.
- Add `--vectorize-daily-summaries` for explicit opt-in after summary quality inspection.
- Keep long-term memory item vector enqueue behavior unchanged and preserve explicit daily-summary vector indexing support when a task is queued.
- Update `docs/telegram_history_import.md` with the reason for the default and the new option.

## Validation
- `uv run pytest tests/test_history_import.py tests/test_vector_memory.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`