### PR TITLE
FEATURE: user-facing memory controls

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -95,7 +95,7 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 - `services/group_memory_processor.py` — async long-term extraction task orchestration and daily summaries.
 - `services/group_agent.py` — agent trigger policy, proactive gating, reply-thread continuity, answer-length policy.
 - `services/vector_memory.py` — embedding, S3 Vectors indexing, semantic retrieval, cleanup/backfill.
-- `services/repositories/group_memory.py` — DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters.
+- `services/repositories/group_memory.py` — DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters, and targeted memory deletion helpers.
 - `services/ai/gemini_client.py` — Gemini calls for agent answers, proactive decisions, summaries, embeddings.
 - `services/spam/` — rule-based spam screening plus Groq async checks.
 
@@ -108,7 +108,7 @@ Single table partitioned by `pk=CHAT#<chat_id>`:
 - `USER#<user_id>` — profile from the user's own messages only.
 - `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...` — long-term memories.
 - `DAILY_SUMMARY#YYYY-MM-DD` — compressed daily group memory.
-- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, retrieval source metadata, and reason for reply-thread continuity and `/agent why`.
+- `AGENT_REPLY#<bot_message_id>` — bot answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, retrieval source metadata, and reason for reply-thread continuity, `/agent why`, and `/memory forget this`.
 - `VECTOR_BACKFILL` — vector backfill status.
 - `PROACTIVE#YYYYMMDD` — daily proactive reply reservation counter.
 
@@ -140,6 +140,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Prompt pollution control**: do not inject unfiltered recent long-term memories into answers; filter by query or use vector retrieval.
 - **Vector retrieval discipline**: use chat metadata filters, requester filters for self-reference when available, and distance cutoffs before adding semantic memories to prompts.
 - **Memory Retrieval Pipeline V1**: `services.memory_retrieval.build_agent_memory_context` wraps existing profile, semantic, long-term, and recent context builders, tracks candidate sources, scores/dedupes locally, and persists compact retrieval source metadata for future `/agent why` explanations.
+- **User-facing memory controls**: `/memory about me` shows only the current user's own profile. `/memory forget this` deletes memory tied to a replied bot answer's recorded source keys or a replied source message, with vector cleanup when configured. Regular users can delete only their own memory; the group owner or bot owner can delete group memory.
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".
 - **S3 Vectors IAM**: metadata-filtered queries and `returnMetadata=True` require both `s3vectors:QueryVectors` and `s3vectors:GetVectors`.
 - **Reply-thread control**: follow-up replies should stay short and should only continue when the reply-to-bot message is a clear question or request; reactions, thanks, laughter, and short comments stay silent.

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -41,7 +41,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - `src/bot/services/group_memory_processor.py`: async long-term extraction task orchestration and daily summaries.
 - `src/bot/vector_indexer_main.py`: dedicated vector memory SQS Lambda entrypoint.
 - `src/bot/services/vector_memory.py`: Gemini embeddings, S3 Vectors indexing/retrieval with metadata filters and distance cutoffs, vector cleanup/backfill.
-- `src/bot/services/repositories/group_memory.py`: DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, and proactive counters.
+- `src/bot/services/repositories/group_memory.py`: DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters, and targeted memory deletion helpers.
 - `src/news/`: scheduled news digest Lambda.
 - `src/quiz/`: scheduled and on-demand quiz Lambda.
 - `src/shared/python/zerde_common/`: shared Lambda layer utilities.
@@ -64,6 +64,8 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Reply-to-bot follow-ups should include the captured quoted source message, previous user request, previous bot answer, and current follow-up when available.
 - Do not answer every reply to a bot message; pure reactions, thanks, laughter, and short comments should be locally skipped unless the user explicitly mentions the bot.
 - Store useful bot answer metadata in `AGENT_REPLY#...` so `/agent why` and thread continuation work.
+- Keep `/agent why` explainable without exposing full memory text: show trigger, reason, confidence, and source types/counts only.
+- Keep `/memory about me` scoped to the requester profile derived from their own messages, and keep `/memory forget this` permission-scoped to own memory unless the caller is the group owner or bot owner.
 - Keep proactive participation conservative: local open-question prefilter, bot-behavior-meta/stop-cue exclusions, recent bot activity penalty, Gemini decision, and daily limit.
 - Do not suppress proactive technical/product questions merely because they mention "bot"/"бот"; score multilingual technical, suggestion, and group-request cues across Kazakh, Russian, English, and Chinese; local prefilter skips for open-question candidates should log structured reasons.
 - Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Zerde is no longer "just call an LLM with the latest message." The bot now has:
 - **User profiles**: lightweight per-user context derived from each user's own messages.
 - **Long-term memory**: schema-based extracted `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, and `DAILY_SUMMARY#...` items, with rule fallback.
 - **Hybrid RAG**: long-term memories embedded with Gemini for S3 Vectors semantic retrieval, plus DynamoDB lexical fallback and local reranking.
-- **Agent behavior**: explicit `/ask`, @mention handling, self-reference grounding, reply-to-bot thread continuity, conservative proactive reply gating, reply-length budgeting, and `/agent why`.
-- **Memory controls**: `/memory`, `/agent`, `/memory forget me` with related vector/summary cleanup, and owner-only group cleanup commands.
+- **Agent behavior**: explicit `/ask`, @mention handling, self-reference grounding, reply-to-bot thread continuity, conservative proactive reply gating, reply-length budgeting, and `/agent why` source summaries.
+- **Memory controls**: `/memory`, `/agent`, `/memory about me`, `/memory forget me`, and `/memory forget this` with related vector cleanup and owner-only group cleanup commands.
 
 RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, then ask the LLM to answer with that context. Zerde uses RAG as one layer inside a larger group-chat agent.
 
@@ -106,8 +106,9 @@ For the deeper developer map, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 | `/voteban` | Everyone | Reply to a message to start a ban vote. |
 | `/quizstats` | Everyone | Personal quiz score, streak, and rank. |
 | `/ask <question>` | Everyone in memory-enabled groups | Ask the agent; can be used as a reply to another message and understands “who am I” from requester identity. |
-| `/memory on/off/status/forget ...` | Group owner or bot owner for settings | Manage group memory and cleanup, including user-related vectors and matching daily summaries. |
-| `/agent on/off/status/why` | Group owner or bot owner for settings | Manage agent participation and inspect why the bot replied. `/agent off` disables proactive, mention, and reply-thread participation; `/ask` remains available if memory is on. |
+| `/memory about me` | Everyone | Show the current user's own stored profile fields without showing other users' claims. |
+| `/memory on/off/status/forget ...` | Group owner or bot owner for settings; users can delete their own memory | Manage group memory and cleanup. `forget this` can delete memory tied to a replied bot answer or source message, with vector cleanup when configured. |
+| `/agent on/off/status/why` | Group owner or bot owner for settings | Manage agent participation and inspect why the bot replied, including memory source types and counts without full memory text. `/agent off` disables proactive, mention, and reply-thread participation; `/ask` remains available if memory is on. |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,7 @@ The table is single-table by chat partition:
 | `sk=GROUP_FACT#...` | Group decision or shared preference. |
 | `sk=JOKE#...` | Possible recurring joke or meme. Use carefully; this is easy to over-retrieve. |
 | `sk=DAILY_SUMMARY#YYYY-MM-DD` | Daily compressed memory for imported or observed messages. |
-| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, and compact retrieval source metadata for reply-thread continuity. |
+| `sk=AGENT_REPLY#<bot_message_id>` | Bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, parent bot message id, requester metadata, and compact retrieval source metadata for reply-thread continuity, `/agent why`, and `/memory forget this`. |
 | `sk=VECTOR_BACKFILL` | Last vector backfill status for a chat. |
 | `sk=PROACTIVE#YYYYMMDD` | Daily proactive reply reservation counter. |
 
@@ -128,6 +128,8 @@ The returned bundle keeps these prompt sections:
 6. Reply-thread context when the user replies to the bot's previous answer, including the captured original quoted message, previous user request, previous bot answer, and current follow-up when available.
 
 The local reranker treats requester profiles as highest trust for self-reference, target-user profiles above ordinary memory, user facts above daily summaries, and jokes as low priority unless the query explicitly asks for a joke or meme. Exact lexical matches boost codes, usernames, and technical terms such as `E1027`, `S3`, or `OpenSearch`; semantic distance, trust level, target-user match, recency, and memory confidence are also considered. If a query has no usable relevance terms, lexical long-term memory is not injected into the answer path.
+
+`/agent why` reads the latest or replied `AGENT_REPLY#...` item and shows trigger, reason, confidence, and only memory source types/counts such as requester profile, semantic memory, lexical memory, long-term group memory, and recent context. It intentionally does not print full memory text.
 
 Memory safety filters apply before context reaches the model. Raw `MSG#...` items can remain in DynamoDB for audit/recent history, but messages that look like future-answer directives ("when someone asks X, answer Y"), self-promotion, or subjective people rankings ("best in the chat", "strongest developer", "ең мықты") are excluded from profile learning, long-term memory classification, daily summaries, vector indexing, recent prompt context, semantic prompt context, and lexical fallback context.
 
@@ -164,7 +166,7 @@ S3 Vectors is used for semantic retrieval over trusted long-term memory:
 - Provider: `VECTOR_MEMORY_PROVIDER=s3_vectors`.
 - Retrieval distance cutoff: `VECTOR_MEMORY_MAX_DISTANCE` (default `0.85`) filters out distant vector matches before prompt injection.
 - Vectorizable items: `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, `DAILY_SUMMARY#`.
-- Cleanup commands should delete both DynamoDB memory and associated vector keys when available. `/memory forget me` also removes daily summaries that mention the forgotten user's stored display name or username.
+- Cleanup commands should delete both DynamoDB memory and associated vector keys when available. `/memory about me` shows only the current user's profile derived from their own messages. `/memory forget me` removes that user's profile, raw messages, user facts, and matching daily summaries. `/memory forget this` can be used as a reply to a bot answer to delete recorded retrieval-source memory, or as a reply to a source message to delete the stored raw `MSG#...` item and long-term memory derived from that message. Regular users can delete only memory tied to their own messages; the group owner or bot owner can delete group memory.
 - Runtime IAM must include `s3vectors:GetVectors` together with `s3vectors:QueryVectors` because retrieval uses metadata filters and asks S3 Vectors to return metadata.
 - Retrieval, S3 query, context injection, and indexing success paths emit INFO logs with safe operational fields such as counts, filters, distance cutoffs, and vector dimensions.
 - Vector indexing runs in the dedicated vector-indexer Lambda, with its own log group and Lambda alarms. The bot Lambda can still query/delete vectors for retrieval and memory cleanup, but it no longer consumes the vector memory queue.

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -24,8 +24,8 @@ Zerde енді тек “соңғы хабарламаны LLM-ге жібере
 - **User profiles**: әр адамның өз хабарламаларынан алынған жеңіл profile.
 - **Long-term memory**: structured schema арқылы алынатын `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, `DAILY_SUMMARY#...`, rule fallback бар.
 - **Hybrid RAG**: long-term memory Gemini embedding арқылы S3 Vectors semantic retrieval-ге түседі, ал DynamoDB lexical fallback және local reranking exact терминдерді ұстайды.
-- **Agent behavior**: `/ask`, @mention, self-reference grounding, bot жауабына reply follow-up, conservative proactive reply gating, жауап ұзындығын басқару, `/agent why`.
-- **Memory controls**: `/memory`, `/agent`, `/memory forget me` related vector/summary cleanup-пен, owner-only group cleanup.
+- **Agent behavior**: `/ask`, @mention, self-reference grounding, bot жауабына reply follow-up, conservative proactive reply gating, жауап ұзындығын басқару, `/agent why` source summary.
+- **Memory controls**: `/memory`, `/agent`, `/memory about me`, `/memory forget me`, `/memory forget this` related vector cleanup-пен, owner-only group cleanup.
 
 RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен релевант memory/document іздеу, содан кейін LLM-ге сол контекстпен жауап бергізу. Zerde-де RAG — үлкенірек agentic bot архитектурасының бір қабаты.
 
@@ -102,8 +102,9 @@ flowchart LR
 | `/voteban` | Барлығына | Reply арқылы ban vote бастау. |
 | `/quizstats` | Барлығына | Жеке quiz score, streak, rank. |
 | `/ask <question>` | Memory қосылған топтарда | Agent-ке сұрақ қою; басқа хабарламаға reply ретінде де қолдануға болады және “мен кіммін” сияқты сұрақтарды requester identity арқылы түсінеді. |
-| `/memory on/off/status/forget ...` | Group owner немесе bot owner | Group memory басқару және user-related vectors/matching daily summaries cleanup. |
-| `/agent on/off/status/why` | Group owner немесе bot owner | Agent participation басқару және bot неге жауап бергенін көру. `/agent off` proactive, mention және reply-thread қатысуын өшіреді; жад қосулы болса, `/ask` қолжетімді. |
+| `/memory about me` | Барлығына | Current user-дің өз хабарламаларынан сақталған profile fields көрсету; басқа адамдардың бағасын көрсетпейді. |
+| `/memory on/off/status/forget ...` | Settings үшін group owner немесе bot owner; users өз memory өшіре алады | Group memory басқару және cleanup. `forget this` reply жасалған bot answer/source message-ке байланысты memory өшіреді, vector cleanup configured болса бірге жүреді. |
+| `/agent on/off/status/why` | Group owner немесе bot owner | Agent participation басқару және bot неге жауап бергенін көру; memory source түрлері/count көрсетіледі, толық memory text көрсетілмейді. `/agent off` proactive, mention және reply-thread қатысуын өшіреді; жад қосулы болса, `/ask` қолжетімді. |
 
 ---
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -24,8 +24,8 @@ Zerde больше не просто отправляет последнее с�
 - **User profiles**: легкий профиль пользователя, построенный только из его собственных сообщений.
 - **Long-term memory**: `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, `JOKE#...`, `DAILY_SUMMARY#...`, извлекаемые по structured schema с rule fallback.
 - **Hybrid RAG**: long-term memory эмбеддится через Gemini для S3 Vectors semantic retrieval, плюс DynamoDB lexical fallback и local reranking.
-- **Agent behavior**: `/ask`, @mention, self-reference grounding, follow-up через reply на ответ бота, conservative proactive reply gating, контроль длины ответа, `/agent why`.
-- **Memory controls**: `/memory`, `/agent`, `/memory forget me` с related vector/summary cleanup, owner-only group cleanup.
+- **Agent behavior**: `/ask`, @mention, self-reference grounding, follow-up через reply на ответ бота, conservative proactive reply gating, контроль длины ответа, `/agent why` source summary.
+- **Memory controls**: `/memory`, `/agent`, `/memory about me`, `/memory forget me`, `/memory forget this` с related vector cleanup, owner-only group cleanup.
 
 RAG означает **Retrieval-Augmented Generation**: сначала найти релевантную память или документы, затем дать LLM этот контекст для ответа. В Zerde RAG — один слой внутри более широкой agentic bot архитектуры.
 
@@ -102,8 +102,9 @@ flowchart LR
 | `/voteban` | Все | Начать голосование за ban, ответив на сообщение. |
 | `/quizstats` | Все | Личный quiz score, streak и rank. |
 | `/ask <question>` | В memory-enabled группах | Задать вопрос agent-у; можно использовать reply на сообщение, включая self-reference вроде “кто я”. |
-| `/memory on/off/status/forget ...` | Group owner или bot owner | Управление group memory и cleanup, включая user-related vectors и matching daily summaries. |
-| `/agent on/off/status/why` | Group owner или bot owner | Управление участием agent-а и объяснение, почему бот ответил. `/agent off` выключает proactive, mention и reply-thread участие; `/ask` остается доступен, если память включена. |
+| `/memory about me` | Все | Показать profile fields текущего пользователя, сохраненные из его собственных сообщений, без чужих оценок. |
+| `/memory on/off/status/forget ...` | Group owner или bot owner для settings; users могут удалить свою memory | Управление group memory и cleanup. `forget this` удаляет memory, связанную с replied bot answer или source message, с vector cleanup если настроен. |
+| `/agent on/off/status/why` | Group owner или bot owner | Управление участием agent-а и объяснение, почему бот ответил, включая типы/count источников памяти без полного текста memory. `/agent off` выключает proactive, mention и reply-thread участие; `/ask` остается доступен, если память включена. |
 
 ---
 

--- a/src/bot/core/translations.py
+++ b/src/bot/core/translations.py
@@ -115,7 +115,9 @@ TRANSLATIONS = {
             "• <code>/memory on</code> — enable group memory\n"
             "• <code>/memory off</code> — disable memory and agent\n"
             "• <code>/memory status</code> — show memory status\n"
+            "• <code>/memory about me</code> — show what I know from your own messages\n"
             "• <code>/memory forget me</code> — delete your memory in this group\n"
+            "• <code>/memory forget this</code> — reply to a bot answer or source message and delete related memory\n"
             "• <code>/memory forget group</code> — delete all group memory"
         ),
         "agent_usage": (
@@ -162,6 +164,24 @@ TRANSLATIONS = {
         "forget_group_done": "🧹 Deleted {deleted} memory items for this group.\n{vector_note}",
         "forget_me_no_user": "❌ I could not identify your Telegram user id.",
         "forget_me_done": "🧹 Deleted {deleted} memory items linked to you in this group.\n{vector_note}",
+        "memory_about_me_empty": "🧠 I do not have a stored profile for you in this group yet.",
+        "memory_about_me_message": (
+            "🧠 <b>I know this from your own messages:</b>\n"
+            "- language style: {language_style}\n"
+            "- common topics: {common_topics}\n"
+            "- self-stated preferences: {preferences}\n"
+            "- self-stated background: {background}\n"
+            "- boundaries: {boundaries}\n\n"
+            "Use <code>/memory forget me</code> to remove your stored user memory."
+        ),
+        "forget_this_usage": ("Reply to a bot answer or source message with <code>/memory forget this</code>."),
+        "forget_this_not_allowed": (
+            "❌ You can only delete memory linked to your own messages. "
+            "The group owner or bot owner can delete group memory."
+        ),
+        "forget_this_no_sources": "🧠 That bot answer has no deletable recorded memory sources.",
+        "forget_this_nothing_deleted": "🧠 I did not find stored memory for that message.",
+        "forget_this_done": "🧹 Deleted {deleted} related memory item(s).\n{vector_note}",
         "vector_configured_yes": "yes",
         "vector_configured_no": "no",
         "vector_backfill_none": "-",
@@ -173,8 +193,22 @@ TRANSLATIONS = {
         "vector_cleanup_delayed": "Vector memory cleanup was not fully confirmed; stored memory was still deleted.",
         "why_reply_missing": "🤷 I do not have a recorded reason for that reply.",
         "why_reply_message": (
-            "🧾 <b>Why I replied</b>\n" "Reason: {reason}\n" "Trigger: {trigger}\n" "Confidence: {confidence}"
+            "🧾 <b>Why I replied</b>\n"
+            "Reason: {reason}\n"
+            "Trigger: {trigger}\n"
+            "Confidence: {confidence}\n"
+            "{sources}"
         ),
+        "why_sources_none": "Memory sources: none recorded",
+        "why_sources_header": "Memory sources:",
+        "why_sources_item": "- {label}: {value}",
+        "why_source_yes": "yes",
+        "why_source_requester_profile": "requester profile",
+        "why_source_target_profile": "target profile",
+        "why_source_semantic": "semantic memory",
+        "why_source_lexical": "lexical memory",
+        "why_source_long_term": "long-term group memory",
+        "why_source_recent": "recent context",
         "genquiz_lambda_not_configured": "❌ Quiz Lambda is not configured.",
         "genquiz_usage": (
             "❌ Usage: /genquiz &lt;topic&gt; [&lt;difficulty&gt; [&lt;lang&gt;]]\n"
@@ -333,7 +367,9 @@ TRANSLATIONS = {
             "• <code>/memory on</code> — топ жадын қосу\n"
             "• <code>/memory off</code> — жад пен agent режимін өшіру\n"
             "• <code>/memory status</code> — жад күйін көрсету\n"
+            "• <code>/memory about me</code> — өз хабарламаларыңыздан не білгенімді көрсету\n"
             "• <code>/memory forget me</code> — осы топтағы өз жадыңызды өшіру\n"
+            "• <code>/memory forget this</code> — bot жауабына не source хабарламаға reply жасап қатысты жадты өшіру\n"
             "• <code>/memory forget group</code> — топтың барлық жадын өшіру"
         ),
         "agent_usage": (
@@ -380,6 +416,26 @@ TRANSLATIONS = {
         "forget_group_done": "🧹 Бұл топ үшін {deleted} жад элементі өшірілді.\n{vector_note}",
         "forget_me_no_user": "❌ Telegram user id-іңізді анықтай алмадым.",
         "forget_me_done": "🧹 Осы топта сізге қатысты {deleted} жад элементі өшірілді.\n{vector_note}",
+        "memory_about_me_empty": "🧠 Бұл топта сіз туралы сақталған профиль әлі жоқ.",
+        "memory_about_me_message": (
+            "🧠 <b>Өз хабарламаларыңыздан мынаны білемін:</b>\n"
+            "- тіл стилі: {language_style}\n"
+            "- жиі тақырыптар: {common_topics}\n"
+            "- өзіңіз айтқан қалаулар: {preferences}\n"
+            "- өзіңіз айтқан background: {background}\n"
+            "- шекаралар: {boundaries}\n\n"
+            "Сақталған user memory өшіру үшін <code>/memory forget me</code> қолданыңыз."
+        ),
+        "forget_this_usage": (
+            "Bot жауабына немесе source хабарламаға reply жасап <code>/memory forget this</code> жіберіңіз."
+        ),
+        "forget_this_not_allowed": (
+            "❌ Тек өз хабарламаларыңызға байланысты жадты өшіре аласыз. "
+            "Топ иесі немесе bot owner group memory өшіре алады."
+        ),
+        "forget_this_no_sources": "🧠 Бұл bot жауабында өшіруге болатын жазылған memory source жоқ.",
+        "forget_this_nothing_deleted": "🧠 Ол хабарлама үшін сақталған жад таппадым.",
+        "forget_this_done": "🧹 Қатысты {deleted} жад элементі өшірілді.\n{vector_note}",
         "vector_configured_yes": "иә",
         "vector_configured_no": "жоқ",
         "vector_backfill_none": "-",
@@ -391,8 +447,22 @@ TRANSLATIONS = {
         "vector_cleanup_delayed": "Vector жадын тазалау толық расталмады; сақталған жад бәрібір өшірілді.",
         "why_reply_missing": "🤷 Бұл жауап үшін жазылған себеп табылмады.",
         "why_reply_message": (
-            "🧾 <b>Неге жауап бердім</b>\n" "Себеп: {reason}\n" "Триггер: {trigger}\n" "Сенімділік: {confidence}"
+            "🧾 <b>Неге жауап бердім</b>\n"
+            "Себеп: {reason}\n"
+            "Триггер: {trigger}\n"
+            "Сенімділік: {confidence}\n"
+            "{sources}"
         ),
+        "why_sources_none": "Memory sources: жазылмаған",
+        "why_sources_header": "Memory sources:",
+        "why_sources_item": "- {label}: {value}",
+        "why_source_yes": "иә",
+        "why_source_requester_profile": "сұраушы профилі",
+        "why_source_target_profile": "нысан user профилі",
+        "why_source_semantic": "semantic memory",
+        "why_source_lexical": "lexical memory",
+        "why_source_long_term": "ұзақ мерзімді group memory",
+        "why_source_recent": "соңғы контекст",
         "genquiz_lambda_not_configured": "❌ Quiz Lambda бапталмаған.",
         "genquiz_usage": (
             "❌ Қолданылуы: /genquiz &lt;тақырып&gt; [&lt;деңгей&gt; [&lt;тіл&gt;]]\n"
@@ -543,7 +613,9 @@ TRANSLATIONS = {
             "• <code>/memory on</code> — 开启群记忆\n"
             "• <code>/memory off</code> — 关闭记忆和 agent\n"
             "• <code>/memory status</code> — 查看记忆状态\n"
+            "• <code>/memory about me</code> — 查看我从你自己的消息中记住了什么\n"
             "• <code>/memory forget me</code> — 删除你在本群的记忆\n"
+            "• <code>/memory forget this</code> — 回复 bot 答案或来源消息并删除相关记忆\n"
             "• <code>/memory forget group</code> — 删除整个群的记忆"
         ),
         "agent_usage": (
@@ -588,6 +660,21 @@ TRANSLATIONS = {
         "forget_group_done": "🧹 已删除本群 {deleted} 条记忆。\n{vector_note}",
         "forget_me_no_user": "❌ 我无法识别你的 Telegram user id。",
         "forget_me_done": "🧹 已删除本群与你相关的 {deleted} 条记忆。\n{vector_note}",
+        "memory_about_me_empty": "🧠 我还没有在这个群里保存你的画像。",
+        "memory_about_me_message": (
+            "🧠 <b>我从你自己的消息中知道这些：</b>\n"
+            "- 语言风格：{language_style}\n"
+            "- 常见话题：{common_topics}\n"
+            "- 自述偏好：{preferences}\n"
+            "- 自述背景：{background}\n"
+            "- 边界：{boundaries}\n\n"
+            "使用 <code>/memory forget me</code> 删除你的用户记忆。"
+        ),
+        "forget_this_usage": "请回复一条 bot 答案或来源消息，并发送 <code>/memory forget this</code>。",
+        "forget_this_not_allowed": "❌ 你只能删除与你自己消息相关的记忆。群主或 bot owner 可以删除群记忆。",
+        "forget_this_no_sources": "🧠 那条 bot 答案没有可删除的已记录记忆来源。",
+        "forget_this_nothing_deleted": "🧠 我没有找到那条消息对应的已存记忆。",
+        "forget_this_done": "🧹 已删除 {deleted} 条相关记忆。\n{vector_note}",
         "vector_configured_yes": "是",
         "vector_configured_no": "否",
         "vector_backfill_none": "-",
@@ -598,7 +685,19 @@ TRANSLATIONS = {
         "vector_cleanup_skipped": "未配置向量记忆清理。",
         "vector_cleanup_delayed": "向量记忆清理未完全确认；已删除存储记忆。",
         "why_reply_missing": "🤷 我没有找到那条回复的记录原因。",
-        "why_reply_message": ("🧾 <b>我为什么回复</b>\n" "原因：{reason}\n" "触发：{trigger}\n" "置信度：{confidence}"),
+        "why_reply_message": (
+            "🧾 <b>我为什么回复</b>\n" "原因：{reason}\n" "触发：{trigger}\n" "置信度：{confidence}\n" "{sources}"
+        ),
+        "why_sources_none": "记忆来源：未记录",
+        "why_sources_header": "记忆来源：",
+        "why_sources_item": "- {label}: {value}",
+        "why_source_yes": "是",
+        "why_source_requester_profile": "提问者画像",
+        "why_source_target_profile": "目标用户画像",
+        "why_source_semantic": "语义记忆",
+        "why_source_lexical": "词面记忆",
+        "why_source_long_term": "长期群记忆",
+        "why_source_recent": "近期上下文",
         "genquiz_lambda_not_configured": "❌ Quiz Lambda 未配置。",
         "genquiz_usage": (
             "❌ 用法：/genquiz &lt;主题&gt; [&lt;难度&gt; [&lt;语言&gt;]]\n"
@@ -750,7 +849,10 @@ TRANSLATIONS = {
             "• <code>/memory on</code> — включить память группы\n"
             "• <code>/memory off</code> — выключить память и agent\n"
             "• <code>/memory status</code> — показать статус памяти\n"
+            "• <code>/memory about me</code> — показать, что я знаю из ваших сообщений\n"
             "• <code>/memory forget me</code> — удалить вашу память в этой группе\n"
+            "• <code>/memory forget this</code> — ответьте на ответ бота или source-сообщение "
+            "и удалите связанную память\n"
             "• <code>/memory forget group</code> — удалить всю память группы"
         ),
         "agent_usage": (
@@ -799,6 +901,24 @@ TRANSLATIONS = {
         "forget_group_done": "🧹 Удалено элементов памяти для этой группы: {deleted}.\n{vector_note}",
         "forget_me_no_user": "❌ Я не смог определить ваш Telegram user id.",
         "forget_me_done": "🧹 Удалено элементов памяти, связанных с вами в этой группе: {deleted}.\n{vector_note}",
+        "memory_about_me_empty": "🧠 У меня пока нет сохраненного профиля для вас в этой группе.",
+        "memory_about_me_message": (
+            "🧠 <b>Я знаю это из ваших собственных сообщений:</b>\n"
+            "- стиль языка: {language_style}\n"
+            "- частые темы: {common_topics}\n"
+            "- заявленные предпочтения: {preferences}\n"
+            "- заявленный background: {background}\n"
+            "- границы: {boundaries}\n\n"
+            "Используйте <code>/memory forget me</code>, чтобы удалить вашу user memory."
+        ),
+        "forget_this_usage": ("Ответьте на ответ бота или source-сообщение командой <code>/memory forget this</code>."),
+        "forget_this_not_allowed": (
+            "❌ Вы можете удалять только память, связанную с вашими сообщениями. "
+            "Владелец группы или bot owner может удалять group memory."
+        ),
+        "forget_this_no_sources": "🧠 У этого ответа бота нет записанных источников памяти, которые можно удалить.",
+        "forget_this_nothing_deleted": "🧠 Я не нашел сохраненную память для этого сообщения.",
+        "forget_this_done": "🧹 Удалено связанных элементов памяти: {deleted}.\n{vector_note}",
         "vector_configured_yes": "да",
         "vector_configured_no": "нет",
         "vector_backfill_none": "-",
@@ -810,8 +930,22 @@ TRANSLATIONS = {
         "vector_cleanup_delayed": "Очистка vector-памяти не полностью подтверждена; сохраненная память удалена.",
         "why_reply_missing": "🤷 У меня нет записанной причины для этого ответа.",
         "why_reply_message": (
-            "🧾 <b>Почему я ответил</b>\n" "Причина: {reason}\n" "Триггер: {trigger}\n" "Уверенность: {confidence}"
+            "🧾 <b>Почему я ответил</b>\n"
+            "Причина: {reason}\n"
+            "Триггер: {trigger}\n"
+            "Уверенность: {confidence}\n"
+            "{sources}"
         ),
+        "why_sources_none": "Источники памяти: не записаны",
+        "why_sources_header": "Источники памяти:",
+        "why_sources_item": "- {label}: {value}",
+        "why_source_yes": "да",
+        "why_source_requester_profile": "профиль запросившего",
+        "why_source_target_profile": "профиль целевого пользователя",
+        "why_source_semantic": "семантическая память",
+        "why_source_lexical": "лексическая память",
+        "why_source_long_term": "долгосрочная память группы",
+        "why_source_recent": "недавний контекст",
         "genquiz_lambda_not_configured": "❌ Quiz Lambda не настроена.",
         "genquiz_usage": (
             "❌ Использование: /genquiz &lt;тема&gt; [&lt;сложность&gt; [&lt;язык&gt;]]\n"

--- a/src/bot/services/handlers/commands.py
+++ b/src/bot/services/handlers/commands.py
@@ -1,5 +1,9 @@
 """Simple bot commands: /start, /help, /support, /ping, /stats, /genquiz."""
 
+import html
+from collections import Counter
+from typing import Any
+
 from core.config import (
     ADMIN_USER_ID,
     AGENT_ENABLED,
@@ -17,6 +21,7 @@ from services.group_memory import display_name
 from services.handlers.quiz import react_genquiz_processing
 from services.vector_memory import (
     delete_chat_vectors,
+    delete_memory_vectors_for_items,
     delete_user_vectors,
     get_vector_index_status,
     vector_memory_configured,
@@ -285,6 +290,80 @@ def handle_memory_status(ctx: Context) -> None:
     )
 
 
+def _profile_values(value: Any, *, limit: int = 6) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    values: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        text = str(raw or "").replace("\n", " ").strip()
+        key = text.lower()
+        if text and key not in seen:
+            seen.add(key)
+            values.append(text[:160])
+        if len(values) >= limit:
+            break
+    return values
+
+
+def _profile_topics(profile: dict[str, Any], *, limit: int = 6) -> list[str]:
+    interests = _profile_values(profile.get("interests"), limit=limit)
+    if interests:
+        return interests
+    counts = profile.get("topic_counts")
+    if not isinstance(counts, dict):
+        return []
+    ranked: list[tuple[str, int]] = []
+    for raw_term, raw_count in counts.items():
+        term = str(raw_term or "").strip()
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+        if term and count > 0:
+            ranked.append((term, count))
+    ranked.sort(key=lambda item: (-item[1], item[0]))
+    return [term for term, _ in ranked[:limit]]
+
+
+def _profile_line(values: list[str]) -> str:
+    if not values:
+        return "-"
+    return ", ".join(html.escape(value) for value in values)
+
+
+def handle_memory_about_me(ctx: Context) -> None:
+    if not _require_memory_repo(ctx):
+        return
+    if not ctx.user_id:
+        ctx.reply(get_translated_text("forget_me_no_user", ctx.lang_code), ctx.message_id)
+        return
+    profile = ctx.memory_repo.get_user_profile(ctx.chat_id, ctx.user_id)
+    if not profile:
+        ctx.reply(get_translated_text("memory_about_me_empty", ctx.lang_code), ctx.message_id)
+        return
+    language_style = _profile_values(profile.get("language_style"))
+    common_topics = _profile_topics(profile)
+    preferences = _profile_values(profile.get("preferences"))
+    background = _profile_values(profile.get("known_facts"))
+    boundaries = _profile_values(profile.get("boundaries"))
+    if not any((language_style, common_topics, preferences, background, boundaries)):
+        ctx.reply(get_translated_text("memory_about_me_empty", ctx.lang_code), ctx.message_id)
+        return
+    ctx.reply(
+        get_translated_text(
+            "memory_about_me_message",
+            ctx.lang_code,
+            language_style=_profile_line(language_style),
+            common_topics=_profile_line(common_topics),
+            preferences=_profile_line(preferences),
+            background=_profile_line(background),
+            boundaries=_profile_line(boundaries),
+        ),
+        ctx.message_id,
+    )
+
+
 def handle_memory(ctx: Context) -> None:
     action = _normalized_subcommand(_command_args(ctx.text))
     if action == "on":
@@ -293,8 +372,12 @@ def handle_memory(ctx: Context) -> None:
         handle_memory_off(ctx)
     elif action == "status":
         handle_memory_status(ctx)
+    elif action == "about me":
+        handle_memory_about_me(ctx)
     elif action == "forget me":
         handle_forget_me(ctx)
+    elif action == "forget this":
+        handle_forget_this(ctx)
     elif action == "forget group":
         handle_forget_group(ctx)
     else:
@@ -428,6 +511,134 @@ def handle_forget_me(ctx: Context) -> None:
     )
 
 
+def _is_group_owner_or_bot_owner(ctx: Context) -> bool:
+    return _is_chat_owner_or_admin_user(ctx)
+
+
+def _is_reply_to_bot_message(reply_to_message: dict[str, Any]) -> bool:
+    sender = reply_to_message.get("from") if isinstance(reply_to_message, dict) else {}
+    return bool(isinstance(sender, dict) and sender.get("is_bot"))
+
+
+def _delete_items_vectors_note(ctx: Context, items: list[dict[str, Any]]) -> str:
+    if not vector_memory_configured():
+        return get_translated_text("vector_cleanup_skipped", ctx.lang_code)
+    try:
+        deleted = delete_memory_vectors_for_items(ctx.chat_id, items)
+        return get_translated_text("vector_cleanup_deleted", ctx.lang_code, deleted=deleted)
+    except Exception:
+        logger.exception("Failed to delete selected vector memory", extra={"chat_id": ctx.chat_id})
+        return get_translated_text("vector_cleanup_delayed", ctx.lang_code)
+
+
+def _source_sk_values(retrieval_sources: Any) -> list[str]:
+    if not isinstance(retrieval_sources, list):
+        return []
+    source_sks: list[str] = []
+    seen: set[str] = set()
+    for source in retrieval_sources:
+        if not isinstance(source, dict):
+            continue
+        source_sk = str(source.get("source_sk") or "").strip()
+        if source_sk and source_sk not in seen:
+            seen.add(source_sk)
+            source_sks.append(source_sk)
+    return source_sks
+
+
+def _deletable_source_sks_for_user(ctx: Context, source_sks: list[str], *, can_delete_group_memory: bool) -> list[str]:
+    if can_delete_group_memory:
+        return source_sks
+    allowed: list[str] = []
+    for source_sk in source_sks:
+        item = ctx.memory_repo.get_memory_item(ctx.chat_id, source_sk)
+        if item and ctx.user_id and ctx.memory_repo.is_memory_item_related_to_user(item, ctx.user_id):
+            allowed.append(source_sk)
+    return allowed
+
+
+def _handle_forget_this_bot_answer(ctx: Context, bot_message_id: int | str | None) -> None:
+    if bot_message_id is None:
+        ctx.reply(get_translated_text("forget_this_usage", ctx.lang_code), ctx.message_id)
+        return
+    item = ctx.memory_repo.get_agent_reply_explanation(ctx.chat_id, bot_message_id=bot_message_id)
+    if not item:
+        ctx.reply(get_translated_text("why_reply_missing", ctx.lang_code), ctx.message_id)
+        return
+    source_sks = _source_sk_values(item.get("retrieval_sources"))
+    if not source_sks:
+        ctx.reply(get_translated_text("forget_this_no_sources", ctx.lang_code), ctx.message_id)
+        return
+
+    can_delete_group_memory = _is_group_owner_or_bot_owner(ctx)
+    deletable_sks = _deletable_source_sks_for_user(
+        ctx,
+        source_sks,
+        can_delete_group_memory=can_delete_group_memory,
+    )
+    if not deletable_sks:
+        ctx.reply(get_translated_text("forget_this_not_allowed", ctx.lang_code), ctx.message_id)
+        return
+
+    deleted_items = ctx.memory_repo.delete_memory_items_by_sks(ctx.chat_id, deletable_sks)
+    if not deleted_items:
+        ctx.reply(get_translated_text("forget_this_nothing_deleted", ctx.lang_code), ctx.message_id)
+        return
+    vector_note = _delete_items_vectors_note(ctx, deleted_items)
+    ctx.reply(
+        get_translated_text(
+            "forget_this_done",
+            ctx.lang_code,
+            deleted=len(deleted_items),
+            vector_note=vector_note,
+        ),
+        ctx.message_id,
+    )
+
+
+def _handle_forget_this_source_message(ctx: Context, source_message: dict[str, Any]) -> None:
+    message_id = source_message.get("message_id")
+    if message_id is None:
+        ctx.reply(get_translated_text("forget_this_usage", ctx.lang_code), ctx.message_id)
+        return
+    can_delete_group_memory = _is_group_owner_or_bot_owner(ctx)
+    sender = source_message.get("from") if isinstance(source_message, dict) else {}
+    sender_user_id = sender.get("id") if isinstance(sender, dict) else None
+    if not can_delete_group_memory and (not ctx.user_id or str(sender_user_id) != str(ctx.user_id)):
+        ctx.reply(get_translated_text("forget_this_not_allowed", ctx.lang_code), ctx.message_id)
+        return
+
+    deleted_items = ctx.memory_repo.delete_memory_for_message(ctx.chat_id, message_id)
+    if not deleted_items:
+        ctx.reply(get_translated_text("forget_this_nothing_deleted", ctx.lang_code), ctx.message_id)
+        return
+    vector_note = _delete_items_vectors_note(ctx, deleted_items)
+    ctx.reply(
+        get_translated_text(
+            "forget_this_done",
+            ctx.lang_code,
+            deleted=len(deleted_items),
+            vector_note=vector_note,
+        ),
+        ctx.message_id,
+    )
+
+
+def handle_forget_this(ctx: Context) -> None:
+    if not _require_memory_repo(ctx):
+        return
+    if not ctx.user_id:
+        ctx.reply(get_translated_text("forget_me_no_user", ctx.lang_code), ctx.message_id)
+        return
+    if not isinstance(ctx.reply_to_message, dict):
+        ctx.reply(get_translated_text("forget_this_usage", ctx.lang_code), ctx.message_id)
+        return
+    if _is_reply_to_bot_message(ctx.reply_to_message):
+        _handle_forget_this_bot_answer(ctx, ctx.reply_to_message.get("message_id"))
+        return
+    _handle_forget_this_source_message(ctx, ctx.reply_to_message)
+
+
 def _delete_chat_vectors_note(ctx: Context) -> str:
     if not vector_memory_configured():
         return get_translated_text("vector_cleanup_skipped", ctx.lang_code)
@@ -448,6 +659,51 @@ def _delete_user_vectors_note(ctx: Context, user_id: int | str) -> str:
     except Exception:
         logger.exception("Failed to delete user vector memory", extra={"chat_id": ctx.chat_id, "user_id": user_id})
         return get_translated_text("vector_cleanup_delayed", ctx.lang_code)
+
+
+_WHY_SOURCE_ORDER = (
+    "requester_profile",
+    "target_profile",
+    "semantic",
+    "lexical",
+    "long_term",
+    "recent",
+)
+_WHY_PRESENCE_SOURCES = {"requester_profile", "target_profile", "recent"}
+
+
+def _agent_source_label(source: str, lang: str) -> str:
+    key = {
+        "requester_profile": "why_source_requester_profile",
+        "target_profile": "why_source_target_profile",
+        "semantic": "why_source_semantic",
+        "lexical": "why_source_lexical",
+        "long_term": "why_source_long_term",
+        "recent": "why_source_recent",
+    }.get(source)
+    return get_translated_text(key, lang) if key else html.escape(source.replace("_", " "))
+
+
+def _format_agent_memory_sources(retrieval_sources: Any, lang: str) -> str:
+    counts: Counter[str] = Counter()
+    if isinstance(retrieval_sources, list):
+        for source in retrieval_sources:
+            if not isinstance(source, dict):
+                continue
+            source_name = str(source.get("source") or "").strip()
+            if source_name:
+                counts[source_name] += 1
+    if not counts:
+        return get_translated_text("why_sources_none", lang)
+
+    lines = [get_translated_text("why_sources_header", lang)]
+    ordered_sources = [source for source in _WHY_SOURCE_ORDER if counts.get(source)]
+    ordered_sources.extend(sorted(source for source in counts if source not in _WHY_SOURCE_ORDER))
+    for source in ordered_sources:
+        label = _agent_source_label(source, lang)
+        value = get_translated_text("why_source_yes", lang) if source in _WHY_PRESENCE_SOURCES else str(counts[source])
+        lines.append(get_translated_text("why_sources_item", lang, label=label, value=value))
+    return "\n".join(lines)
 
 
 def handle_why_reply(ctx: Context) -> None:
@@ -474,6 +730,7 @@ def handle_why_reply(ctx: Context) -> None:
             reason=reason,
             trigger=trigger_kind,
             confidence=f"{float(confidence):.2f}" if confidence is not None else "-",
+            sources=_format_agent_memory_sources(item.get("retrieval_sources"), ctx.lang_code),
         ),
         ctx.message_id,
     )

--- a/src/bot/services/repositories/group_memory.py
+++ b/src/bot/services/repositories/group_memory.py
@@ -269,6 +269,132 @@ class GroupMemoryRepository:
             or (sk.startswith("DAILY_SUMMARY#") and self._daily_summary_mentions_terms(item, cleanup_terms))
         )
 
+    @classmethod
+    def is_memory_item_related_to_user(cls, item: dict[str, Any], user_id: int | str) -> bool:
+        """Return whether a stored memory item directly belongs to one user."""
+        user_id_str = str(user_id)
+        sk = str(item.get("sk") or "")
+        return bool(
+            str(item.get("user_id") or "") == user_id_str
+            or sk == cls._user_sk(user_id)
+            or sk.startswith(f"USER_FACT#{user_id_str}#")
+        )
+
+    @staticmethod
+    def _item_matches_message_id(item: dict[str, Any], message_id: int | str) -> bool:
+        try:
+            target_id = int(message_id)
+        except (TypeError, ValueError):
+            return False
+        try:
+            if int(item.get("message_id")) == target_id:
+                return True
+        except (TypeError, ValueError):
+            pass
+        evidence_ids = item.get("evidence_message_ids")
+        if not isinstance(evidence_ids, list):
+            return False
+        for raw_id in evidence_ids:
+            try:
+                if int(raw_id) == target_id:
+                    return True
+            except (TypeError, ValueError):
+                continue
+        return False
+
+    def list_message_items_by_message_id(
+        self,
+        chat_id: int | str,
+        message_id: int | str,
+        *,
+        scan_limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Find stored raw MSG items matching a Telegram message id."""
+        items: list[dict[str, Any]] = []
+        seen = 0
+        start_key: dict[str, Any] | None = None
+        scan_limit = max(1, int(scan_limit))
+        while seen < scan_limit:
+            kwargs: dict[str, Any] = {
+                "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)) & Key("sk").begins_with("MSG#"),
+                "ScanIndexForward": False,
+                "Limit": min(100, scan_limit - seen),
+            }
+            if start_key:
+                kwargs["ExclusiveStartKey"] = start_key
+            resp = self.table.query(**kwargs)
+            batch = resp.get("Items") or []
+            seen += len(batch)
+            items.extend(item for item in batch if self._item_matches_message_id(item, message_id))
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                return items
+        return items
+
+    def list_long_term_memory_items_by_message_id(
+        self,
+        chat_id: int | str,
+        message_id: int | str,
+        *,
+        scan_limit_per_prefix: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Find vectorizable long-term memories produced from one Telegram message."""
+        matched: list[dict[str, Any]] = []
+        scan_limit_per_prefix = max(1, int(scan_limit_per_prefix))
+        for prefix in _VECTOR_MEMORY_PREFIXES:
+            seen = 0
+            start_key: dict[str, Any] | None = None
+            while seen < scan_limit_per_prefix:
+                kwargs: dict[str, Any] = {
+                    "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id)) & Key("sk").begins_with(prefix),
+                    "Limit": min(100, scan_limit_per_prefix - seen),
+                }
+                if start_key:
+                    kwargs["ExclusiveStartKey"] = start_key
+                resp = self.table.query(**kwargs)
+                batch = resp.get("Items") or []
+                seen += len(batch)
+                matched.extend(item for item in batch if self._item_matches_message_id(item, message_id))
+                start_key = resp.get("LastEvaluatedKey")
+                if not start_key:
+                    break
+        return matched
+
+    def delete_memory_items_by_sks(self, chat_id: int | str, source_sks: list[str]) -> list[dict[str, Any]]:
+        """Delete explicit memory items and return the items that existed."""
+        unique_sks: list[str] = []
+        seen: set[str] = set()
+        for source_sk in source_sks:
+            sk = str(source_sk or "").strip()
+            if sk and sk not in seen:
+                seen.add(sk)
+                unique_sks.append(sk)
+        if not unique_sks:
+            return []
+
+        items: list[dict[str, Any]] = []
+        for sk in unique_sks:
+            resp = self.table.get_item(Key={"pk": self._chat_pk(chat_id), "sk": sk})
+            item = resp.get("Item") or {}
+            if item:
+                items.append(item)
+        if not items:
+            return []
+
+        with self.table.batch_writer() as batch:
+            for item in items:
+                batch.delete_item(Key={"pk": item["pk"], "sk": item["sk"]})
+        return items
+
+    def delete_memory_for_message(self, chat_id: int | str, message_id: int | str) -> list[dict[str, Any]]:
+        """Delete the stored raw message and long-term memories derived from it."""
+        candidates = [
+            *self.list_message_items_by_message_id(chat_id, message_id),
+            *self.list_long_term_memory_items_by_message_id(chat_id, message_id),
+        ]
+        source_sks = [str(item.get("sk") or "") for item in candidates if item.get("sk")]
+        return self.delete_memory_items_by_sks(chat_id, source_sks)
+
     @staticmethod
     def _profile_terms(text: str) -> list[str]:
         """Extract lightweight topic terms from a user's own message."""

--- a/src/bot/services/vector_memory.py
+++ b/src/bot/services/vector_memory.py
@@ -544,10 +544,22 @@ def _vector_keys_for_items(chat_id: int | str, items: list[dict[str, Any]]) -> l
     keys: list[str] = []
     for item in items:
         source_sk = str(item.get("sk") or "")
-        if not source_sk:
+        if not source_sk or not GroupMemoryRepository.is_vectorizable_sk(source_sk):
             continue
         keys.append(str(item.get("vector_key") or memory_vector_key(chat_id, source_sk)))
     return keys
+
+
+def delete_memory_vectors_for_items(
+    chat_id: int | str,
+    items: list[dict[str, Any]],
+    *,
+    vector_repo: S3VectorMemoryRepository | None = None,
+) -> int:
+    if not vector_memory_configured():
+        return 0
+    vector_repo = vector_repo or S3VectorMemoryRepository()
+    return vector_repo.delete_vectors(_vector_keys_for_items(chat_id, items))
 
 
 def delete_chat_vectors(

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -2150,6 +2150,28 @@ def test_memory_command_routes_subcommands(monkeypatch):
     forget_me.assert_called_once_with(ctx)
 
 
+def test_memory_command_routes_about_me(monkeypatch):
+    ctx = _command_ctx(user_id=42)
+    ctx.text = "/memory about me"
+    about_me = MagicMock()
+    monkeypatch.setattr(commands, "handle_memory_about_me", about_me)
+
+    commands.handle_memory(ctx)
+
+    about_me.assert_called_once_with(ctx)
+
+
+def test_memory_command_routes_forget_this(monkeypatch):
+    ctx = _command_ctx(user_id=42)
+    ctx.text = "/memory forget this"
+    forget_this = MagicMock()
+    monkeypatch.setattr(commands, "handle_forget_this", forget_this)
+
+    commands.handle_memory(ctx)
+
+    forget_this.assert_called_once_with(ctx)
+
+
 def test_agent_command_routes_why(monkeypatch):
     ctx = _command_ctx(user_id=42)
     ctx.text = "/agent why"
@@ -2368,6 +2390,217 @@ def test_forget_me_deletes_vector_memory_when_configured(monkeypatch):
     ctx.memory_repo.delete_user_memory.assert_called_once_with(-100123, 42)
 
 
+def test_memory_about_me_shows_current_users_profile_only():
+    ctx = _command_ctx(user_id=42)
+    ctx.memory_repo.get_user_profile.return_value = {
+        "user_id": "42",
+        "language_style": ["uses-latin", "asks-questions"],
+        "interests": ["lambda", "opensearch"],
+        "preferences": ["I prefer concise answers"],
+        "known_facts": ["I maintain the bot"],
+        "boundaries": ["do not ping me at night"],
+    }
+
+    commands.handle_memory_about_me(ctx)
+
+    ctx.memory_repo.get_user_profile.assert_called_once_with(-100123, 42)
+    message = ctx.reply.call_args.args[0]
+    assert "I know this from your own messages" in message
+    assert "lambda" in message
+    assert "I prefer concise answers" in message
+    assert "do not ping me at night" in message
+    assert "Grace" not in message
+
+
+def test_memory_about_me_empty_profile_is_friendly():
+    ctx = _command_ctx(user_id=42)
+    ctx.memory_repo.get_user_profile.return_value = {}
+
+    commands.handle_memory_about_me(ctx)
+
+    assert "do not have a stored profile" in ctx.reply.call_args.args[0]
+
+
+def test_forget_this_reply_to_own_source_message_deletes_message_memory(monkeypatch):
+    monkeypatch.setattr(commands, "vector_memory_configured", lambda: False)
+    ctx = _command_ctx(user_id=42, status="member")
+    ctx.reply_to_message = {
+        "message_id": 8,
+        "from": {"id": 42, "is_bot": False, "first_name": "Ada"},
+        "text": "I prefer concise answers",
+    }
+    ctx.memory_repo.delete_memory_for_message.return_value = [
+        {"pk": "CHAT#-100123", "sk": "MSG#0000000001000#8"},
+        {"pk": "CHAT#-100123", "sk": "USER_FACT#42#0000000001000#8"},
+    ]
+
+    commands.handle_forget_this(ctx)
+
+    ctx.memory_repo.delete_memory_for_message.assert_called_once_with(-100123, 8)
+    assert "Deleted 2 related memory" in ctx.reply.call_args.args[0]
+
+
+def test_forget_this_rejects_other_users_source_message():
+    ctx = _command_ctx(user_id=42, status="member")
+    ctx.reply_to_message = {
+        "message_id": 8,
+        "from": {"id": 7, "is_bot": False, "first_name": "Nurt"},
+        "text": "We chose S3 Vectors.",
+    }
+
+    commands.handle_forget_this(ctx)
+
+    ctx.memory_repo.delete_memory_for_message.assert_not_called()
+    assert "only delete memory linked to your own messages" in ctx.reply.call_args.args[0]
+
+
+def test_forget_this_group_owner_can_delete_group_source_message(monkeypatch):
+    monkeypatch.setattr(commands, "ADMIN_USER_ID", 1)
+    monkeypatch.setattr(commands, "vector_memory_configured", lambda: False)
+    ctx = _command_ctx(user_id=42, status="creator")
+    ctx.reply_to_message = {
+        "message_id": 8,
+        "from": {"id": 7, "is_bot": False, "first_name": "Nurt"},
+        "text": "We chose S3 Vectors.",
+    }
+    ctx.memory_repo.delete_memory_for_message.return_value = [
+        {"pk": "CHAT#-100123", "sk": "GROUP_FACT#0000000001000#8"},
+    ]
+
+    commands.handle_forget_this(ctx)
+
+    ctx.memory_repo.delete_memory_for_message.assert_called_once_with(-100123, 8)
+    assert "Deleted 1 related memory" in ctx.reply.call_args.args[0]
+
+
+def test_forget_this_bot_answer_deletes_only_current_users_sources(monkeypatch):
+    monkeypatch.setattr(commands, "vector_memory_configured", lambda: False)
+    ctx = _command_ctx(user_id=42, status="member")
+    ctx.reply_to_message = {"message_id": 999, "from": {"id": 1000, "is_bot": True}}
+    ctx.memory_repo.get_agent_reply_explanation.return_value = {
+        "retrieval_sources": [
+            {"source": "requester_profile", "source_sk": "USER#42"},
+            {"source": "semantic", "source_sk": "GROUP_FACT#0000000001000#8"},
+        ]
+    }
+    items = {
+        "USER#42": {"pk": "CHAT#-100123", "sk": "USER#42", "user_id": "42"},
+        "GROUP_FACT#0000000001000#8": {
+            "pk": "CHAT#-100123",
+            "sk": "GROUP_FACT#0000000001000#8",
+            "user_id": "7",
+        },
+    }
+    ctx.memory_repo.get_memory_item.side_effect = lambda chat_id, sk: items[sk]
+    ctx.memory_repo.is_memory_item_related_to_user.side_effect = GroupMemoryRepository.is_memory_item_related_to_user
+    ctx.memory_repo.delete_memory_items_by_sks.return_value = [items["USER#42"]]
+
+    commands.handle_forget_this(ctx)
+
+    ctx.memory_repo.delete_memory_items_by_sks.assert_called_once_with(-100123, ["USER#42"])
+    assert "Deleted 1 related memory" in ctx.reply.call_args.args[0]
+
+
+def test_forget_this_bot_answer_group_owner_deletes_group_sources(monkeypatch):
+    monkeypatch.setattr(commands, "ADMIN_USER_ID", 1)
+    monkeypatch.setattr(commands, "vector_memory_configured", lambda: True)
+    delete_vectors = MagicMock(return_value=1)
+    monkeypatch.setattr(commands, "delete_memory_vectors_for_items", delete_vectors)
+    ctx = _command_ctx(user_id=42, status="creator")
+    ctx.reply_to_message = {"message_id": 999, "from": {"id": 1000, "is_bot": True}}
+    item = {"pk": "CHAT#-100123", "sk": "GROUP_FACT#0000000001000#8"}
+    ctx.memory_repo.get_agent_reply_explanation.return_value = {
+        "retrieval_sources": [{"source": "semantic", "source_sk": "GROUP_FACT#0000000001000#8"}]
+    }
+    ctx.memory_repo.delete_memory_items_by_sks.return_value = [item]
+
+    commands.handle_forget_this(ctx)
+
+    ctx.memory_repo.delete_memory_items_by_sks.assert_called_once_with(
+        -100123,
+        ["GROUP_FACT#0000000001000#8"],
+    )
+    delete_vectors.assert_called_once_with(-100123, [item])
+    assert "1" in ctx.reply.call_args.args[0]
+
+
+def test_delete_memory_for_message_deletes_raw_and_derived_memory():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.list_message_items_by_message_id = MagicMock(
+        return_value=[{"pk": "CHAT#-100123", "sk": "MSG#0000000001000#8"}]
+    )
+    repo.list_long_term_memory_items_by_message_id = MagicMock(
+        return_value=[{"pk": "CHAT#-100123", "sk": "USER_FACT#42#0000000001000#8"}]
+    )
+    repo.delete_memory_items_by_sks = MagicMock(
+        return_value=[
+            {"pk": "CHAT#-100123", "sk": "MSG#0000000001000#8"},
+            {"pk": "CHAT#-100123", "sk": "USER_FACT#42#0000000001000#8"},
+        ]
+    )
+
+    deleted = repo.delete_memory_for_message(-100123, 8)
+
+    assert [item["sk"] for item in deleted] == [
+        "MSG#0000000001000#8",
+        "USER_FACT#42#0000000001000#8",
+    ]
+    repo.delete_memory_items_by_sks.assert_called_once_with(
+        -100123,
+        ["MSG#0000000001000#8", "USER_FACT#42#0000000001000#8"],
+    )
+
+
+def test_list_long_term_memory_items_by_message_id_queries_vector_prefixes():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+    repo.table.query.side_effect = [
+        {
+            "Items": [
+                {"sk": "EVENT#0000000001000#8", "message_id": 8},
+                {"sk": "EVENT#0000000001000#9", "message_id": 9},
+            ]
+        },
+        {"Items": [{"sk": "USER_FACT#42#0000000001000#8", "evidence_message_ids": [8]}]},
+        {"Items": []},
+        {"Items": [{"sk": "JOKE#0000000001000#7", "evidence_message_ids": [7]}]},
+        {"Items": [{"sk": "DAILY_SUMMARY#2026-06-12", "message_id": 8}]},
+    ]
+
+    items = repo.list_long_term_memory_items_by_message_id(-100123, 8)
+
+    assert [item["sk"] for item in items] == [
+        "EVENT#0000000001000#8",
+        "USER_FACT#42#0000000001000#8",
+        "DAILY_SUMMARY#2026-06-12",
+    ]
+    assert _memory_query_prefixes(repo) == [
+        "EVENT#",
+        "USER_FACT#",
+        "GROUP_FACT#",
+        "JOKE#",
+        "DAILY_SUMMARY#",
+    ]
+
+
+def test_delete_memory_items_by_sks_deletes_existing_unique_items():
+    repo = GroupMemoryRepository.__new__(GroupMemoryRepository)
+    repo.table = MagicMock()
+    batch = MagicMock()
+    repo.table.batch_writer.return_value.__enter__.return_value = batch
+    item = {"pk": "CHAT#-100123", "sk": "USER#42"}
+    repo.table.get_item.side_effect = [
+        {"Item": item},
+        {},
+    ]
+
+    deleted = repo.delete_memory_items_by_sks(-100123, ["USER#42", "USER#42", "MISSING#1"])
+
+    assert deleted == [item]
+    assert repo.table.get_item.call_count == 2
+    batch.delete_item.assert_called_once_with(Key={"pk": "CHAT#-100123", "sk": "USER#42"})
+
+
 def test_why_reply_uses_replied_bot_message_reason():
     ctx = _command_ctx(user_id=42)
     ctx.reply_to_message = {"message_id": 999, "from": {"is_bot": True}}
@@ -2381,3 +2614,29 @@ def test_why_reply_uses_replied_bot_message_reason():
 
     ctx.memory_repo.get_agent_reply_explanation.assert_called_once_with(-100123, bot_message_id=999)
     assert "open question" in ctx.reply.call_args.args[0]
+
+
+def test_why_reply_includes_memory_source_counts_without_text():
+    ctx = _command_ctx(user_id=42)
+    ctx.reply_to_message = {"message_id": 999, "from": {"is_bot": True}}
+    ctx.memory_repo.get_agent_reply_explanation.return_value = {
+        "trigger_kind": "explicit",
+        "reason": "explicit question",
+        "confidence": Decimal("0.91"),
+        "retrieval_sources": [
+            {"source": "requester_profile", "source_sk": "USER#42", "text": "private profile text"},
+            {"source": "semantic", "source_sk": "USER_FACT#42#1#2", "text": "private semantic text"},
+            {"source": "semantic", "source_sk": "GROUP_FACT#1#3"},
+            {"source": "recent"},
+        ],
+    }
+
+    commands.handle_why_reply(ctx)
+
+    message = ctx.reply.call_args.args[0]
+    assert "Memory sources:" in message
+    assert "requester profile: yes" in message
+    assert "semantic memory: 2" in message
+    assert "recent context: yes" in message
+    assert "private profile text" not in message
+    assert "private semantic text" not in message

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -66,6 +66,24 @@ def test_s3_vectors_repository_put_query_delete_and_list(monkeypatch):
     assert repo.get_index()["indexName"] == "idx"
 
 
+def test_delete_memory_vectors_for_items_skips_non_vectorizable_items(monkeypatch):
+    monkeypatch.setattr(vector_memory, "vector_memory_configured", lambda: True)
+    vector_repo = MagicMock()
+    vector_repo.delete_vectors.return_value = 1
+
+    deleted = vector_memory.delete_memory_vectors_for_items(
+        -100123,
+        [
+            {"sk": "MSG#0000000001000#8"},
+            {"sk": "USER_FACT#42#0000000001000#8", "vector_key": "memory/user-fact"},
+        ],
+        vector_repo=vector_repo,
+    )
+
+    vector_repo.delete_vectors.assert_called_once_with(["memory/user-fact"])
+    assert deleted == 1
+
+
 def test_s3_vectors_repository_query_filters_by_user_and_kind(monkeypatch):
     fake_client = MagicMock()
     fake_client.query_vectors.return_value = {"vectors": []}


### PR DESCRIPTION
## Summary
- Add `/memory about me` to show the requester’s own stored profile fields only.
- Add `/memory forget this` for replied bot answers and source messages, with permission checks and vector cleanup for deleted long-term memory items.
- Enhance `/agent why` with memory source type/count summaries without exposing full memory text.
- Update translations, README docs, architecture docs, and repo guidance for the new user-facing memory controls.

## Validation
- `uv run pytest tests/test_group_memory_agent.py tests/test_vector_memory.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`