### PR TITLE
FIX: query vectorizable memory by prefix

### DIFF
--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -14,6 +14,7 @@ from services.memory_safety import is_memory_learning_safe
 from services.repositories._common import get_dynamodb
 
 _VECTOR_MEMORY_PREFIXES = ("EVENT#", "USER_FACT#", "GROUP_FACT#", "JOKE#", "DAILY_SUMMARY#")
+_VECTOR_PREFIX_TOKEN_KEY = "__vector_prefix"
 
 
 class GroupMemoryRepository:
@@ -69,6 +70,36 @@ class GroupMemoryRepository:
     @staticmethod
     def is_vectorizable_sk(sk: str) -> bool:
         return sk.startswith(_VECTOR_MEMORY_PREFIXES)
+
+    @staticmethod
+    def _vector_prefix_for_start_key(start_key: dict[str, Any] | None) -> str:
+        if not start_key:
+            return _VECTOR_MEMORY_PREFIXES[0]
+        token_prefix = str(start_key.get(_VECTOR_PREFIX_TOKEN_KEY) or "")
+        if token_prefix in _VECTOR_MEMORY_PREFIXES:
+            return token_prefix
+        sk = str(start_key.get("sk") or "")
+        for prefix in _VECTOR_MEMORY_PREFIXES:
+            if sk.startswith(prefix):
+                return prefix
+        return _VECTOR_MEMORY_PREFIXES[0]
+
+    @staticmethod
+    def _dynamodb_start_key_for_prefix(start_key: dict[str, Any] | None, prefix: str) -> dict[str, Any] | None:
+        if not start_key:
+            return None
+        sk = str(start_key.get("sk") or "")
+        if not sk.startswith(prefix):
+            return None
+        return {key: value for key, value in start_key.items() if not str(key).startswith("__")}
+
+    @staticmethod
+    def _next_vector_prefix_token(prefix: str) -> dict[str, Any] | None:
+        try:
+            next_prefix = _VECTOR_MEMORY_PREFIXES[_VECTOR_MEMORY_PREFIXES.index(prefix) + 1]
+        except IndexError:
+            return None
+        return {_VECTOR_PREFIX_TOKEN_KEY: next_prefix}
 
     @staticmethod
     def _normalise_profile_samples(value: Any) -> list[str]:
@@ -590,26 +621,42 @@ class GroupMemoryRepository:
         start_key: dict[str, Any] | None = None,
         user_id: int | str | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-        """Return one DynamoDB page of memory items eligible for vector indexing."""
-        kwargs: dict[str, Any] = {
-            "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)),
-            "Limit": limit,
-        }
-        if start_key:
-            kwargs["ExclusiveStartKey"] = start_key
-        resp = self.table.query(**kwargs)
+        """Return one page of memory items eligible for vector indexing."""
         cleanup_terms = (
             self._cleanup_terms_from_profile(self.get_user_profile(chat_id, user_id)) if user_id is not None else set()
         )
+        limit = max(1, int(limit))
         items: list[dict[str, Any]] = []
-        for item in resp.get("Items") or []:
-            sk = str(item.get("sk") or "")
-            if not self.is_vectorizable_sk(sk):
-                continue
-            if user_id is not None and not self._matches_user_memory_item(item, user_id, cleanup_terms):
-                continue
-            items.append(item)
-        return items, resp.get("LastEvaluatedKey")
+        start_prefix = self._vector_prefix_for_start_key(start_key)
+        start_index = _VECTOR_MEMORY_PREFIXES.index(start_prefix)
+        exclusive_start_key = self._dynamodb_start_key_for_prefix(start_key, start_prefix)
+
+        for prefix in _VECTOR_MEMORY_PREFIXES[start_index:]:
+            remaining = limit - len(items)
+            if remaining <= 0:
+                return items, self._next_vector_prefix_token(prefix)
+
+            kwargs: dict[str, Any] = {
+                "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)) & Key("sk").begins_with(prefix),
+                "Limit": remaining,
+            }
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            resp = self.table.query(**kwargs)
+            for item in resp.get("Items") or []:
+                if user_id is not None and not self._matches_user_memory_item(item, user_id, cleanup_terms):
+                    continue
+                items.append(item)
+
+            next_key = resp.get("LastEvaluatedKey")
+            if next_key:
+                return items, next_key
+            if len(items) >= limit:
+                return items, self._next_vector_prefix_token(prefix)
+            exclusive_start_key = None
+
+        return items, None
 
     def mark_vector_status(
         self,

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -1860,6 +1860,84 @@ def test_forget_me_deletes_current_users_memory():
     assert "5" in ctx.reply.call_args.args[0]
 
 
+def _memory_query_prefixes(repo: GroupMemoryRepository) -> list[str]:
+    prefixes = []
+    for call in repo.table.query.call_args_list:
+        expression = call.kwargs["KeyConditionExpression"]
+        key_conditions = expression.get_expression()["values"]
+        begins_with = key_conditions[1].get_expression()
+        assert begins_with["operator"] == "begins_with"
+        prefixes.append(begins_with["values"][1])
+    return prefixes
+
+
+def test_vectorizable_memory_items_query_vector_prefixes_not_full_partition():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+    repo.table.query.side_effect = [
+        {"Items": [{"sk": "EVENT#1#2"}]},
+        {"Items": [{"sk": "USER_FACT#42#1#3"}]},
+        {"Items": [{"sk": "GROUP_FACT#1#4"}]},
+        {"Items": [{"sk": "JOKE#1#5"}]},
+        {"Items": [{"sk": "DAILY_SUMMARY#2026-06-10"}]},
+    ]
+
+    items, next_key = repo.list_vectorizable_memory_items(-100123, limit=10)
+
+    assert next_key is None
+    assert [item["sk"] for item in items] == [
+        "EVENT#1#2",
+        "USER_FACT#42#1#3",
+        "GROUP_FACT#1#4",
+        "JOKE#1#5",
+        "DAILY_SUMMARY#2026-06-10",
+    ]
+    assert _memory_query_prefixes(repo) == [
+        "EVENT#",
+        "USER_FACT#",
+        "GROUP_FACT#",
+        "JOKE#",
+        "DAILY_SUMMARY#",
+    ]
+
+
+def test_vectorizable_memory_items_continue_at_next_prefix_when_page_fills_boundary():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+    repo.table.query.side_effect = [
+        {"Items": [{"sk": "EVENT#1#2"}]},
+        {"Items": [{"sk": "USER_FACT#42#1#3"}]},
+    ]
+
+    items, next_key = repo.list_vectorizable_memory_items(-100123, limit=1)
+    resumed_items, resumed_next_key = repo.list_vectorizable_memory_items(-100123, limit=1, start_key=next_key)
+
+    assert [item["sk"] for item in items] == ["EVENT#1#2"]
+    assert next_key == {"__vector_prefix": "USER_FACT#"}
+    assert [item["sk"] for item in resumed_items] == ["USER_FACT#42#1#3"]
+    assert resumed_next_key == {"__vector_prefix": "GROUP_FACT#"}
+    assert _memory_query_prefixes(repo) == ["EVENT#", "USER_FACT#"]
+
+
+def test_vectorizable_memory_items_resume_inside_prefix_with_dynamodb_start_key():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+    first_next_key = {"pk": "CHAT#-100123", "sk": "EVENT#1#2"}
+    repo.table.query.side_effect = [
+        {"Items": [{"sk": "EVENT#1#2"}], "LastEvaluatedKey": first_next_key},
+        {"Items": [{"sk": "EVENT#1#3"}]},
+    ]
+
+    items, next_key = repo.list_vectorizable_memory_items(-100123, limit=1)
+    resumed_items, _ = repo.list_vectorizable_memory_items(-100123, limit=1, start_key=next_key)
+
+    assert [item["sk"] for item in items] == ["EVENT#1#2"]
+    assert next_key == first_next_key
+    assert [item["sk"] for item in resumed_items] == ["EVENT#1#3"]
+    assert repo.table.query.call_args_list[1].kwargs["ExclusiveStartKey"] == first_next_key
+    assert _memory_query_prefixes(repo) == ["EVENT#", "EVENT#"]
+
+
 def test_user_related_vector_items_include_matching_daily_summaries():
     repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
     repo.table = MagicMock()
@@ -1870,27 +1948,31 @@ def test_user_related_vector_items_include_matching_daily_summaries():
             "display_name": "Ada Lovelace",
         }
     }
-    repo.table.query.return_value = {
-        "Items": [
-            {"sk": "USER_FACT#42#1#2", "user_id": "42"},
-            {"sk": "EVENT#1#3", "user_id": "42"},
-            {
-                "sk": "DAILY_SUMMARY#2026-06-10",
-                "summary": "Ada Lovelace discussed Lambda memory.",
-            },
-            {
-                "sk": "DAILY_SUMMARY#2026-06-11",
-                "summary": "Grace discussed DynamoDB.",
-            },
-        ]
-    }
+    repo.table.query.side_effect = [
+        {"Items": [{"sk": "EVENT#1#3", "user_id": "42"}]},
+        {"Items": [{"sk": "USER_FACT#42#1#2", "user_id": "42"}]},
+        {"Items": []},
+        {"Items": []},
+        {
+            "Items": [
+                {
+                    "sk": "DAILY_SUMMARY#2026-06-10",
+                    "summary": "Ada Lovelace discussed Lambda memory.",
+                },
+                {
+                    "sk": "DAILY_SUMMARY#2026-06-11",
+                    "summary": "Grace discussed DynamoDB.",
+                },
+            ]
+        },
+    ]
 
     items, next_key = repo.list_vectorizable_memory_items(-100123, user_id=42)
 
     assert next_key is None
     assert [item["sk"] for item in items] == [
-        "USER_FACT#42#1#2",
         "EVENT#1#3",
+        "USER_FACT#42#1#2",
         "DAILY_SUMMARY#2026-06-10",
     ]
 


### PR DESCRIPTION
## Summary
- Change `list_vectorizable_memory_items()` from a broad `CHAT#...` partition query plus Python prefix filtering to prefix-specific `sk begins_with(...)` DynamoDB queries.
- Preserve pagination for backfill and vector cleanup with raw DynamoDB `LastEvaluatedKey` continuation inside a prefix and an opaque prefix continuation token between prefixes.
- Add regression tests that assert the iterator queries only vectorizable prefixes and can resume at prefix boundaries and inside a DynamoDB prefix page.

## Notes
- This PR intentionally avoids adding a GSI.
- This optimizes the shared vectorizable iterator used by vector backfill and vector cleanup. The broader `get_memory_overview()` status path still counts the full memory partition and can be narrowed separately if `/memory status` remains too expensive on imported chats.

## Validation
- `uv run pytest tests/test_group_memory_agent.py tests/test_vector_memory.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`