### PR TITLE
FEATURE: split vector indexer lambda

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -49,9 +49,9 @@ RAG is one capability inside the agent. Do not treat vector search as the only s
 ```mermaid
 flowchart LR
   Telegram[Telegram_groups] --> APIGW[HTTP_API_Gateway]
-  APIGW --> BotLambda[Bot_Lambda_webhook_and_SQS_worker]
+  APIGW --> BotLambda[Bot_Lambda_webhook_and_main_SQS_worker]
   MainQ[SQS_timeout_tasks_queue] --> BotLambda
-  VectorQ[SQS_vector_memory_queue] --> BotLambda
+  VectorQ[SQS_vector_memory_queue] --> VectorIndexer[Vector_Indexer_Lambda]
   BotLambda --> MainQ
   BotLambda --> VectorQ
   BotLambda --> Stats[(DynamoDB_stats)]
@@ -59,16 +59,23 @@ flowchart LR
   BotLambda --> S3Vectors[S3_Vectors_memory_index]
   BotLambda --> Gemini[Gemini]
   BotLambda --> Groq[Groq]
+  VectorIndexer --> VectorQ
+  VectorIndexer --> Stats
+  VectorIndexer --> Memory
+  VectorIndexer --> S3Vectors
+  VectorIndexer --> Gemini
   EventBridge[EventBridge_schedules] --> NewsLambda[News_Lambda]
   EventBridge --> QuizLambda[Quiz_Lambda]
   Layer[zerde_common_layer] -.-> BotLambda
+  Layer -.-> VectorIndexer
   Layer -.-> NewsLambda
   Layer -.-> QuizLambda
 ```
 
 | Lambda | Package | Entry | Purpose |
 |--------|---------|-------|---------|
-| Bot | `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and SQS worker. Handles captcha, voteban, spam, `/ask`, agent replies, group memory, vector indexing, and cleanup commands. |
+| Bot | `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles captcha, voteban, spam, `/ask`, agent replies, group memory, semantic retrieval, and cleanup commands. |
+| Vector indexer | `src/bot/` | `vector_indexer_main.py:lambda_handler` | Dedicated vector memory queue consumer for `PROCESS_VECTOR_MEMORY` and `PROCESS_VECTOR_MEMORY_BACKFILL`. |
 | News | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest. |
 | Quiz | `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand quiz workflow. |
 
@@ -76,10 +83,11 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 
 ## Bot Package Map
 
-- `main.py` — detects SQS vs API Gateway and delegates.
+- `main.py` — detects API Gateway vs main SQS tasks and delegates.
+- `vector_indexer_main.py` — consumes only vector memory SQS tasks.
 - `app.py` — lazy wiring for Telegram client, dispatcher, captcha repo, and memory repo.
 - `webhook.py` — verifies Telegram secret, screens spam, observes memory, filters irrelevant events, routes agent/commands.
-- `services/sqs_task_router.py` — routes SQS tasks and re-raises failures for retry/DLQ semantics.
+- `services/sqs_task_router.py` — routes main and vector SQS task families and re-raises failures for retry/DLQ semantics.
 - `services/group_memory.py` — stores recent group context, formats prompt context, requester/target-user profile context, and query-filtered long-term memory.
 - `services/group_memory_processor.py` — async long-term extraction and daily summaries.
 - `services/group_agent.py` — agent trigger policy, proactive gating, reply-thread continuity, answer-length policy.
@@ -110,8 +118,8 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - `PROCESS_GROUP_ASK` — async explicit `/ask` answer.
 - `PROCESS_GROUP_MEMORY` — classify/store long-term memory from one message.
 - `PROCESS_DAILY_GROUP_SUMMARIES` — daily summaries for configured groups.
-- `PROCESS_VECTOR_MEMORY` — embed/index one memory item.
-- `PROCESS_VECTOR_MEMORY_BACKFILL` — page through vectorizable memory and enqueue indexing.
+- `PROCESS_VECTOR_MEMORY` — embed/index one memory item; consumed by the vector-indexer Lambda.
+- `PROCESS_VECTOR_MEMORY_BACKFILL` — page through vectorizable memory and enqueue indexing; consumed by the vector-indexer Lambda.
 
 ## Secrets And Config
 
@@ -123,8 +131,8 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 ## Key Design Decisions
 
 - **No SnapStart**: low-frequency workloads and Python package trade-offs make SnapStart unnecessary here.
-- **One bot Lambda for webhook and SQS**: `/ask`, spam, captcha, memory, and vector tasks share warm containers and common wiring.
-- **Separate vector queue**: slower embedding/backfill work does not block real-time timeout/spam/ask tasks.
+- **Bot Lambda for webhook and main SQS only**: `/ask`, spam, captcha, and memory extraction share the bot warm path.
+- **Separate vector indexer Lambda and vector queue**: slower embedding/backfill/S3 Vectors work has independent concurrency, logs, alarms, and DLQ visibility so it does not block webhook or interactive `/ask` work.
 - **Trust hierarchy for agent answers**: current user message and reply-thread context > requester profile for self-reference > target user's own profile > query-matched vector memory > query-filtered long-term memory > recent group chatter.
 - **Prompt pollution control**: do not inject unfiltered recent long-term memories into answers; filter by query or use vector retrieval.
 - **Vector retrieval discipline**: use chat metadata filters, requester filters for self-reference when available, and distance cutoffs before adding semantic memories to prompts.

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -32,10 +32,11 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 
 ## Repository Map
 
-- `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector indexing.
+- `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector indexing entrypoints.
 - `src/bot/services/group_agent.py`: agent trigger policy, proactive gating, reply-thread continuity, response length policy.
 - `src/bot/services/group_memory.py`: recent context observation and prompt formatting, requester/target-user profiles, query-filtered long-term context.
 - `src/bot/services/group_memory_processor.py`: async long-term memory extraction and daily summaries.
+- `src/bot/vector_indexer_main.py`: dedicated vector memory SQS Lambda entrypoint.
 - `src/bot/services/vector_memory.py`: Gemini embeddings, S3 Vectors indexing/retrieval with metadata filters and distance cutoffs, vector cleanup/backfill.
 - `src/bot/services/repositories/group_memory.py`: DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, and proactive counters.
 - `src/news/`: scheduled news digest Lambda.
@@ -66,13 +67,16 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 
 ## SQS And Persistence
 
-SQS handler failures should re-raise when retry/DLQ semantics are intended. Current bot SQS task types:
+SQS handler failures should re-raise when retry/DLQ semantics are intended. Current main bot SQS task types:
 
 - `CHECK_TIMEOUT`
 - `SPAM_CHECK`
 - `PROCESS_GROUP_ASK`
 - `PROCESS_GROUP_MEMORY`
 - `PROCESS_DAILY_GROUP_SUMMARIES`
+
+Current vector-indexer SQS task types:
+
 - `PROCESS_VECTOR_MEMORY`
 - `PROCESS_VECTOR_MEMORY_BACKFILL`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ flowchart LR
   TG["Telegram"] --> APIGW["HTTP API Gateway"]
   APIGW --> BOT["Bot Lambda<br/>src/bot/main.py"]
   MAINQ["SQS timeout/tasks queue"] --> BOT
-  VQ["SQS vector memory queue"] --> BOT
+  VQ["SQS vector memory queue"] --> VIDX["Vector indexer Lambda<br/>src/bot/vector_indexer_main.py"]
 
   BOT --> STATS[("DynamoDB stats table")]
   BOT --> MEMORY[("DynamoDB memory table")]
@@ -31,6 +31,11 @@ flowchart LR
   BOT --> S3V["S3 Vectors index"]
   BOT --> GEMINI["Gemini API"]
   BOT --> GROQ["Groq API"]
+  VIDX --> VQ
+  VIDX --> STATS
+  VIDX --> MEMORY
+  VIDX --> S3V
+  VIDX --> GEMINI
 
   EB["EventBridge"] --> NEWS["News Lambda"]
   EB --> QUIZ["Quiz Lambda"]
@@ -40,6 +45,7 @@ flowchart LR
   QUIZ --> TG
 
   LAYER["zerde_common Lambda layer"] -.-> BOT
+  LAYER -.-> VIDX
   LAYER -.-> NEWS
   LAYER -.-> QUIZ
 ```
@@ -48,7 +54,8 @@ flowchart LR
 
 | Package | Entry | Main responsibilities |
 |---------|-------|-----------------------|
-| `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and SQS worker in one Lambda. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, vector indexing, and cleanup commands. |
+| `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, semantic retrieval, and cleanup commands. |
+| `src/bot/` | `vector_indexer_main.py:lambda_handler` | Dedicated vector memory SQS worker for embedding/indexing and vector backfill paging. |
 | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest and Telegram delivery. |
 | `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand multilingual developer quizzes. |
 | `src/shared/python/zerde_common/` | Lambda layer | Shared env helpers, SSM batch secret loading, provider errors, JSON logging, redaction, Telegram update log truncation. |
@@ -66,17 +73,17 @@ flowchart LR
 
 ## SQS Tasks
 
-The bot Lambda consumes both real-time and slower background tasks:
+The bot Lambda consumes real-time and group-memory tasks. The vector-indexer Lambda consumes slower embedding/backfill work from the vector queue:
 
 | Task type | Queue | Handler |
 |-----------|-------|---------|
-| `CHECK_TIMEOUT` | timeout/tasks queue | Captcha timeout enforcement. |
-| `SPAM_CHECK` | timeout/tasks queue | Groq-based async spam classification. |
-| `PROCESS_GROUP_ASK` | timeout/tasks queue | Async explicit agent answer with optional requester metadata. |
-| `PROCESS_GROUP_MEMORY` | timeout/tasks queue | Extract one long-term memory item from a stored group message. |
-| `PROCESS_DAILY_GROUP_SUMMARIES` | timeout/tasks queue | Build daily summaries for configured groups. |
-| `PROCESS_VECTOR_MEMORY` | vector memory queue | Embed and index one memory item in S3 Vectors. |
-| `PROCESS_VECTOR_MEMORY_BACKFILL` | vector memory queue | Page through historical vectorizable memory items and enqueue indexing. |
+| `CHECK_TIMEOUT` | timeout/tasks queue | Bot Lambda captcha timeout enforcement. |
+| `SPAM_CHECK` | timeout/tasks queue | Bot Lambda Groq-based async spam classification. |
+| `PROCESS_GROUP_ASK` | timeout/tasks queue | Bot Lambda async explicit agent answer with optional requester metadata. |
+| `PROCESS_GROUP_MEMORY` | timeout/tasks queue | Bot Lambda extraction of one long-term memory item from a stored group message. |
+| `PROCESS_DAILY_GROUP_SUMMARIES` | timeout/tasks queue | Bot Lambda daily summaries for configured groups. |
+| `PROCESS_VECTOR_MEMORY` | vector memory queue | Vector-indexer Lambda embeds and indexes one memory item in S3 Vectors. |
+| `PROCESS_VECTOR_MEMORY_BACKFILL` | vector memory queue | Vector-indexer Lambda pages through historical vectorizable memory items and enqueues indexing. |
 
 Failures re-raise in `services/sqs_task_router.py` so SQS retry and DLQ semantics apply.
 
@@ -151,6 +158,7 @@ S3 Vectors is used for semantic retrieval over trusted long-term memory:
 - Cleanup commands should delete both DynamoDB memory and associated vector keys when available. `/memory forget me` also removes daily summaries that mention the forgotten user's stored display name or username.
 - Runtime IAM must include `s3vectors:GetVectors` together with `s3vectors:QueryVectors` because retrieval uses metadata filters and asks S3 Vectors to return metadata.
 - Retrieval, S3 query, context injection, and indexing success paths emit INFO logs with safe operational fields such as counts, filters, distance cutoffs, and vector dimensions.
+- Vector indexing runs in the dedicated vector-indexer Lambda, with its own log group and Lambda alarms. The bot Lambda can still query/delete vectors for retrieval and memory cleanup, but it no longer consumes the vector memory queue.
 
 When vector indexing is incomplete, the agent still works with recent context and query-filtered DynamoDB long-term memory. Do not assume vector backfill will fix prompt pollution by itself. Vector retrieval uses metadata filters where available, including requester user filters for self-reference questions.
 

--- a/infra/components/__init__.py
+++ b/infra/components/__init__.py
@@ -2,10 +2,12 @@ from .bot import BotConstruct
 from .messaging import MessagingConstruct
 from .news import NewsConstruct
 from .quiz import QuizConstruct
+from .vector_indexer import VectorIndexerConstruct
 
 __all__ = [
     "MessagingConstruct",
     "NewsConstruct",
     "BotConstruct",
     "QuizConstruct",
+    "VectorIndexerConstruct",
 ]

--- a/infra/components/bot.py
+++ b/infra/components/bot.py
@@ -227,6 +227,11 @@ class BotConstruct(Construct):
         )
 
         self.handler_lambda = webhook_lambda
+        self.stats_table = stats_table
+        self.memory_table = memory_table
+        self.vector_bucket = vector_bucket
+        self.vector_index = vector_index
+        self.bot_environment = bot_environment
 
         # Grant least-privilege SSM read access for secrets under the env prefix.
         stack = Stack.of(self)
@@ -271,7 +276,6 @@ class BotConstruct(Construct):
         queue.grant_send_messages(webhook_lambda)
         queue.grant_consume_messages(webhook_lambda)
         vector_queue.grant_send_messages(webhook_lambda)
-        vector_queue.grant_consume_messages(webhook_lambda)
         stats_table.grant_read_write_data(webhook_lambda)
         memory_table.grant_read_write_data(webhook_lambda)
         if vector_bucket is not None and vector_index is not None:
@@ -299,15 +303,6 @@ class BotConstruct(Construct):
                 batch_size=1,
                 max_batching_window=Duration.seconds(0),
                 max_concurrency=10,
-            )
-        )
-
-        webhook_lambda.add_event_source(
-            lambda_event_sources.SqsEventSource(
-                vector_queue,
-                batch_size=1,
-                max_batching_window=Duration.seconds(0),
-                max_concurrency=3,
             )
         )
 

--- a/infra/components/vector_indexer.py
+++ b/infra/components/vector_indexer.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any
+
+from aws_cdk import Duration, RemovalPolicy, Stack
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as _lambda
+from aws_cdk import aws_lambda_event_sources as lambda_event_sources
+from aws_cdk import aws_logs as logs
+from aws_cdk import aws_s3vectors as s3vectors
+from aws_cdk import aws_sqs as sqs
+from aws_cdk.aws_lambda_python_alpha import PythonFunction
+from components.constants import CONSTRUCT_PREFIX, LAMBDA_RUNTIME, PROJECT_ROOT, RESOURCE_PREFIX
+from constructs import Construct
+
+
+class VectorIndexerConstruct(Construct):
+    """Dedicated Lambda for vector memory indexing and backfill SQS tasks."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        shared_layer: _lambda.ILayer,
+        env_name: str,
+        is_prod: bool,
+        ssm_secret_prefix: str,
+        vector_queue: sqs.Queue,
+        memory_table: dynamodb.Table,
+        stats_table: dynamodb.Table,
+        vector_bucket: s3vectors.CfnVectorBucket | None,
+        vector_index: s3vectors.CfnIndex | None,
+        environment: dict[str, Any],
+    ) -> None:
+        super().__init__(scope, construct_id)
+
+        removal_policy = RemovalPolicy.RETAIN if is_prod else RemovalPolicy.DESTROY
+        vector_indexer_lambda = PythonFunction(
+            self,
+            f"{CONSTRUCT_PREFIX}VectorIndexerLambda",
+            function_name=f"{RESOURCE_PREFIX}-vector-indexer-{env_name}",
+            entry=str(PROJECT_ROOT / "src" / "bot"),
+            index="vector_indexer_main.py",
+            handler="lambda_handler",
+            runtime=LAMBDA_RUNTIME,
+            architecture=_lambda.Architecture.ARM_64,
+            layers=[shared_layer],
+            timeout=Duration.seconds(300),
+            memory_size=1024,
+            log_group=logs.LogGroup(
+                self,
+                f"{CONSTRUCT_PREFIX}VectorIndexerLogGroup",
+                log_group_name=f"/aws/lambda/{RESOURCE_PREFIX}-vector-indexer-{env_name}",
+                retention=logs.RetentionDays.ONE_WEEK,
+                removal_policy=removal_policy,
+            ),
+            environment=environment,
+        )
+
+        self.handler_lambda = vector_indexer_lambda
+
+        stack = Stack.of(self)
+        vector_indexer_ssm_secret_names = [
+            "gemini-api-key",
+            "gemini-embedding-api-key",
+        ]
+        vector_indexer_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                sid="ReadZerdeVectorIndexerSSMSecrets",
+                actions=["ssm:GetParameters"],
+                resources=[
+                    f"arn:aws:ssm:{stack.region}:{stack.account}:parameter{ssm_secret_prefix}/{name}"
+                    for name in vector_indexer_ssm_secret_names
+                ],
+            )
+        )
+        vector_indexer_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                sid="DecryptZerdeVectorIndexerSSMSecrets",
+                actions=["kms:Decrypt"],
+                resources=["*"],
+                conditions={
+                    "StringEquals": {
+                        "kms:ViaService": f"ssm.{stack.region}.amazonaws.com",
+                        "kms:CallerAccount": stack.account,
+                    }
+                },
+            )
+        )
+
+        vector_queue.grant_consume_messages(vector_indexer_lambda)
+        vector_queue.grant_send_messages(vector_indexer_lambda)
+        memory_table.grant_read_write_data(vector_indexer_lambda)
+        # Embedding quota counters live in the stats table; keep this narrower than bot access.
+        stats_table.grant(vector_indexer_lambda, "dynamodb:GetItem", "dynamodb:UpdateItem")
+        if vector_bucket is not None and vector_index is not None:
+            vector_indexer_lambda.add_to_role_policy(
+                iam.PolicyStatement(
+                    sid="UseZerdeMemoryVectors",
+                    actions=[
+                        "s3vectors:PutVectors",
+                        "s3vectors:QueryVectors",
+                        "s3vectors:GetVectors",
+                        "s3vectors:DeleteVectors",
+                        "s3vectors:ListVectors",
+                        "s3vectors:GetIndex",
+                    ],
+                    resources=[
+                        vector_bucket.attr_vector_bucket_arn,
+                        vector_index.attr_index_arn,
+                    ],
+                )
+            )
+
+        vector_indexer_lambda.add_event_source(
+            lambda_event_sources.SqsEventSource(
+                vector_queue,
+                batch_size=1,
+                max_batching_window=Duration.seconds(0),
+                max_concurrency=3,
+            )
+        )

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from aws_cdk import CfnOutput, Stack
-from components import BotConstruct, MessagingConstruct, NewsConstruct, QuizConstruct
+from components import BotConstruct, MessagingConstruct, NewsConstruct, QuizConstruct, VectorIndexerConstruct
 from components.constants import CONSTRUCT_PREFIX, RESOURCE_PREFIX
 from components.observability import (
     add_lambda_operational_alarms,
@@ -180,6 +180,21 @@ class ZerdeTelegramBotStack(Stack):
             vector_memory_index_name=vector_memory_index_name,
         )
 
+        vector_indexer = VectorIndexerConstruct(
+            self,
+            f"{CONSTRUCT_PREFIX}VectorIndexer",
+            shared_layer=zerde_layer,
+            env_name=env_name,
+            is_prod=is_prod,
+            ssm_secret_prefix=ssm_secret_prefix,
+            vector_queue=messaging.vector_queue,
+            memory_table=bot.memory_table,
+            stats_table=bot.stats_table,
+            vector_bucket=bot.vector_bucket,
+            vector_index=bot.vector_index,
+            environment=bot.bot_environment,
+        )
+
         news = NewsConstruct(
             self,
             f"{CONSTRUCT_PREFIX}News",
@@ -225,6 +240,13 @@ class ZerdeTelegramBotStack(Stack):
             logical_slug="bot",
             fn=bot.handler_lambda,
             duration_p95_threshold_ms=80_000,
+        )
+        add_lambda_operational_alarms(
+            self,
+            env_name=env_name,
+            logical_slug="vector-indexer",
+            fn=vector_indexer.handler_lambda,
+            duration_p95_threshold_ms=240_000,
         )
         add_lambda_operational_alarms(
             self,

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -1,4 +1,4 @@
-"""Bot Lambda: API Gateway webhook and SQS consumer (single function, one warm path)."""
+"""Bot Lambda: API Gateway webhook and main SQS task consumer."""
 
 import time
 from typing import Any

--- a/src/bot/services/sqs_task_router.py
+++ b/src/bot/services/sqs_task_router.py
@@ -1,4 +1,4 @@
-"""SQS record routing: captcha timeout, spam, group-agent, and memory tasks."""
+"""SQS record routing for real-time bot work and vector indexing work."""
 
 from __future__ import annotations
 
@@ -19,13 +19,51 @@ from services.vector_memory import process_vector_memory_backfill_task, process_
 logger = LoggerAdapter(get_logger(__name__), {})
 
 
+def _load_task_body(record: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(record["body"])
+
+
+def _should_skip_unconfigured_chat(body: dict[str, Any]) -> bool:
+    task_chat_id = body.get("chat_id")
+    if task_chat_id is None:
+        return False
+    if is_configured_group_chat(int(task_chat_id)):
+        return False
+    logger.debug("Skipping SQS task from non-whitelisted chat", extra={"chat_id": task_chat_id})
+    return True
+
+
+def _log_task_completed(record: dict[str, Any], body: dict[str, Any], task_type: str | None, started_at: float) -> None:
+    elapsed_ms = int((time.monotonic() - started_at) * 1000)
+    logger.info(
+        "SQS task record completed",
+        extra={
+            "task_type": task_type,
+            "latency_ms": elapsed_ms,
+            "message_id": record.get("messageId"),
+            "chat_id": body.get("chat_id"),
+        },
+    )
+
+
+def _log_task_failure(record: dict[str, Any], exc: Exception) -> None:
+    logger.error(
+        "Critical error processing SQS record",
+        extra={
+            "message_id": record.get("messageId"),
+            "error": exc,
+        },
+        exc_info=True,
+    )
+
+
 def process_sqs_event(
     event: dict[str, Any],
     bot: TelegramClient,
     captcha_repo: CaptchaRepository,
     memory_repo: GroupMemoryRepository | None = None,
 ) -> None:
-    """Process one Lambda invocation carrying SQS ``Records``."""
+    """Process main bot SQS tasks. Vector tasks are handled by the vector-indexer Lambda."""
     logger.debug(
         "Received SQS batch",
         extra={"record_count": len(event.get("Records", []))},
@@ -33,11 +71,8 @@ def process_sqs_event(
 
     for record in event["Records"]:
         try:
-            body = json.loads(record["body"])
-
-            task_chat_id = body.get("chat_id")
-            if task_chat_id is not None and not is_configured_group_chat(int(task_chat_id)):
-                logger.debug("Skipping SQS task from non-whitelisted chat", extra={"chat_id": task_chat_id})
+            body = _load_task_body(record)
+            if _should_skip_unconfigured_chat(body):
                 continue
 
             task_type = body.get("task_type")
@@ -55,35 +90,51 @@ def process_sqs_event(
                 process_group_memory_task(body, repo=memory_repo)
             elif task_type == "PROCESS_DAILY_GROUP_SUMMARIES":
                 process_daily_group_summaries_task(body, repo=memory_repo)
-            elif task_type == "PROCESS_VECTOR_MEMORY":
-                process_vector_memory_task(body, repo=memory_repo)
-            elif task_type == "PROCESS_VECTOR_MEMORY_BACKFILL":
-                process_vector_memory_backfill_task(body, repo=memory_repo)
             else:
                 logger.warning(
                     "Unexpected SQS record: unsupported task_type, ignoring",
                     extra={"task_type": task_type},
                 )
-            elapsed_ms = int((time.monotonic() - t0) * 1000)
-            logger.info(
-                "SQS task record completed",
-                extra={
-                    "task_type": task_type,
-                    "latency_ms": elapsed_ms,
-                    "message_id": record.get("messageId"),
-                    "chat_id": task_chat_id,
-                },
-            )
+            _log_task_completed(record, body, task_type, t0)
 
         except Exception as e:
-            logger.error(
-                "Critical error processing SQS record",
-                extra={
-                    "message_id": record.get("messageId"),
-                    "error": e,
-                },
-                exc_info=True,
-            )
+            _log_task_failure(record, e)
             raise
 
     logger.info("SQS batch processing completed")
+
+
+def process_vector_sqs_event(
+    event: dict[str, Any],
+    memory_repo: GroupMemoryRepository | None = None,
+) -> None:
+    """Process vector memory SQS tasks only. Failures bubble up for retry/DLQ."""
+    logger.debug(
+        "Received vector SQS batch",
+        extra={"record_count": len(event.get("Records", []))},
+    )
+
+    for record in event["Records"]:
+        try:
+            body = _load_task_body(record)
+            if _should_skip_unconfigured_chat(body):
+                continue
+
+            task_type = body.get("task_type")
+            t0 = time.monotonic()
+            if task_type == "PROCESS_VECTOR_MEMORY":
+                process_vector_memory_task(body, repo=memory_repo)
+            elif task_type == "PROCESS_VECTOR_MEMORY_BACKFILL":
+                process_vector_memory_backfill_task(body, repo=memory_repo)
+            else:
+                logger.warning(
+                    "Unexpected vector SQS record: unsupported task_type, ignoring",
+                    extra={"task_type": task_type},
+                )
+            _log_task_completed(record, body, task_type, t0)
+
+        except Exception as e:
+            _log_task_failure(record, e)
+            raise
+
+    logger.info("Vector SQS batch processing completed")

--- a/src/bot/vector_indexer_main.py
+++ b/src/bot/vector_indexer_main.py
@@ -1,0 +1,36 @@
+"""Vector indexer Lambda: consumes only vector memory SQS tasks."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from core.logger import LoggerAdapter, get_logger
+from services.sqs_task_router import process_vector_sqs_event
+from zerde_common.logging_utils import api_gateway_event_summary
+
+logger = LoggerAdapter(get_logger(__name__), {})
+logger.info("Vector indexer Lambda initialized")
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> None:
+    """Process vector-memory SQS batches. Exceptions bubble up for retry/DLQ."""
+    request_id = getattr(context, "aws_request_id", "unknown")
+    logger.extra["request_id"] = request_id
+    records = event.get("Records", [])
+    log_extra: dict = api_gateway_event_summary(event)
+    log_extra["lambda_request_id"] = request_id
+    logger.info("Vector indexer Lambda handler called", extra=log_extra)
+    started = time.monotonic()
+    try:
+        process_vector_sqs_event(event)
+    finally:
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        logger.info(
+            "Vector indexer SQS batch finished",
+            extra={
+                "lambda_request_id": request_id,
+                "latency_ms": elapsed_ms,
+                "record_count": len(records),
+            },
+        )

--- a/tests/test_infra_configuration.py
+++ b/tests/test_infra_configuration.py
@@ -13,6 +13,7 @@ if str(INFRA_DIR) not in sys.path:
 from components import bot as bot_component  # noqa: E402
 from components import news as news_component  # noqa: E402
 from components import quiz as quiz_component  # noqa: E402
+from components import vector_indexer as vector_indexer_component  # noqa: E402
 from stack import ZerdeTelegramBotStack  # noqa: E402
 
 
@@ -39,17 +40,210 @@ def _dev_template(monkeypatch: Any) -> Template:
     monkeypatch.setattr(bot_component, "PythonFunction", _stub_python_function)
     monkeypatch.setattr(news_component, "PythonFunction", _stub_python_function)
     monkeypatch.setattr(quiz_component, "PythonFunction", _stub_python_function)
+    monkeypatch.setattr(vector_indexer_component, "PythonFunction", _stub_python_function)
 
     app = App()
     stack = ZerdeTelegramBotStack(app, "TestStack", env_name="dev")
     return Template.from_stack(stack)
 
 
-def test_bot_lambda_vector_policy_allows_metadata_query_dependencies() -> None:
+def _resources(template: Template) -> dict[str, Any]:
+    return template.to_json()["Resources"]
+
+
+def _find_resource_by_property(
+    template: Template,
+    resource_type: str,
+    property_name: str,
+    property_value: str,
+) -> tuple[str, dict[str, Any]]:
+    for logical_id, resource in _resources(template).items():
+        if resource.get("Type") != resource_type:
+            continue
+        if resource.get("Properties", {}).get(property_name) == property_value:
+            return logical_id, resource
+    raise AssertionError(f"Missing {resource_type} with {property_name}={property_value}")
+
+
+def _event_source_targets(template: Template, queue_logical_id: str) -> list[Any]:
+    queue_arn = {"Fn::GetAtt": [queue_logical_id, "Arn"]}
+    targets: list[Any] = []
+    for resource in _resources(template).values():
+        if resource.get("Type") != "AWS::Lambda::EventSourceMapping":
+            continue
+        properties = resource.get("Properties", {})
+        if properties.get("EventSourceArn") == queue_arn:
+            targets.append(properties.get("FunctionName"))
+    return targets
+
+
+def _function_role_id(function_resource: dict[str, Any]) -> str:
+    role = function_resource["Properties"]["Role"]
+    return role["Fn::GetAtt"][0]
+
+
+def _as_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _role_statements(template: Template, role_logical_id: str) -> list[dict[str, Any]]:
+    statements: list[dict[str, Any]] = []
+    for resource in _resources(template).values():
+        if resource.get("Type") != "AWS::IAM::Policy":
+            continue
+        properties = resource.get("Properties", {})
+        if {"Ref": role_logical_id} not in _as_list(properties.get("Roles", [])):
+            continue
+        policy_statements = properties["PolicyDocument"]["Statement"]
+        statements.extend(_as_list(policy_statements))
+    return statements
+
+
+def _role_has_action_on_queue(
+    template: Template,
+    role_logical_id: str,
+    actions: set[str],
+    queue_logical_id: str,
+) -> bool:
+    queue_arn = {"Fn::GetAtt": [queue_logical_id, "Arn"]}
+    for statement in _role_statements(template, role_logical_id):
+        statement_actions = set(_as_list(statement.get("Action", [])))
+        if actions.isdisjoint(statement_actions):
+            continue
+        if queue_arn in _as_list(statement.get("Resource", [])):
+            return True
+    return False
+
+
+def test_vector_policies_allow_metadata_query_dependencies() -> None:
     source = Path("infra/components/bot.py").read_text()
+    vector_indexer_source = Path("infra/components/vector_indexer.py").read_text()
 
     assert '"s3vectors:QueryVectors"' in source
     assert '"s3vectors:GetVectors"' in source
+    assert '"s3vectors:QueryVectors"' in vector_indexer_source
+    assert '"s3vectors:GetVectors"' in vector_indexer_source
+
+
+def test_main_and_vector_queues_have_separate_lambda_consumers(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+    bot_lambda_id, _ = _find_resource_by_property(
+        template,
+        "AWS::Lambda::Function",
+        "FunctionName",
+        "zerde-serverless-bot-dev",
+    )
+    vector_indexer_lambda_id, _ = _find_resource_by_property(
+        template,
+        "AWS::Lambda::Function",
+        "FunctionName",
+        "zerde-serverless-vector-indexer-dev",
+    )
+    main_queue_id, _ = _find_resource_by_property(
+        template,
+        "AWS::SQS::Queue",
+        "QueueName",
+        "zerde-serverless-timeout-tasks-queue-dev",
+    )
+    vector_queue_id, _ = _find_resource_by_property(
+        template,
+        "AWS::SQS::Queue",
+        "QueueName",
+        "zerde-serverless-vector-memory-tasks-queue-dev",
+    )
+
+    assert _event_source_targets(template, main_queue_id) == [{"Ref": bot_lambda_id}]
+    assert _event_source_targets(template, vector_queue_id) == [{"Ref": vector_indexer_lambda_id}]
+
+
+def test_bot_can_send_but_not_consume_vector_queue(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+    _, bot_lambda = _find_resource_by_property(
+        template,
+        "AWS::Lambda::Function",
+        "FunctionName",
+        "zerde-serverless-bot-dev",
+    )
+    vector_queue_id, _ = _find_resource_by_property(
+        template,
+        "AWS::SQS::Queue",
+        "QueueName",
+        "zerde-serverless-vector-memory-tasks-queue-dev",
+    )
+    bot_role_id = _function_role_id(bot_lambda)
+
+    assert _role_has_action_on_queue(template, bot_role_id, {"sqs:SendMessage"}, vector_queue_id)
+    assert not _role_has_action_on_queue(
+        template,
+        bot_role_id,
+        {"sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:ChangeMessageVisibility"},
+        vector_queue_id,
+    )
+
+
+def test_vector_indexer_consumes_vector_queue(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+    _, vector_indexer_lambda = _find_resource_by_property(
+        template,
+        "AWS::Lambda::Function",
+        "FunctionName",
+        "zerde-serverless-vector-indexer-dev",
+    )
+    vector_queue_id, _ = _find_resource_by_property(
+        template,
+        "AWS::SQS::Queue",
+        "QueueName",
+        "zerde-serverless-vector-memory-tasks-queue-dev",
+    )
+    vector_role_id = _function_role_id(vector_indexer_lambda)
+
+    assert _role_has_action_on_queue(
+        template,
+        vector_role_id,
+        {"sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:ChangeMessageVisibility"},
+        vector_queue_id,
+    )
+    assert _role_has_action_on_queue(template, vector_role_id, {"sqs:SendMessage"}, vector_queue_id)
+
+
+def test_vector_indexer_ssm_access_is_limited_to_gemini(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+    _, vector_indexer_lambda = _find_resource_by_property(
+        template,
+        "AWS::Lambda::Function",
+        "FunctionName",
+        "zerde-serverless-vector-indexer-dev",
+    )
+    vector_role_id = _function_role_id(vector_indexer_lambda)
+    ssm_statements = [
+        statement
+        for statement in _role_statements(template, vector_role_id)
+        if "ssm:GetParameters" in _as_list(statement.get("Action", []))
+    ]
+    serialized_statements = repr(ssm_statements)
+
+    assert "gemini-api-key" in serialized_statements
+    assert "gemini-embedding-api-key" in serialized_statements
+    assert "bot-token" not in serialized_statements
+    assert "webhook-secret-token" not in serialized_statements
+    assert "groq-api-key" not in serialized_statements
+    assert "deepseek-api-key" not in serialized_statements
+
+
+def test_synthesizes_vector_indexer_operational_alarms(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "AlarmName": "zerde-serverless-vector-indexer-dev-errors",
+            "MetricName": "Errors",
+            "Namespace": "AWS/Lambda",
+            "Threshold": 1,
+        },
+    )
 
 
 def test_synthesizes_main_and_vector_dlq_visible_alarms(monkeypatch: Any) -> None:

--- a/tests/test_sqs_task_router.py
+++ b/tests/test_sqs_task_router.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from services.repositories.captcha import CaptchaRepository
-from services.sqs_task_router import process_sqs_event
+from services.sqs_task_router import process_sqs_event, process_vector_sqs_event
 
 
 def _record(body: dict) -> dict:
@@ -111,7 +111,7 @@ def test_process_vector_memory_routes() -> None:
         patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
         patch("services.sqs_task_router.process_vector_memory_task") as mock_pv,
     ):
-        process_sqs_event({"Records": [_record(body)]}, MagicMock(), MagicMock(), memory_repo)
+        process_vector_sqs_event({"Records": [_record(body)]}, memory_repo)
     mock_pv.assert_called_once_with(body, repo=memory_repo)
 
 
@@ -126,8 +126,39 @@ def test_process_vector_memory_backfill_routes() -> None:
         patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
         patch("services.sqs_task_router.process_vector_memory_backfill_task") as mock_pb,
     ):
-        process_sqs_event({"Records": [_record(body)]}, MagicMock(), MagicMock(), memory_repo)
+        process_vector_sqs_event({"Records": [_record(body)]}, memory_repo)
     mock_pb.assert_called_once_with(body, repo=memory_repo)
+
+
+def test_main_sqs_router_ignores_vector_tasks() -> None:
+    body = {
+        "task_type": "PROCESS_VECTOR_MEMORY",
+        "chat_id": -1001,
+        "source_sk": "EVENT#1#2",
+    }
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch("services.sqs_task_router.process_vector_memory_task") as mock_pv,
+    ):
+        process_sqs_event({"Records": [_record(body)]}, MagicMock(), MagicMock(), MagicMock())
+    mock_pv.assert_not_called()
+
+
+def test_vector_sqs_router_ignores_main_tasks() -> None:
+    body = {
+        "task_type": "PROCESS_GROUP_ASK",
+        "chat_id": -1001,
+        "update_id": 99,
+        "reply_to_message_id": 3,
+        "user_text": "what is k8s?",
+        "lang": "kk",
+    }
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch("services.sqs_task_router.process_group_ask_task") as mock_pa,
+    ):
+        process_vector_sqs_event({"Records": [_record(body)]}, MagicMock())
+    mock_pa.assert_not_called()
 
 
 def test_non_whitelisted_chat_skips_handlers() -> None:
@@ -165,3 +196,20 @@ def test_handler_failure_reraises_for_sqs_retry() -> None:
     ):
         with pytest.raises(RuntimeError, match="boom"):
             process_sqs_event({"Records": [_record(body)]}, MagicMock(), MagicMock(), MagicMock())
+
+
+def test_vector_handler_failure_reraises_for_sqs_retry() -> None:
+    body = {
+        "task_type": "PROCESS_VECTOR_MEMORY",
+        "chat_id": -1001,
+        "source_sk": "EVENT#1#2",
+    }
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch(
+            "services.sqs_task_router.process_vector_memory_task",
+            side_effect=RuntimeError("vector boom"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="vector boom"):
+            process_vector_sqs_event({"Records": [_record(body)]}, MagicMock())


### PR DESCRIPTION
## Summary
- Add a dedicated vector-indexer Lambda entrypoint for `PROCESS_VECTOR_MEMORY` and `PROCESS_VECTOR_MEMORY_BACKFILL`.
- Move vector queue consumption from the bot Lambda to the new indexer while keeping bot send access for enqueueing vector tasks.
- Add vector-indexer log group and Lambda alarms, plus focused CDK assertions for event-source and IAM isolation.
- Update architecture docs and router tests to reflect the split task families.

## Deploy impact
- Removes the bot Lambda event source mapping for `zerde-serverless-vector-memory-tasks-queue-*`.
- Adds `zerde-serverless-vector-indexer-*` Lambda, log group, vector queue event source mapping, and error/throttle/duration alarms.
- Bot role keeps only `sqs:SendMessage`-style access to the vector queue.
- Vector-indexer role gets vector queue consume/send, memory table read/write, narrow stats table access for embedding RPD counters, Gemini SSM parameters, and S3 Vectors access.

## Validation
- `uv run pytest tests/test_sqs_task_router.py tests/test_infra_configuration.py -q`
- `uv run pytest tests/ -q`
- `cd infra && uv run cdk synth -c env=dev`
- `cd infra && uv run cdk diff -c env=dev`
- `uv run pre-commit run --all-files`