### PR TITLE
FEATURE: add memory retrieval pipeline

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -37,7 +37,7 @@ ZerdeBot started as a simple serverless Telegram bot and LLM wrapper. It is now 
 - It observes opted-in group messages.
 - It stores recent context, user profiles, long-term memory, daily summaries, and agent reply metadata in DynamoDB.
 - It indexes long-term memory in S3 Vectors for semantic RAG retrieval.
-- It answers `/ask`, @mentions, and reply-to-bot follow-ups with requester, profile, recent, long-term, and semantic context.
+- It answers `/ask`, @mentions, and reply-to-bot follow-ups through a retrieval pipeline that gathers requester, profile, recent, long-term, and semantic context.
 - Reply-thread follow-ups carry the captured quoted source message, previous user request, and previous bot answer when available.
 - It may proactively answer only after conservative local and LLM social-timing gates.
 - It still supports captcha, anti-spam, voteban, daily news, and quizzes.
@@ -89,6 +89,7 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 - `webhook.py` — verifies Telegram secret, screens spam, observes memory, filters irrelevant events, routes agent/commands.
 - `services/sqs_task_router.py` — routes main and vector SQS task families and re-raises failures for retry/DLQ semantics.
 - `services/group_memory.py` — stores recent group context, formats prompt context, requester/target-user profile context, and query-filtered long-term memory.
+- `services/memory_retrieval.py` — thin Memory Retrieval Pipeline V1 wrapper for query intent, candidate/source tracking, local scoring, dedupe, and context packing.
 - `services/group_memory_processor.py` — async long-term extraction and daily summaries.
 - `services/group_agent.py` — agent trigger policy, proactive gating, reply-thread continuity, answer-length policy.
 - `services/vector_memory.py` — embedding, S3 Vectors indexing, semantic retrieval, cleanup/backfill.
@@ -105,7 +106,7 @@ Single table partitioned by `pk=CHAT#<chat_id>`:
 - `USER#<user_id>` — profile from the user's own messages only.
 - `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...` — long-term memories.
 - `DAILY_SUMMARY#YYYY-MM-DD` — compressed daily group memory.
-- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, and reason for reply-thread continuity and `/agent why`.
+- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, retrieval source metadata, and reason for reply-thread continuity and `/agent why`.
 - `VECTOR_BACKFILL` — vector backfill status.
 - `PROACTIVE#YYYYMMDD` — daily proactive reply reservation counter.
 
@@ -136,6 +137,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Trust hierarchy for agent answers**: current user message and reply-thread context > requester profile for self-reference > target user's own profile > query-matched vector memory > query-filtered long-term memory > recent group chatter.
 - **Prompt pollution control**: do not inject unfiltered recent long-term memories into answers; filter by query or use vector retrieval.
 - **Vector retrieval discipline**: use chat metadata filters, requester filters for self-reference when available, and distance cutoffs before adding semantic memories to prompts.
+- **Memory Retrieval Pipeline V1**: `services.memory_retrieval.build_agent_memory_context` wraps existing profile, semantic, long-term, and recent context builders, tracks candidate sources, scores/dedupes locally, and persists compact retrieval source metadata for future `/agent why` explanations.
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
 - **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -35,6 +35,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector indexing entrypoints.
 - `src/bot/services/group_agent.py`: agent trigger policy, proactive gating, reply-thread continuity, response length policy.
 - `src/bot/services/group_memory.py`: recent context observation and prompt formatting, requester/target-user profiles, query-filtered long-term context.
+- `src/bot/services/memory_retrieval.py`: Memory Retrieval Pipeline V1 wrapper for query intent, source tracking, local scoring/dedupe, and context packing around existing retrieval helpers.
 - `src/bot/services/group_memory_processor.py`: async long-term memory extraction and daily summaries.
 - `src/bot/vector_indexer_main.py`: dedicated vector memory SQS Lambda entrypoint.
 - `src/bot/services/vector_memory.py`: Gemini embeddings, S3 Vectors indexing/retrieval with metadata filters and distance cutoffs, vector cleanup/backfill.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ ZerdeBot is no longer a simple LLM wrapper. The bot is now a serverless Telegram
 - It observes opted-in group messages and stores recent context.
 - It extracts long-term memories and daily summaries.
 - It embeds long-term memory into S3 Vectors for semantic retrieval.
-- It answers explicit questions with requester identity, recent context, user profiles, long-term memory, and query-matched vector memory.
+- It answers explicit questions through a retrieval pipeline that combines requester identity, recent context, user profiles, long-term memory, and query-matched vector memory.
 - It can continue reply threads with its own previous answers and the original quoted source message when that context was captured.
 - It may proactively join a discussion, but only after local gating, model timing judgment, recent-bot-activity penalty, and daily limits.
 
@@ -55,6 +55,7 @@ flowchart LR
 | Package | Entry | Main responsibilities |
 |---------|-------|-----------------------|
 | `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, semantic retrieval, and cleanup commands. |
+| `src/bot/services/memory_retrieval.py` | `build_agent_memory_context` | Memory Retrieval Pipeline V1: query intent, source tracking, local scoring/dedupe, and context packing around existing retrieval helpers. |
 | `src/bot/` | `vector_indexer_main.py:lambda_handler` | Dedicated vector memory SQS worker for embedding/indexing and vector backfill paging. |
 | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest and Telegram delivery. |
 | `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand multilingual developer quizzes. |
@@ -101,7 +102,7 @@ The table is single-table by chat partition:
 | `sk=GROUP_FACT#...` | Group decision or shared preference. |
 | `sk=JOKE#...` | Possible recurring joke or meme. Use carefully; this is easy to over-retrieve. |
 | `sk=DAILY_SUMMARY#YYYY-MM-DD` | Daily compressed memory for imported or observed messages. |
-| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, parent bot message id, and requester metadata for reply-thread continuity. |
+| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, and compact retrieval source metadata for reply-thread continuity. |
 | `sk=VECTOR_BACKFILL` | Last vector backfill status for a chat. |
 | `sk=PROACTIVE#YYYYMMDD` | Daily proactive reply reservation counter. |
 
@@ -109,7 +110,9 @@ Only long-term memory prefixes and daily summaries are vectorizable. Raw `MSG#..
 
 ## Agent Answer Context
 
-`services.group_agent.answer_group_question` builds these sections:
+`services.group_agent.answer_group_question` calls `services.memory_retrieval.build_agent_memory_context`, which wraps the existing retrievers into Memory Retrieval Pipeline V1. The pipeline analyzes query intent, retrieves candidates, scores/dedupes them locally, packs context within a character budget, and returns compact `retrieval_sources` metadata for `AGENT_REPLY#...` records.
+
+The returned bundle keeps these prompt sections:
 
 1. Trusted requester profile context for the user who asked the question.
 2. Trusted target-user profile context, only for users explicitly mentioned in the user message.

--- a/src/bot/services/group_agent.py
+++ b/src/bot/services/group_agent.py
@@ -36,6 +36,7 @@ from services.group_memory import (
     format_requester_profile_context,
     format_user_profile_context,
 )
+from services.memory_retrieval import build_agent_memory_context
 from services.memory_safety import (
     looks_like_future_answer_directive,
     looks_like_subjective_person_ranking_question,
@@ -47,25 +48,6 @@ from services.vector_memory import format_semantic_memory_context, retrieve_rele
 logger = LoggerAdapter(get_logger(__name__), {})
 
 _agent_gemini: GeminiClient | None = None
-
-_SELF_REFERENCE_CUES = (
-    "who am i",
-    "who am i?",
-    "what do you know about me",
-    "what did i say",
-    "did i say",
-    "我是谁",
-    "你知道我",
-    "我说过",
-    "кто я",
-    "я кто",
-    "что ты знаешь обо мне",
-    "что я говорил",
-    "что я сказал",
-    "мен кім",
-    "мен кіммін",
-    "мен не дедім",
-)
 
 
 @dataclass(frozen=True)
@@ -111,12 +93,6 @@ def _mentions_bot(text: str) -> bool:
     if not AGENT_BOT_USERNAME:
         return False
     return re.search(rf"@{re.escape(AGENT_BOT_USERNAME)}\b", text, flags=re.IGNORECASE) is not None
-
-
-def _looks_like_self_reference(text: str) -> bool:
-    lowered = " ".join((text or "").lower().split())
-    compact = lowered.replace(" ", "")
-    return any(cue in lowered or cue.replace(" ", "") in compact for cue in _SELF_REFERENCE_CUES)
 
 
 def _replies_to_bot(message: dict[str, Any]) -> bool:
@@ -879,51 +855,49 @@ def answer_group_question(
     if not gemini:
         return False
 
-    recent_context = format_recent_context(repo, chat_id, limit=AGENT_RECENT_CONTEXT_LIMIT)
-    long_term_memory_context = format_long_term_memory_context(repo, chat_id, query_text=user_text)
-    self_reference = _looks_like_self_reference(user_text)
-    semantic_memories = retrieve_relevant_memories(
-        chat_id,
-        user_text,
-        limit=8,
-        user_id=requester_user_id if self_reference else None,
-    )
-    semantic_memory_context = format_semantic_memory_context(semantic_memories)
-    logger.info(
-        "Group agent semantic memory context prepared",
-        extra={
-            "chat_id": chat_id,
-            "retrieved_count": len(semantic_memories),
-            "context_item_count": len(semantic_memory_context.splitlines()) if semantic_memory_context else 0,
-            "context_chars": len(semantic_memory_context),
-            "self_reference": self_reference,
-            "requester_filter_applied": bool(self_reference and requester_user_id is not None),
-        },
-    )
     ignored_usernames = {AGENT_BOT_USERNAME} if AGENT_BOT_USERNAME else set()
-    user_profile_context = format_user_profile_context(
-        repo,
-        chat_id,
+    memory_bundle = build_agent_memory_context(
+        repo=repo,
+        chat_id=chat_id,
         user_text=user_text,
-        ignored_usernames=ignored_usernames,
-    )
-    requester_profile_context = format_requester_profile_context(
-        repo,
-        chat_id,
         requester_user_id=requester_user_id,
         requester_username=requester_username,
         requester_display_name=requester_display_name,
+        ignored_usernames=ignored_usernames,
+        recent_limit=AGENT_RECENT_CONTEXT_LIMIT,
+        semantic_limit=8,
+        recent_context_fn=format_recent_context,
+        long_term_context_fn=format_long_term_memory_context,
+        semantic_retrieval_fn=retrieve_relevant_memories,
+        semantic_context_fn=format_semantic_memory_context,
+        user_profile_context_fn=format_user_profile_context,
+        requester_profile_context_fn=format_requester_profile_context,
+    )
+    logger.info(
+        "Group agent memory retrieval context prepared",
+        extra={
+            "chat_id": chat_id,
+            "candidate_count": len(memory_bundle.candidates),
+            "retrieval_source_count": len(memory_bundle.retrieval_sources),
+            "semantic_context_item_count": (
+                len(memory_bundle.semantic_memory_context.splitlines()) if memory_bundle.semantic_memory_context else 0
+            ),
+            "semantic_context_chars": len(memory_bundle.semantic_memory_context),
+            "self_reference": memory_bundle.intent.is_self_reference,
+            "requester_filter_applied": bool(memory_bundle.intent.is_self_reference and requester_user_id is not None),
+            "target_username_count": len(memory_bundle.intent.target_usernames),
+        },
     )
     reply_policy = _reply_policy(user_text)
 
     try:
         answer, _ = gemini.group_chat_reply(
             user_message=user_text,
-            recent_context=recent_context,
-            long_term_memory_context=long_term_memory_context,
-            semantic_memory_context=semantic_memory_context,
-            user_profile_context=user_profile_context,
-            requester_profile_context=requester_profile_context,
+            recent_context=memory_bundle.recent_context,
+            long_term_memory_context=memory_bundle.long_term_memory_context,
+            semantic_memory_context=memory_bundle.semantic_memory_context,
+            user_profile_context=memory_bundle.user_profile_context,
+            requester_profile_context=memory_bundle.requester_profile_context,
             reply_instructions=reply_policy.instructions,
             max_output_tokens=reply_policy.max_output_tokens,
             lang=lang,
@@ -983,5 +957,6 @@ def answer_group_question(
             requester_user_id=requester_user_id,
             requester_username=requester_username,
             requester_display_name=requester_display_name,
+            retrieval_sources=memory_bundle.retrieval_sources,
         )
     return True

--- a/src/bot/services/memory_retrieval.py
+++ b/src/bot/services/memory_retrieval.py
@@ -1,0 +1,479 @@
+"""Thin retrieval pipeline wrapper for group-agent memory context."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Any
+
+from services.group_memory import (
+    extract_mentioned_usernames,
+    format_long_term_memory_context,
+    format_recent_context,
+    format_requester_profile_context,
+    format_user_profile_context,
+)
+from services.memory_safety import is_memory_learning_safe
+from services.repositories.group_memory import GroupMemoryRepository
+from services.vector_memory import format_semantic_memory_context, retrieve_relevant_memories
+
+_SELF_REFERENCE_CUES = (
+    "who am i",
+    "what do you know about me",
+    "what did i say",
+    "did i say",
+    "我是谁",
+    "你知道我",
+    "我说过",
+    "кто я",
+    "я кто",
+    "что ты знаешь обо мне",
+    "что я говорил",
+    "что я сказал",
+    "мен кім",
+    "мен кіммін",
+    "мен не дедім",
+)
+
+_GROUP_DECISION_CUES = (
+    "decide",
+    "decided",
+    "choose",
+    "chose",
+    "picked",
+    "agreed",
+    "what did we pick",
+    "решили",
+    "выбрали",
+    "договорились",
+    "таңдадық",
+    "шештік",
+    "келістік",
+    "决定",
+    "选择",
+)
+
+_PAST_EVENT_CUES = (
+    "what happened",
+    "when did",
+    "yesterday",
+    "last week",
+    "last month",
+    "раньше",
+    "вчера",
+    "когда",
+    "что было",
+    "не болды",
+    "қашан",
+    "кеше",
+    "以前",
+    "昨天",
+    "发生",
+)
+
+_JOKE_CUES = (
+    "joke",
+    "meme",
+    "inside joke",
+    "шутк",
+    "мем",
+    "прикол",
+    "әзіл",
+    "қалжың",
+    "мем",
+    "笑话",
+    "梗",
+)
+
+_TIME_HINT_RE = re.compile(
+    r"\b(?:today|yesterday|tomorrow|last\s+\w+|next\s+\w+|"
+    r"\d{4}-\d{2}-\d{2}|\d{1,2}[./-]\d{1,2}(?:[./-]\d{2,4})?)\b",
+    flags=re.IGNORECASE,
+)
+
+_TERM_RE = re.compile(r"[0-9a-zа-яәғқңөұүһіё+#._-]{3,}", flags=re.IGNORECASE)
+_STOP_TERMS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "what",
+    "who",
+    "why",
+    "how",
+    "что",
+    "как",
+    "кто",
+    "это",
+    "мен",
+    "кім",
+    "не",
+}
+
+
+@dataclass(frozen=True)
+class RetrievalIntent:
+    is_self_reference: bool
+    target_usernames: set[str]
+    target_user_ids: set[str]
+    asks_group_decision: bool
+    asks_past_event: bool
+    asks_joke_or_meme: bool
+    time_hint: str | None
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    source: str
+    source_sk: str | None
+    memory_kind: str | None
+    text: str
+    score: float
+    trust_level: int
+    created_at: int | None
+    metadata: dict[str, Any]
+
+    def source_metadata(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "source": self.source,
+            "score": round(max(0.0, min(1.0, self.score)), 4),
+            "trust_level": self.trust_level,
+        }
+        if self.source_sk:
+            data["source_sk"] = self.source_sk
+        if self.memory_kind:
+            data["memory_kind"] = self.memory_kind
+        if self.created_at is not None:
+            data["created_at"] = self.created_at
+        return data
+
+
+@dataclass(frozen=True)
+class RetrievalBundle:
+    intent: RetrievalIntent
+    recent_context: str
+    long_term_memory_context: str
+    semantic_memory_context: str
+    user_profile_context: str
+    requester_profile_context: str
+    candidates: list[MemoryCandidate]
+    retrieval_sources: list[dict[str, Any]]
+
+
+def _contains_any(text: str, cues: tuple[str, ...]) -> bool:
+    lowered = " ".join((text or "").lower().split())
+    compact = lowered.replace(" ", "")
+    return any(cue in lowered or cue.replace(" ", "") in compact for cue in cues)
+
+
+def analyze_query_intent(
+    user_text: str,
+    requester_user_id: int | str | None = None,
+    *,
+    ignored_usernames: set[str] | None = None,
+) -> RetrievalIntent:
+    """Extract a small, local intent signal set for retrieval decisions."""
+    ignored = {item.lower().lstrip("@") for item in (ignored_usernames or set()) if item}
+    target_usernames = extract_mentioned_usernames(user_text, ignore=ignored)
+    target_user_ids = (
+        {str(requester_user_id)}
+        if requester_user_id is not None and _contains_any(user_text, _SELF_REFERENCE_CUES)
+        else set()
+    )
+    time_match = _TIME_HINT_RE.search(user_text or "")
+    return RetrievalIntent(
+        is_self_reference=_contains_any(user_text, _SELF_REFERENCE_CUES),
+        target_usernames=target_usernames,
+        target_user_ids=target_user_ids,
+        asks_group_decision=_contains_any(user_text, _GROUP_DECISION_CUES),
+        asks_past_event=_contains_any(user_text, _PAST_EVENT_CUES),
+        asks_joke_or_meme=_contains_any(user_text, _JOKE_CUES),
+        time_hint=time_match.group(0) if time_match else None,
+    )
+
+
+def _query_terms(text: str) -> set[str]:
+    return {term.lower().lstrip("@") for term in _TERM_RE.findall(text or "") if term.lower() not in _STOP_TERMS}
+
+
+def _line_kind(line: str) -> str | None:
+    match = re.match(r"\[([a-z_]+)", line.strip())
+    return match.group(1) if match else None
+
+
+def _semantic_candidate(row: dict[str, Any]) -> MemoryCandidate | None:
+    metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+    text = str(metadata.get("text") or "").replace("\n", " ").strip()
+    if not text or not is_memory_learning_safe(text):
+        return None
+    distance = row.get("distance")
+    similarity_score = 0.5
+    if isinstance(distance, int | float):
+        similarity_score = max(0.0, min(1.0, 1.0 - float(distance)))
+    created_at = metadata.get("created_at")
+    try:
+        created_at_int = int(created_at) if created_at is not None else None
+    except (TypeError, ValueError):
+        created_at_int = None
+    return MemoryCandidate(
+        source="semantic",
+        source_sk=str(metadata.get("source_sk") or "") or None,
+        memory_kind=str(metadata.get("memory_kind") or "") or None,
+        text=text,
+        score=similarity_score,
+        trust_level=60,
+        created_at=created_at_int,
+        metadata={**metadata, "distance": distance},
+    )
+
+
+def _context_line_candidates(source: str, context: str, *, trust_level: int) -> list[MemoryCandidate]:
+    candidates: list[MemoryCandidate] = []
+    for line in context.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        candidates.append(
+            MemoryCandidate(
+                source=source,
+                source_sk=None,
+                memory_kind=_line_kind(text),
+                text=text,
+                score=0.0,
+                trust_level=trust_level,
+                created_at=None,
+                metadata={},
+            )
+        )
+    return candidates
+
+
+def retrieve_candidates(
+    *,
+    repo: GroupMemoryRepository,
+    chat_id: int | str,
+    user_text: str,
+    intent: RetrievalIntent,
+    requester_user_id: int | str | None = None,
+    requester_username: str | None = None,
+    requester_display_name: str | None = None,
+    ignored_usernames: set[str] | None = None,
+    recent_limit: int | None = None,
+    semantic_limit: int = 8,
+    recent_context_fn: Callable[..., str] = format_recent_context,
+    long_term_context_fn: Callable[..., str] = format_long_term_memory_context,
+    semantic_retrieval_fn: Callable[..., list[dict[str, Any]]] = retrieve_relevant_memories,
+    semantic_context_fn: Callable[[list[dict[str, Any]]], str] = format_semantic_memory_context,
+    user_profile_context_fn: Callable[..., str] = format_user_profile_context,
+    requester_profile_context_fn: Callable[..., str] = format_requester_profile_context,
+) -> tuple[dict[str, str], list[MemoryCandidate]]:
+    """Call existing retrievers/formatters and convert their output to candidates."""
+    recent_context = recent_context_fn(repo, chat_id, limit=recent_limit)
+    long_term_context = long_term_context_fn(repo, chat_id, query_text=user_text)
+    semantic_rows = semantic_retrieval_fn(
+        chat_id,
+        user_text,
+        limit=semantic_limit,
+        user_id=requester_user_id if intent.is_self_reference else None,
+    )
+    semantic_context = semantic_context_fn(semantic_rows)
+    user_profile_context = user_profile_context_fn(
+        repo,
+        chat_id,
+        user_text=user_text,
+        ignored_usernames=ignored_usernames,
+    )
+    requester_profile_context = requester_profile_context_fn(
+        repo,
+        chat_id,
+        requester_user_id=requester_user_id,
+        requester_username=requester_username,
+        requester_display_name=requester_display_name,
+    )
+
+    candidates: list[MemoryCandidate] = []
+    if requester_profile_context:
+        candidates.append(
+            MemoryCandidate(
+                source="requester_profile",
+                source_sk=f"USER#{requester_user_id}" if requester_user_id is not None else None,
+                memory_kind="profile",
+                text=requester_profile_context,
+                score=0.0,
+                trust_level=100,
+                created_at=None,
+                metadata={"requester_user_id": str(requester_user_id) if requester_user_id is not None else ""},
+            )
+        )
+    if user_profile_context:
+        candidates.append(
+            MemoryCandidate(
+                source="target_profile",
+                source_sk=None,
+                memory_kind="profile",
+                text=user_profile_context,
+                score=0.0,
+                trust_level=90,
+                created_at=None,
+                metadata={"target_usernames": sorted(intent.target_usernames)},
+            )
+        )
+    for row in semantic_rows:
+        candidate = _semantic_candidate(row)
+        if candidate:
+            candidates.append(candidate)
+    candidates.extend(_context_line_candidates("long_term", long_term_context, trust_level=50))
+    candidates.extend(_context_line_candidates("recent", recent_context, trust_level=20))
+    return (
+        {
+            "recent_context": recent_context,
+            "long_term_memory_context": long_term_context,
+            "semantic_memory_context": semantic_context,
+            "user_profile_context": user_profile_context,
+            "requester_profile_context": requester_profile_context,
+        },
+        candidates,
+    )
+
+
+def score_candidates(
+    candidates: list[MemoryCandidate],
+    *,
+    intent: RetrievalIntent,
+    user_text: str,
+    now: int | None = None,
+) -> list[MemoryCandidate]:
+    """Apply explainable local scores without changing the underlying retrievers."""
+    now = int(time.time()) if now is None else now
+    terms = _query_terms(user_text)
+    scored: list[MemoryCandidate] = []
+    for candidate in candidates:
+        score = candidate.score + candidate.trust_level / 120.0
+        text_lower = candidate.text.lower()
+        exact_matches = sum(1 for term in terms if term in text_lower)
+        score += min(0.2, exact_matches * 0.04)
+
+        if intent.target_usernames and any(username in text_lower for username in intent.target_usernames):
+            score += 0.2
+        if candidate.source == "requester_profile" and intent.is_self_reference:
+            score += 0.25
+        if candidate.memory_kind in {"event", "daily_summary"} and (
+            intent.asks_group_decision or intent.asks_past_event
+        ):
+            score += 0.12
+        if candidate.memory_kind == "joke":
+            score += 0.2 if intent.asks_joke_or_meme else -0.25
+        if candidate.created_at:
+            age_days = max(0.0, (now - candidate.created_at) / 86_400)
+            score += max(-0.1, 0.08 - min(0.18, age_days / 365.0 * 0.18))
+        confidence = candidate.metadata.get("confidence")
+        if isinstance(confidence, int | float):
+            score += (float(confidence) - 0.5) * 0.16
+
+        scored.append(replace(candidate, score=max(0.0, min(1.0, score))))
+    return sorted(scored, key=lambda item: (item.score, item.trust_level), reverse=True)
+
+
+def dedupe_candidates(candidates: list[MemoryCandidate]) -> list[MemoryCandidate]:
+    """Keep the highest-scoring candidate for duplicated source/text pairs."""
+    deduped: dict[tuple[str | None, str], MemoryCandidate] = {}
+    for candidate in candidates:
+        normalized_text = " ".join(candidate.text.lower().split())[:500]
+        key = (candidate.source_sk, normalized_text)
+        existing = deduped.get(key)
+        if existing is None or (candidate.score, candidate.trust_level) > (existing.score, existing.trust_level):
+            deduped[key] = candidate
+    return sorted(deduped.values(), key=lambda item: (item.score, item.trust_level), reverse=True)
+
+
+def _pack_text(text: str, remaining: int) -> tuple[str, int]:
+    if remaining <= 0 or not text:
+        return "", remaining
+    packed_lines: list[str] = []
+    used = 0
+    for line in text.splitlines():
+        candidate = line if not packed_lines else "\n" + line
+        candidate_len = len(candidate)
+        if used + candidate_len > remaining:
+            break
+        packed_lines.append(line)
+        used += candidate_len
+    return "\n".join(packed_lines), remaining - used
+
+
+def pack_context(
+    *,
+    intent: RetrievalIntent,
+    contexts: dict[str, str],
+    candidates: list[MemoryCandidate],
+    char_budget: int = 12_000,
+    source_limit: int = 16,
+) -> RetrievalBundle:
+    """Pack context sections in trust order and return source metadata."""
+    remaining = max(0, int(char_budget))
+    packed: dict[str, str] = {}
+    for key in (
+        "requester_profile_context",
+        "user_profile_context",
+        "semantic_memory_context",
+        "long_term_memory_context",
+        "recent_context",
+    ):
+        packed[key], remaining = _pack_text(contexts.get(key, ""), remaining)
+
+    selected_sources = [candidate.source_metadata() for candidate in candidates[:source_limit]]
+    return RetrievalBundle(
+        intent=intent,
+        recent_context=packed["recent_context"],
+        long_term_memory_context=packed["long_term_memory_context"],
+        semantic_memory_context=packed["semantic_memory_context"],
+        user_profile_context=packed["user_profile_context"],
+        requester_profile_context=packed["requester_profile_context"],
+        candidates=candidates,
+        retrieval_sources=selected_sources,
+    )
+
+
+def build_agent_memory_context(
+    *,
+    repo: GroupMemoryRepository,
+    chat_id: int | str,
+    user_text: str,
+    requester_user_id: int | str | None = None,
+    requester_username: str | None = None,
+    requester_display_name: str | None = None,
+    ignored_usernames: set[str] | None = None,
+    recent_limit: int | None = None,
+    semantic_limit: int = 8,
+    char_budget: int = 12_000,
+    recent_context_fn: Callable[..., str] = format_recent_context,
+    long_term_context_fn: Callable[..., str] = format_long_term_memory_context,
+    semantic_retrieval_fn: Callable[..., list[dict[str, Any]]] = retrieve_relevant_memories,
+    semantic_context_fn: Callable[[list[dict[str, Any]]], str] = format_semantic_memory_context,
+    user_profile_context_fn: Callable[..., str] = format_user_profile_context,
+    requester_profile_context_fn: Callable[..., str] = format_requester_profile_context,
+) -> RetrievalBundle:
+    """Build agent prompt contexts plus retrieval source metadata."""
+    intent = analyze_query_intent(user_text, requester_user_id, ignored_usernames=ignored_usernames)
+    contexts, candidates = retrieve_candidates(
+        repo=repo,
+        chat_id=chat_id,
+        user_text=user_text,
+        intent=intent,
+        requester_user_id=requester_user_id,
+        requester_username=requester_username,
+        requester_display_name=requester_display_name,
+        ignored_usernames=ignored_usernames,
+        recent_limit=recent_limit,
+        semantic_limit=semantic_limit,
+        recent_context_fn=recent_context_fn,
+        long_term_context_fn=long_term_context_fn,
+        semantic_retrieval_fn=semantic_retrieval_fn,
+        semantic_context_fn=semantic_context_fn,
+        user_profile_context_fn=user_profile_context_fn,
+        requester_profile_context_fn=requester_profile_context_fn,
+    )
+    scored = dedupe_candidates(score_candidates(candidates, intent=intent, user_text=user_text))
+    return pack_context(intent=intent, contexts=contexts, candidates=scored, char_budget=char_budget)

--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -795,6 +795,36 @@ class GroupMemoryRepository:
                 return False
             raise
 
+    @staticmethod
+    def _normalise_retrieval_sources(sources: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        normalised: list[dict[str, Any]] = []
+        for source in (sources or [])[:20]:
+            if not isinstance(source, dict):
+                continue
+            source_name = str(source.get("source") or "").strip()[:80]
+            if not source_name:
+                continue
+            entry: dict[str, Any] = {"source": source_name}
+            if source.get("source_sk"):
+                entry["source_sk"] = str(source["source_sk"])[:180]
+            if source.get("memory_kind"):
+                entry["memory_kind"] = str(source["memory_kind"])[:60]
+            try:
+                entry["score"] = Decimal(str(round(float(source.get("score") or 0.0), 4)))
+            except (TypeError, ValueError):
+                entry["score"] = Decimal("0")
+            try:
+                entry["trust_level"] = int(source.get("trust_level") or 0)
+            except (TypeError, ValueError):
+                entry["trust_level"] = 0
+            if source.get("created_at") is not None:
+                try:
+                    entry["created_at"] = int(source["created_at"])
+                except (TypeError, ValueError):
+                    pass
+            normalised.append(entry)
+        return normalised
+
     def record_agent_reply(
         self,
         *,
@@ -812,6 +842,7 @@ class GroupMemoryRepository:
         requester_user_id: int | str | None = None,
         requester_username: str | None = None,
         requester_display_name: str | None = None,
+        retrieval_sources: list[dict[str, Any]] | None = None,
     ) -> None:
         now = int(time.time())
         ttl = now + 7 * 24 * 60 * 60
@@ -845,6 +876,9 @@ class GroupMemoryRepository:
             item["requester_username"] = requester_username[:160]
         if requester_display_name:
             item["requester_display_name"] = requester_display_name[:160]
+        normalised_sources = self._normalise_retrieval_sources(retrieval_sources)
+        if normalised_sources:
+            item["retrieval_sources"] = normalised_sources
         self.table.put_item(Item=item)
 
     def get_agent_reply_explanation(

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -1164,6 +1164,16 @@ def test_record_agent_reply_persists_thread_metadata():
         current_user_message="why?",
         source_message_context="Original replied-to message:\n[speaker user_id=7] What is Python?",
         parent_bot_message_id=444,
+        retrieval_sources=[
+            {
+                "source": "semantic",
+                "source_sk": "USER_FACT#42#1#2",
+                "memory_kind": "user_fact",
+                "score": 0.82,
+                "trust_level": 60,
+            },
+            {"source": "requester_profile", "source_sk": "USER#42", "score": 1.0, "trust_level": 100},
+        ],
     )
 
     item = repo.table.put_item.call_args.kwargs["Item"]
@@ -1172,6 +1182,10 @@ def test_record_agent_reply_persists_thread_metadata():
     assert item["current_user_message"] == "why?"
     assert "What is Python" in item["source_message_context"]
     assert item["parent_bot_message_id"] == 444
+    assert item["retrieval_sources"][0]["source"] == "semantic"
+    assert item["retrieval_sources"][0]["source_sk"] == "USER_FACT#42#1#2"
+    assert str(item["retrieval_sources"][0]["score"]) == "0.82"
+    assert item["retrieval_sources"][1]["source"] == "requester_profile"
 
 
 def test_group_chat_reply_prompt_resists_third_party_profile_poisoning(monkeypatch):
@@ -1342,6 +1356,10 @@ def test_answer_group_question_passes_target_profile_context(monkeypatch):
     assert repo.record_agent_reply.call_args.kwargs["answer_text"] == "Баяшат OpenSearch жайлы жиі жазады."
     assert repo.record_agent_reply.call_args.kwargs["user_message"] == "@zerde_kz_bot @bayashat кім"
     assert repo.record_agent_reply.call_args.kwargs["requester_user_id"] == 42
+    retrieval_sources = repo.record_agent_reply.call_args.kwargs["retrieval_sources"]
+    assert any(source["source"] == "semantic" for source in retrieval_sources)
+    assert any(source["source"] == "target_profile" for source in retrieval_sources)
+    assert any(source["source"] == "requester_profile" for source in retrieval_sources)
 
 
 def test_answer_group_question_blocks_subjective_ranking_without_gemini(monkeypatch):

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -1,0 +1,164 @@
+from unittest.mock import MagicMock
+
+from services.memory_retrieval import (
+    MemoryCandidate,
+    RetrievalIntent,
+    analyze_query_intent,
+    build_agent_memory_context,
+    pack_context,
+    score_candidates,
+)
+
+
+def _empty_context(*args, **kwargs) -> str:
+    return ""
+
+
+def test_analyze_query_intent_detects_self_reference_and_targets():
+    intent = analyze_query_intent(
+        "我是谁 and what do you know about @ada from yesterday?",
+        requester_user_id=42,
+        ignored_usernames={"zerde_kz_bot"},
+    )
+
+    assert intent.is_self_reference is True
+    assert intent.target_user_ids == {"42"}
+    assert intent.target_usernames == {"ada"}
+    assert intent.time_hint == "yesterday"
+
+
+def test_build_agent_memory_context_scopes_self_reference_semantic_to_requester():
+    repo = MagicMock()
+    semantic_retrieval = MagicMock(return_value=[])
+
+    bundle = build_agent_memory_context(
+        repo=repo,
+        chat_id=-100123,
+        user_text="我是谁",
+        requester_user_id=42,
+        requester_username="ada",
+        requester_display_name="Ada",
+        recent_context_fn=_empty_context,
+        long_term_context_fn=_empty_context,
+        semantic_retrieval_fn=semantic_retrieval,
+        semantic_context_fn=lambda rows: "",
+        user_profile_context_fn=_empty_context,
+        requester_profile_context_fn=lambda *args, **kwargs: "Requester profile: username=@ada",
+    )
+
+    semantic_retrieval.assert_called_once()
+    assert semantic_retrieval.call_args.kwargs["user_id"] == 42
+    assert bundle.requester_profile_context == "Requester profile: username=@ada"
+    assert bundle.retrieval_sources[0]["source"] == "requester_profile"
+
+
+def test_build_agent_memory_context_does_not_scope_non_self_reference_semantic_query():
+    repo = MagicMock()
+    semantic_retrieval = MagicMock(return_value=[])
+
+    build_agent_memory_context(
+        repo=repo,
+        chat_id=-100123,
+        user_text="what did we decide about S3 Vectors?",
+        requester_user_id=42,
+        recent_context_fn=_empty_context,
+        long_term_context_fn=_empty_context,
+        semantic_retrieval_fn=semantic_retrieval,
+        semantic_context_fn=lambda rows: "",
+        user_profile_context_fn=_empty_context,
+        requester_profile_context_fn=_empty_context,
+    )
+
+    assert semantic_retrieval.call_args.kwargs["user_id"] is None
+
+
+def test_build_agent_memory_context_injects_target_profile_context():
+    repo = MagicMock()
+
+    bundle = build_agent_memory_context(
+        repo=repo,
+        chat_id=-100123,
+        user_text="@bayashat кім?",
+        recent_context_fn=_empty_context,
+        long_term_context_fn=_empty_context,
+        semantic_retrieval_fn=MagicMock(return_value=[]),
+        semantic_context_fn=lambda rows: "",
+        user_profile_context_fn=lambda *args, **kwargs: "Trusted profile: username=@bayashat",
+        requester_profile_context_fn=_empty_context,
+    )
+
+    assert bundle.intent.target_usernames == {"bayashat"}
+    assert bundle.user_profile_context == "Trusted profile: username=@bayashat"
+    assert any(source["source"] == "target_profile" for source in bundle.retrieval_sources)
+
+
+def test_joke_intent_preserves_joke_candidate_and_non_joke_query_penalizes_it():
+    joke = MemoryCandidate(
+        source="semantic",
+        source_sk="JOKE#1#2",
+        memory_kind="joke",
+        text="The banana deploy meme is a recurring group joke.",
+        score=0.6,
+        trust_level=60,
+        created_at=None,
+        metadata={},
+    )
+    event = MemoryCandidate(
+        source="semantic",
+        source_sk="EVENT#1#3",
+        memory_kind="event",
+        text="The group chose S3 Vectors for retrieval.",
+        score=0.6,
+        trust_level=60,
+        created_at=None,
+        metadata={},
+    )
+
+    joke_intent = analyze_query_intent("what is the banana meme?")
+    joke_scored = score_candidates([joke], intent=joke_intent, user_text="what is the banana meme?")
+    non_joke_intent = analyze_query_intent("what did we choose for retrieval?")
+    non_joke_scored = score_candidates(
+        [joke, event], intent=non_joke_intent, user_text="what did we choose for retrieval?"
+    )
+
+    assert joke_scored[0].memory_kind == "joke"
+    joke_score = next(candidate.score for candidate in non_joke_scored if candidate.memory_kind == "joke")
+    event_score = next(candidate.score for candidate in non_joke_scored if candidate.memory_kind == "event")
+    assert joke_score < event_score
+
+
+def test_pack_context_respects_char_budget():
+    intent = RetrievalIntent(
+        is_self_reference=False,
+        target_usernames=set(),
+        target_user_ids=set(),
+        asks_group_decision=False,
+        asks_past_event=False,
+        asks_joke_or_meme=False,
+        time_hint=None,
+    )
+    bundle = pack_context(
+        intent=intent,
+        contexts={
+            "requester_profile_context": "requester line",
+            "user_profile_context": "target line",
+            "semantic_memory_context": "semantic line",
+            "long_term_memory_context": "long term line",
+            "recent_context": "recent line",
+        },
+        candidates=[],
+        char_budget=26,
+    )
+
+    total_chars = sum(
+        len(value)
+        for value in (
+            bundle.requester_profile_context,
+            bundle.user_profile_context,
+            bundle.semantic_memory_context,
+            bundle.long_term_memory_context,
+            bundle.recent_context,
+        )
+    )
+    assert total_chars <= 26
+    assert bundle.requester_profile_context == "requester line"


### PR DESCRIPTION
## Summary
- Add `services/memory_retrieval.py` with Retrieval Pipeline V1 dataclasses and steps for query intent, candidate retrieval, local scoring, dedupe, context packing, and source metadata.
- Wire `answer_group_question()` through `build_agent_memory_context()` while preserving the existing profile, semantic, long-term, and recent context helpers.
- Persist compact `retrieval_sources` metadata on `AGENT_REPLY#...` records so `/agent why` can expose memory sources later.
- Update architecture docs and repo guidance to describe the retrieval pipeline and new reply metadata.

## Behavior notes
- Self-reference queries still scope semantic retrieval to the requester `user_id`.
- Target username queries still inject trusted target-user profile context.
- First version keeps retrieval thin: it tracks, scores, dedupes, and packs sources locally without replacing the existing retrievers.
- Jokes/memes get a local score boost only for joke/meme intent and are penalized otherwise.

## Validation
- `uv run pytest tests/test_memory_retrieval.py tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`

No CDK synth/diff run because this PR does not touch infrastructure.