### PR TITLE
FEATURE: make memory context candidate driven

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -90,7 +90,7 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 - `webhook.py` — verifies Telegram secret, screens spam, observes memory, filters irrelevant events, routes agent/commands.
 - `services/sqs_task_router.py` — routes main and vector SQS task families and re-raises failures for retry/DLQ semantics.
 - `services/group_memory.py` — stores recent group context, formats prompt context, requester/target-user profile context, and query-filtered long-term memory.
-- `services/memory_retrieval.py` — thin Memory Retrieval Pipeline V1 wrapper for query intent, candidate/source tracking, local scoring, dedupe, and context packing.
+- `services/memory_retrieval.py` — Memory Retrieval Pipeline V1 for query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and source tracking.
 - `services/memory_extractor.py` — structured long-term memory schema, Gemini extraction normalisation, rule fallback, and storage guards.
 - `services/group_memory_processor.py` — async long-term extraction task orchestration, cheap Gemini candidate gating, extractor LLM budgets, and daily summaries.
 - `services/group_agent.py` — agent trigger policy, proactive gating, reply-thread continuity, answer-length policy.
@@ -139,7 +139,7 @@ Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `D
 - **Trust hierarchy for agent answers**: current user message and reply-thread context > requester profile for self-reference > target user's own profile > query-matched vector memory > query-filtered long-term memory > recent group chatter.
 - **Prompt pollution control**: do not inject unfiltered recent long-term memories into answers; filter by query or use vector retrieval.
 - **Vector retrieval discipline**: use chat metadata filters, requester filters for self-reference when available, and distance cutoffs before adding semantic memories to prompts.
-- **Memory Retrieval Pipeline V1**: `services.memory_retrieval.build_agent_memory_context` wraps existing profile, semantic, long-term, and recent context builders, tracks candidate sources, scores/dedupes locally, and persists compact retrieval source metadata for future `/agent why` explanations.
+- **Memory Retrieval Pipeline V1**: `services.memory_retrieval.build_agent_memory_context` retrieves profile, semantic, lexical, long-term, and recent candidates, scores/dedupes them locally, renders prompt sections only from selected top candidates, and persists compact metadata for the selected retrieval sources used by `/agent why`.
 - **User-facing memory controls**: `/memory about me` shows only the current user's own profile. `/memory forget this` deletes memory tied to a replied bot answer's recorded source keys or a replied source message, with vector cleanup when configured. Regular users can delete only their own memory; the group owner or bot owner can delete group memory.
 - **Memory extraction budget**: default `GROUP_MEMORY_EXTRACTOR_MODE=gemini_candidate_only` means ordinary safe chatter falls back to rules without calling Gemini. `GROUP_MEMORY_EXTRACTOR_DAILY_LLM_LIMIT` and `GROUP_MEMORY_EXTRACTOR_PER_CHAT_DAILY_LIMIT` bound candidate Gemini extraction before it can consume shared generate RPD.
 - **Memory safety filters**: never learn or prompt with future-answer directives such as "when someone asks X, answer Y", self-promotion, or subjective people rankings such as "best in the chat" / "strongest developer".

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -36,7 +36,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - `src/bot/`: Telegram webhook, dispatcher, SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector indexing entrypoints.
 - `src/bot/services/group_agent.py`: agent trigger policy, proactive gating, reply-thread continuity, response length policy.
 - `src/bot/services/group_memory.py`: recent context observation and prompt formatting, requester/target-user profiles, query-filtered long-term context.
-- `src/bot/services/memory_retrieval.py`: Memory Retrieval Pipeline V1 wrapper for query intent, source tracking, local scoring/dedupe, and context packing around existing retrieval helpers.
+- `src/bot/services/memory_retrieval.py`: Memory Retrieval Pipeline V1 for query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and selected-source tracking.
 - `src/bot/services/memory_extractor.py`: structured long-term memory schema, Gemini extraction normalization, rule fallback, and storage guards.
 - `src/bot/services/group_memory_processor.py`: async long-term extraction task orchestration, cheap Gemini candidate gating, extractor LLM budgets, and daily summaries.
 - `src/bot/vector_indexer_main.py`: dedicated vector memory SQS Lambda entrypoint.
@@ -52,6 +52,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 ## Memory And Agent Guardrails
 
 - Do not inject unfiltered long-term memory into agent prompts. Use query-filtered long-term context and semantic vector retrieval.
+- Do not let preformatted whole context sections bypass the local reranker; prompt memory sections should be rendered from selected, deduped candidates.
 - Self-reference questions must include requester identity/profile context in the answer path.
 - User profile context must be derived from the target user's own messages; third-party roasts or labels are low trust.
 - Query-filtered long-term memory must stay empty when the current query has no usable relevance terms.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ flowchart LR
 | Package | Entry | Main responsibilities |
 |---------|-------|-----------------------|
 | `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, semantic retrieval, and cleanup commands. |
-| `src/bot/services/memory_retrieval.py` | `build_agent_memory_context` | Memory Retrieval Pipeline V1: query intent, source tracking, local scoring/dedupe, and context packing around existing retrieval helpers. |
+| `src/bot/services/memory_retrieval.py` | `build_agent_memory_context` | Memory Retrieval Pipeline V1: query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and selected-source tracking. |
 | `src/bot/` | `vector_indexer_main.py:lambda_handler` | Dedicated vector memory SQS worker for embedding/indexing and vector backfill paging. |
 | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest and Telegram delivery. |
 | `src/quiz/` | `main.py:lambda_handler` | Scheduled and on-demand multilingual developer quizzes. |
@@ -118,9 +118,9 @@ The extractor stores only memories above `GROUP_MEMORY_EXTRACTOR_MIN_CONFIDENCE`
 
 ## Agent Answer Context
 
-`services.group_agent.answer_group_question` calls `services.memory_retrieval.build_agent_memory_context`, which wraps the existing retrievers into Memory Retrieval Pipeline V1. The pipeline analyzes query intent, retrieves profile, semantic, lexical, long-term, and recent candidates, scores/dedupes them locally, packs context within a character budget, and returns compact `retrieval_sources` metadata for `AGENT_REPLY#...` records.
+`services.group_agent.answer_group_question` calls `services.memory_retrieval.build_agent_memory_context`, which wraps the existing retrievers into Memory Retrieval Pipeline V1. The pipeline analyzes query intent, retrieves raw profile, semantic, lexical, long-term, and recent candidates, scores/dedupes them locally, selects the top candidates within a character budget, renders prompt sections from those selected candidates, and returns compact `retrieval_sources` metadata for the sources that actually reached the prompt.
 
-The returned bundle keeps these prompt sections:
+The returned bundle still exposes separate prompt sections for Gemini, but their content is candidate-driven rather than copied wholesale from each retriever:
 
 1. Trusted requester profile context for the user who asked the question.
 2. Trusted target-user profile context, only for users explicitly mentioned in the user message.
@@ -129,7 +129,7 @@ The returned bundle keeps these prompt sections:
 5. Recent group context with speaker metadata.
 6. Reply-thread context when the user replies to the bot's previous answer, including the captured original quoted message, previous user request, previous bot answer, and current follow-up when available.
 
-The local reranker treats requester profiles as highest trust for self-reference, target-user profiles above ordinary memory, user facts above daily summaries, and jokes as low priority unless the query explicitly asks for a joke or meme. Exact lexical matches boost codes, usernames, and technical terms such as `E1027`, `S3`, or `OpenSearch`; semantic distance, trust level, target-user match, recency, and memory confidence are also considered. If a query has no usable relevance terms, lexical long-term memory is not injected into the answer path.
+The local reranker treats requester profiles as highest trust for self-reference, target-user profiles above ordinary memory, user facts above daily summaries, and jokes as low priority unless the query explicitly asks for a joke or meme. Exact lexical matches boost codes, usernames, and technical terms such as `E1027`, `S3`, or `OpenSearch`; semantic distance, trust level, target-user match, recency, and memory confidence are also considered. Because selected candidates are what render prompt content, this ranking directly controls whether a semantic user fact, lexical exact match, daily summary, joke, old event, or recent message reaches Gemini. If a query has no usable relevance terms, lexical long-term memory is not injected into the answer path.
 
 `/agent why` reads the latest or replied `AGENT_REPLY#...` item and shows trigger, reason, confidence, and only memory source types/counts such as requester profile, semantic memory, lexical memory, long-term group memory, and recent context. It intentionally does not print full memory text.
 

--- a/src/bot/services/memory_retrieval.py
+++ b/src/bot/services/memory_retrieval.py
@@ -350,17 +350,48 @@ def _format_lexical_memory_context(candidates: list[MemoryCandidate]) -> str:
     return "\n".join(lines)
 
 
-def _merge_contexts(*contexts: str) -> str:
-    lines: list[str] = []
-    seen: set[str] = set()
-    for context in contexts:
-        for line in (context or "").splitlines():
-            normalized = " ".join(line.lower().split())
-            if not normalized or normalized in seen:
-                continue
-            seen.add(normalized)
-            lines.append(line)
-    return "\n".join(lines)
+def _format_semantic_candidate_context(candidate: MemoryCandidate) -> str:
+    text = candidate.text.replace("\n", " ").strip()
+    if not text or not is_memory_learning_safe(text):
+        return ""
+    bits = [f"kind={candidate.memory_kind or 'memory'}"]
+    if candidate.source_sk:
+        bits.append(f"source={candidate.source_sk}")
+    speaker = str(
+        candidate.metadata.get("display_name")
+        or candidate.metadata.get("username")
+        or candidate.metadata.get("user_id")
+        or ""
+    ).strip()
+    if speaker:
+        bits.append(f"speaker={speaker[:80]}")
+    distance = candidate.metadata.get("distance")
+    if isinstance(distance, int | float):
+        bits.append(f"distance={distance:.4f}")
+    return f"[semantic_memory {' '.join(bits)}] {text[:900]}"
+
+
+def _render_candidate_context(candidate: MemoryCandidate) -> str:
+    if candidate.source == "semantic":
+        return _format_semantic_candidate_context(candidate)
+    if candidate.source == "lexical":
+        return _format_lexical_memory_context([candidate])
+    text = candidate.text.strip()
+    if not text:
+        return ""
+    return text
+
+
+def _candidate_context_key(candidate: MemoryCandidate) -> str:
+    if candidate.source == "requester_profile":
+        return "requester_profile_context"
+    if candidate.source == "target_profile":
+        return "user_profile_context"
+    if candidate.source == "semantic":
+        return "semantic_memory_context"
+    if candidate.source == "recent":
+        return "recent_context"
+    return "long_term_memory_context"
 
 
 def _default_lexical_search(
@@ -425,18 +456,12 @@ def retrieve_candidates(
         limit=semantic_limit,
         user_id=requester_user_id if intent.is_self_reference else None,
     )
-    semantic_context = semantic_context_fn(semantic_rows)
     semantic_candidates = [candidate for row in semantic_rows if (candidate := _semantic_candidate(row)) is not None]
-    semantic_source_sks = {candidate.source_sk for candidate in semantic_candidates if candidate.source_sk}
     lexical_terms = extract_lexical_terms(user_text)
     lexical_rows = lexical_search_fn(repo, chat_id, lexical_terms, lexical_limit) if lexical_terms else []
     lexical_candidates = [
         candidate for row in lexical_rows if (candidate := _lexical_candidate(row, lexical_terms)) is not None
     ]
-    lexical_context = _format_lexical_memory_context(
-        [candidate for candidate in lexical_candidates if candidate.source_sk not in semantic_source_sks]
-    )
-    packed_long_term_context = _merge_contexts(long_term_context, lexical_context)
     user_profile_context = user_profile_context_fn(
         repo,
         chat_id,
@@ -485,8 +510,8 @@ def retrieve_candidates(
     return (
         {
             "recent_context": recent_context,
-            "long_term_memory_context": packed_long_term_context,
-            "semantic_memory_context": semantic_context,
+            "long_term_memory_context": long_term_context,
+            "semantic_memory_context": "",
             "user_profile_context": user_profile_context,
             "requester_profile_context": requester_profile_context,
         },
@@ -596,26 +621,39 @@ def pack_context(
     char_budget: int = 12_000,
     source_limit: int = 16,
 ) -> RetrievalBundle:
-    """Pack context sections in trust order and return source metadata."""
+    """Render and pack only selected reranked candidates into prompt sections."""
     remaining = max(0, int(char_budget))
-    packed: dict[str, str] = {}
-    for key in (
-        "requester_profile_context",
-        "user_profile_context",
-        "semantic_memory_context",
-        "long_term_memory_context",
-        "recent_context",
-    ):
-        packed[key], remaining = _pack_text(contexts.get(key, ""), remaining)
+    packed_lines: dict[str, list[str]] = {
+        "requester_profile_context": [],
+        "user_profile_context": [],
+        "semantic_memory_context": [],
+        "long_term_memory_context": [],
+        "recent_context": [],
+    }
+    selected_candidates: list[MemoryCandidate] = []
+    for candidate in candidates:
+        if len(selected_candidates) >= source_limit:
+            break
+        key = _candidate_context_key(candidate)
+        rendered = _render_candidate_context(candidate)
+        if not rendered:
+            continue
+        separator_cost = 1 if packed_lines[key] else 0
+        packed_text, remaining_after = _pack_text(rendered, remaining - separator_cost)
+        if not packed_text:
+            continue
+        packed_lines[key].append(packed_text)
+        remaining = remaining_after
+        selected_candidates.append(candidate)
 
-    selected_sources = [candidate.source_metadata() for candidate in candidates[:source_limit]]
+    selected_sources = [candidate.source_metadata() for candidate in selected_candidates]
     return RetrievalBundle(
         intent=intent,
-        recent_context=packed["recent_context"],
-        long_term_memory_context=packed["long_term_memory_context"],
-        semantic_memory_context=packed["semantic_memory_context"],
-        user_profile_context=packed["user_profile_context"],
-        requester_profile_context=packed["requester_profile_context"],
+        recent_context="\n".join(packed_lines["recent_context"]),
+        long_term_memory_context="\n".join(packed_lines["long_term_memory_context"]),
+        semantic_memory_context="\n".join(packed_lines["semantic_memory_context"]),
+        user_profile_context="\n".join(packed_lines["user_profile_context"]),
+        requester_profile_context="\n".join(packed_lines["requester_profile_context"]),
         candidates=candidates,
         retrieval_sources=selected_sources,
     )

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -437,7 +437,57 @@ def test_joke_intent_preserves_joke_candidate_and_non_joke_query_penalizes_it():
     assert joke_score < event_score
 
 
-def test_pack_context_respects_char_budget():
+def test_candidate_driven_context_prefers_user_fact_over_daily_summary_prompt_injection():
+    repo = MagicMock()
+    semantic_rows = [
+        {
+            "distance": 0.01,
+            "metadata": {
+                "source_sk": "DAILY_SUMMARY#2026-06-12",
+                "memory_kind": "daily_summary",
+                "text": "Daily summary: the group briefly mentioned OpenSearch indexing during casual chatter.",
+            },
+        },
+        {
+            "distance": 0.18,
+            "metadata": {
+                "source_sk": "USER_FACT#42#7",
+                "memory_kind": "user_fact",
+                "text": "Ada fixes E1027 indexing.",
+                "confidence": 0.95,
+            },
+        },
+    ]
+
+    bundle = build_agent_memory_context(
+        repo=repo,
+        chat_id=-100123,
+        user_text="OpenSearch indexing E1027",
+        recent_context_fn=lambda *args, **kwargs: "[recent] this should not fit",
+        long_term_context_fn=lambda *args, **kwargs: "[daily_summary] generic OpenSearch daily summary",
+        semantic_retrieval_fn=MagicMock(return_value=semantic_rows),
+        semantic_context_fn=lambda rows: "\n".join(row["metadata"]["text"] for row in rows),
+        lexical_search_fn=MagicMock(return_value=[]),
+        user_profile_context_fn=_empty_context,
+        requester_profile_context_fn=_empty_context,
+        char_budget=110,
+    )
+
+    assert "Ada fixes E1027 indexing" in bundle.semantic_memory_context
+    assert "Daily summary" not in bundle.semantic_memory_context
+    assert "generic OpenSearch daily summary" not in bundle.long_term_memory_context
+    assert bundle.retrieval_sources == [
+        {
+            "source": "semantic",
+            "score": bundle.retrieval_sources[0]["score"],
+            "trust_level": 60,
+            "source_sk": "USER_FACT#42#7",
+            "memory_kind": "user_fact",
+        }
+    ]
+
+
+def test_pack_context_respects_char_budget_with_selected_candidates_only():
     intent = RetrievalIntent(
         is_self_reference=False,
         target_usernames=set(),
@@ -450,14 +500,35 @@ def test_pack_context_respects_char_budget():
     bundle = pack_context(
         intent=intent,
         contexts={
-            "requester_profile_context": "requester line",
-            "user_profile_context": "target line",
-            "semantic_memory_context": "semantic line",
-            "long_term_memory_context": "long term line",
-            "recent_context": "recent line",
+            "requester_profile_context": "legacy requester line",
+            "user_profile_context": "legacy target line",
+            "semantic_memory_context": "legacy semantic line",
+            "long_term_memory_context": "legacy long term line",
+            "recent_context": "legacy recent line",
         },
-        candidates=[],
-        char_budget=26,
+        candidates=[
+            MemoryCandidate(
+                "semantic",
+                "USER_FACT#42#1",
+                "user_fact",
+                "Ada owns OpenSearch indexing.",
+                0.9,
+                60,
+                None,
+                {},
+            ),
+            MemoryCandidate(
+                "recent",
+                None,
+                "message",
+                "[speaker user_id=42] this recent line should not fit",
+                0.1,
+                20,
+                None,
+                {},
+            ),
+        ],
+        char_budget=90,
     )
 
     total_chars = sum(
@@ -470,5 +541,52 @@ def test_pack_context_respects_char_budget():
             bundle.recent_context,
         )
     )
-    assert total_chars <= 26
-    assert bundle.requester_profile_context == "requester line"
+    assert total_chars <= 90
+    assert "legacy" not in "\n".join(
+        [
+            bundle.requester_profile_context,
+            bundle.user_profile_context,
+            bundle.semantic_memory_context,
+            bundle.long_term_memory_context,
+            bundle.recent_context,
+        ]
+    )
+    assert "OpenSearch" in bundle.semantic_memory_context
+    assert bundle.recent_context == ""
+    assert [source["source"] for source in bundle.retrieval_sources] == ["semantic"]
+
+
+def test_pack_context_records_only_sources_selected_for_prompt():
+    intent = analyze_query_intent("OpenSearch indexing")
+
+    bundle = pack_context(
+        intent=intent,
+        contexts={},
+        candidates=[
+            MemoryCandidate(
+                "semantic",
+                "USER_FACT#42#1",
+                "user_fact",
+                "Ada owns OpenSearch indexing.",
+                0.9,
+                60,
+                None,
+                {},
+            ),
+            MemoryCandidate(
+                "semantic",
+                "GROUP_FACT#1#3",
+                "group_fact",
+                "This second memory is too long for the remaining budget.",
+                0.8,
+                54,
+                None,
+                {},
+            ),
+        ],
+        char_budget=90,
+    )
+
+    assert "Ada owns OpenSearch indexing" in bundle.semantic_memory_context
+    assert "second memory" not in bundle.semantic_memory_context
+    assert [source.get("source_sk") for source in bundle.retrieval_sources] == ["USER_FACT#42#1"]


### PR DESCRIPTION
## Summary
- Change `pack_context()` to render prompt sections from selected reranked candidates instead of preformatted whole context sections.
- Render semantic and lexical prompt lines from the selected candidates, while keeping the existing Gemini prompt section API unchanged.
- Record `retrieval_sources` only for candidates that actually fit into the prompt budget.
- Update architecture and repo guidance to describe the candidate-driven retrieval pipeline accurately.

## Validation
- `uv run pytest tests/test_memory_retrieval.py -q`
- `uv run pytest tests/test_memory_retrieval.py tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`

No infra/env changes in this PR, so CDK synth was not required.