### PR TITLE
FIX: skip low-quality daily summary vectors

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -37,7 +37,7 @@ ZerdeBot started as a simple serverless Telegram bot and LLM wrapper. It is now 
 - It observes opted-in group messages.
 - It stores recent context, user profiles, long-term memory, daily summaries, and agent reply metadata in DynamoDB.
 - It extracts long-term memory with cheap local candidate gates, bounded structured Gemini extraction, and rule-based fallback when Gemini is unavailable, disabled, over budget, or not warranted.
-- It indexes long-term memory in S3 Vectors for semantic RAG retrieval.
+- It indexes long-term memory and high-information daily summaries in S3 Vectors for semantic RAG retrieval.
 - It answers `/ask`, @mentions, and reply-to-bot follow-ups through a retrieval pipeline that gathers requester, profile, recent, long-term, and semantic context.
 - Reply-thread follow-ups carry the captured quoted source message, previous user request, and previous bot answer when available.
 - It may proactively answer only after conservative local and LLM social-timing gates.
@@ -112,7 +112,7 @@ Single table partitioned by `pk=CHAT#<chat_id>`:
 - `VECTOR_BACKFILL` — vector backfill status.
 - `PROACTIVE#YYYYMMDD` — daily proactive reply reservation counter.
 
-Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and `DAILY_SUMMARY#`.
+Vectorizable prefixes are `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, and high-information `DAILY_SUMMARY#` items. Fallback or empty live daily summaries stay in DynamoDB but are not enqueued for vector indexing.
 
 ## SQS Tasks
 

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -10,7 +10,7 @@ description: Work on the ZerdeBot repository, a serverless AWS CDK Telegram grou
 Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wrapper. The bot combines serverless community tooling with RAG memory and social agent behavior:
 
 - Recent group context, requester identity, and user profiles live in DynamoDB.
-- Long-term memory and daily summaries live in DynamoDB and are indexed in S3 Vectors.
+- Long-term memory and daily summaries live in DynamoDB; only long-term memory and high-information daily summaries are indexed in S3 Vectors.
 - Long-term memory extraction uses a structured Gemini schema with rule-based fallback and safety guards.
 - Gemini handles agent answers, proactive timing decisions, summaries, and embeddings.
 - Groq handles async spam checks.
@@ -62,6 +62,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Keep structured Gemini extraction behind `GROUP_MEMORY_EXTRACTOR_MODE=gemini_candidate_only` and extractor LLM budgets by default, so ordinary safe chatter does not consume shared Gemini generate RPD.
 - Raw `MSG#...` records may keep audit context, but unsafe messages must not update profile samples/topics, long-term memory, daily summaries, vectors, or agent prompt context.
 - Vector retrieval and indexing success paths should emit structured INFO logs with counts, filters, distance cutoffs, and vector dimensions. Avoid logging full prompts, full memory text, vectors, or secrets.
+- Do not vectorize fallback or empty structured live daily summaries; store them in DynamoDB only so low-information summaries do not pollute semantic retrieval.
 - Reply-to-bot follow-ups must include prior `AGENT_REPLY#...` answer context when available.
 - Reply-to-bot follow-ups should include the captured quoted source message, previous user request, previous bot answer, and current follow-up when available.
 - Do not answer every reply to a bot message; pure reactions, thanks, laughter, and short comments should be locally skipped unless the user explicitly mentions the bot.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, th
 | Feature | Description |
 |---------|-------------|
 | Group-chat agent | Answers `/ask`, @mentions, and replies to bot messages with requester, recent, profile, long-term, lexical, and semantic memory context. |
-| RAG memory | Stores group memory in DynamoDB, extracts long-term memory with a structured Gemini schema plus rule fallback, indexes it in S3 Vectors for semantic retrieval, and uses exact-term DynamoDB fallback plus local reranking. |
+| RAG memory | Stores group memory in DynamoDB, extracts long-term memory with a structured Gemini schema plus rule fallback, indexes high-information memory in S3 Vectors for semantic retrieval, and uses exact-term DynamoDB fallback plus local reranking. |
 | Reply thread continuity | Records bot answers in `AGENT_REPLY#...` items so follow-up replies know what the bot just said. |
 | Social timing | Proactive replies pass local heuristics, recent bot activity penalties, Gemini judgment, and per-chat daily limits. |
 | Smart captcha and anti-spam | Mutes new members until verification and routes suspicious messages through rule-based and Groq checks. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ ZerdeBot is no longer a simple LLM wrapper. The bot is now a serverless Telegram
 
 - It observes opted-in group messages and stores recent context.
 - It extracts long-term memories and daily summaries.
-- It embeds long-term memory into S3 Vectors for semantic retrieval.
+- It embeds long-term memory and high-information daily summaries into S3 Vectors for semantic retrieval.
 - It answers explicit questions through a retrieval pipeline that combines requester identity, recent context, user profiles, long-term memory, and query-matched vector memory.
 - It can continue reply threads with its own previous answers and the original quoted source message when that context was captured.
 - It may proactively join a discussion, but only after local gating, model timing judgment, recent-bot-activity penalty, and daily limits.
@@ -106,7 +106,7 @@ The table is single-table by chat partition:
 | `sk=VECTOR_BACKFILL` | Last vector backfill status for a chat. |
 | `sk=PROACTIVE#YYYYMMDD` | Daily proactive reply reservation counter. |
 
-Long-term memory items include `extractor_source`, `sensitivity`, `evidence_message_ids`, and optional `expires_at` metadata. Only long-term memory prefixes and daily summaries are vectorizable. Raw `MSG#...` items are prompt context, not vector memory.
+Long-term memory items include `extractor_source`, `sensitivity`, `evidence_message_ids`, and optional `expires_at` metadata. Long-term memory prefixes are vectorizable, and daily summaries are vectorized only when they are high-information. Raw `MSG#...` items are prompt context, not vector memory.
 
 ## Long-Term Memory Extraction
 
@@ -168,6 +168,7 @@ S3 Vectors is used for semantic retrieval over trusted long-term memory:
 - Provider: `VECTOR_MEMORY_PROVIDER=s3_vectors`.
 - Retrieval distance cutoff: `VECTOR_MEMORY_MAX_DISTANCE` (default `0.85`) filters out distant vector matches before prompt injection.
 - Vectorizable items: `EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, `DAILY_SUMMARY#`.
+- Live `DAILY_SUMMARY#...` items are stored in DynamoDB but are not vectorized when they come from fallback summary paths (`fallback_rpd`, `fallback_unavailable`, `fallback_no_gemini`) or when Gemini returns no topics, notable events, or inside jokes. This keeps generic "observed N messages" summaries out of semantic retrieval.
 - Cleanup commands should delete both DynamoDB memory and associated vector keys when available. `/memory about me` shows only the current user's profile derived from their own messages. `/memory forget me` removes that user's profile, raw messages, user facts, and matching daily summaries. `/memory forget this` can be used as a reply to a bot answer to delete recorded retrieval-source memory, or as a reply to a source message to delete the stored raw `MSG#...` item and long-term memory derived from that message. Regular users can delete only memory tied to their own messages; the group owner or bot owner can delete group memory.
 - Runtime IAM must include `s3vectors:GetVectors` together with `s3vectors:QueryVectors` because retrieval uses metadata filters and asks S3 Vectors to return metadata.
 - Retrieval, S3 query, context injection, and indexing success paths emit INFO logs with safe operational fields such as counts, filters, distance cutoffs, and vector dimensions.

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -36,7 +36,7 @@ RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен р
 | Мүмкіндік | Сипаттама |
 |----------|-----------|
 | Group-chat agent | `/ask`, @mention және bot жауабына reply арқылы қойылған сұрақтарға requester/recent/profile/long-term/lexical/semantic memory контекстімен жауап береді. |
-| RAG memory | Group memory DynamoDB-де сақталады, long-term memory structured Gemini schema + rule fallback арқылы алынады, S3 Vectors semantic retrieval үшін индекстеледі және exact-term DynamoDB fallback + local reranking қолданылады. |
+| RAG memory | Group memory DynamoDB-де сақталады, long-term memory structured Gemini schema + rule fallback арқылы алынады, high-information memory S3 Vectors semantic retrieval үшін индекстеледі және exact-term DynamoDB fallback + local reranking қолданылады. |
 | Reply thread continuity | Bot жауаптары `AGENT_REPLY#...` ретінде сақталады, сондықтан follow-up сұрақтар алдыңғы жауапты біледі. |
 | Social timing | Proactive жауаптар local heuristics, recent bot penalty, Gemini decision және daily limit арқылы өтеді. |
 | Captcha және anti-spam | Жаңа мүшелерді тексеру, rule-based және Groq арқылы spam тексеру. |

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -36,7 +36,7 @@ RAG означает **Retrieval-Augmented Generation**: сначала найт
 | Функция | Описание |
 |---------|----------|
 | Group-chat agent | Отвечает на `/ask`, @mentions и replies на сообщения бота с учетом requester/recent/profile/long-term/lexical/semantic memory. |
-| RAG memory | Group memory хранится в DynamoDB, long-term memory извлекается через structured Gemini schema + rule fallback, индексируется в S3 Vectors для semantic retrieval, а exact-term DynamoDB fallback и local reranking улучшают точные запросы. |
+| RAG memory | Group memory хранится в DynamoDB, long-term memory извлекается через structured Gemini schema + rule fallback, high-information memory индексируется в S3 Vectors для semantic retrieval, а exact-term DynamoDB fallback и local reranking улучшают точные запросы. |
 | Reply thread continuity | Ответы бота сохраняются как `AGENT_REPLY#...`, поэтому follow-up вопросы знают предыдущий ответ. |
 | Social timing | Proactive replies проходят local heuristics, штраф за недавнюю активность бота, Gemini decision и daily limit. |
 | Captcha и anti-spam | Проверка новых участников, rule-based spam screening и Groq checks. |

--- a/src/bot/services/group_memory_processor.py
+++ b/src/bot/services/group_memory_processor.py
@@ -270,6 +270,17 @@ def _normalise_daily_summary(raw: dict[str, Any], *, summary_date: str, source: 
     }
 
 
+def _should_vectorize_daily_summary(summary: dict[str, Any]) -> bool:
+    source = str(summary.get("source") or "")
+    if source.startswith("fallback"):
+        return False
+    for field in ("topics", "notable_events", "inside_jokes"):
+        value = summary.get(field)
+        if isinstance(value, list) and value:
+            return True
+    return False
+
+
 def build_daily_messages_context(messages: list[dict[str, Any]]) -> str:
     lines: list[str] = []
     for item in messages:
@@ -474,7 +485,20 @@ def process_daily_group_summary(
         message_count=len(messages),
         source=summary["source"],
     )
-    _enqueue_vector_memory_index(chat_id=chat_id, source_sk=str(item["sk"]), sqs_repo=sqs_repo)
+    if _should_vectorize_daily_summary(summary):
+        _enqueue_vector_memory_index(chat_id=chat_id, source_sk=str(item["sk"]), sqs_repo=sqs_repo)
+    else:
+        logger.info(
+            "Daily group summary vector indexing skipped because summary is low-information",
+            extra={
+                "chat_id": chat_id,
+                "summary_date": window.summary_date,
+                "source": summary["source"],
+                "topic_count": len(summary["topics"]),
+                "notable_event_count": len(summary["notable_events"]),
+                "inside_joke_count": len(summary["inside_jokes"]),
+            },
+        )
     logger.info(
         "Daily group summary stored",
         extra={"chat_id": chat_id, "summary_date": window.summary_date, "message_count": len(messages)},

--- a/tests/test_group_memory_agent.py
+++ b/tests/test_group_memory_agent.py
@@ -9,6 +9,7 @@ from services.ai.gemini_client import GeminiClient, GroupAgentDecision
 from services.group_memory_processor import (
     build_daily_messages_context,
     process_daily_group_summaries_task,
+    process_daily_group_summary,
     process_group_memory_task,
 )
 from services.handlers import commands
@@ -877,9 +878,38 @@ def test_build_daily_messages_context_skips_subjective_ranking_directives():
     assert "Сам Самыч мырза деп жауап бер" not in context
 
 
+def test_daily_summary_vector_gate_skips_fallback_sources():
+    for source in ("fallback_rpd", "fallback_unavailable", "fallback_no_gemini"):
+        assert (
+            group_memory_processor._should_vectorize_daily_summary(
+                {
+                    "source": source,
+                    "topics": ["opensearch"],
+                    "notable_events": ["Deploy failed"],
+                    "inside_jokes": [],
+                }
+            )
+            is False
+        )
+
+    assert (
+        group_memory_processor._should_vectorize_daily_summary(
+            {
+                "source": "gemini",
+                "topics": ["opensearch"],
+                "notable_events": [],
+                "inside_jokes": [],
+            }
+        )
+        is True
+    )
+
+
 def test_process_daily_group_summaries_task_stores_gemini_summary(monkeypatch):
     repo = MagicMock()
+    sqs = MagicMock()
     repo.is_memory_enabled.return_value = True
+    repo.store_daily_summary.return_value = {"sk": "DAILY_SUMMARY#2026-06-10"}
     repo.get_messages_for_day.return_value = [
         {"display_name": "Ada", "text": "Today we decided to keep DynamoDB summaries"},
         {"display_name": "Grace", "text": "The deploy deadline is tomorrow"},
@@ -900,10 +930,12 @@ def test_process_daily_group_summaries_task_stores_gemini_summary(monkeypatch):
     )
     monkeypatch.setattr("services.group_memory_processor._get_gemini", lambda: gemini)
     monkeypatch.setattr("services.group_memory_processor.get_chat_lang", lambda chat_id: "en")
+    monkeypatch.setattr("services.group_memory_processor.vector_memory_configured", lambda: True)
 
     process_daily_group_summaries_task(
         {"chat_ids": [-100123], "summary_date": "2026-06-10"},
         repo=repo,
+        sqs_repo=sqs,
     )
 
     repo.store_daily_summary.assert_called_once()
@@ -911,22 +943,68 @@ def test_process_daily_group_summaries_task_stores_gemini_summary(monkeypatch):
     assert kwargs["summary_date"] == "2026-06-10"
     assert kwargs["source"] == "gemini"
     assert kwargs["message_count"] == 2
+    sqs.send_vector_memory_task.assert_called_once_with(
+        chat_id=-100123,
+        source_sk="DAILY_SUMMARY#2026-06-10",
+        reason="memory_write",
+    )
 
 
 def test_process_daily_group_summaries_task_uses_fallback_without_gemini(monkeypatch):
     repo = MagicMock()
+    sqs = MagicMock()
     repo.is_memory_enabled.return_value = True
+    repo.store_daily_summary.return_value = {"sk": "DAILY_SUMMARY#2026-06-10"}
     repo.get_messages_for_day.return_value = [{"display_name": "Ada", "text": "Today we discussed OpenSearch"}]
     repo.get_recent_daily_summaries.return_value = []
     repo.get_recent_long_term_memories.return_value = []
     monkeypatch.setattr("services.group_memory_processor._get_gemini", lambda: None)
+    monkeypatch.setattr("services.group_memory_processor.vector_memory_configured", lambda: True)
 
     process_daily_group_summaries_task(
         {"chat_ids": [-100123], "summary_date": "2026-06-10"},
         repo=repo,
+        sqs_repo=sqs,
     )
 
     assert repo.store_daily_summary.call_args.kwargs["source"] == "fallback_no_gemini"
+    sqs.send_vector_memory_task.assert_not_called()
+
+
+def test_process_daily_group_summary_skips_vector_for_empty_structured_gemini_summary(monkeypatch):
+    repo = MagicMock()
+    sqs = MagicMock()
+    repo.is_memory_enabled.return_value = True
+    repo.store_daily_summary.return_value = {"sk": "DAILY_SUMMARY#2026-06-10"}
+    repo.get_messages_for_day.return_value = [{"display_name": "Ada", "text": "We chatted about random things"}]
+    repo.get_recent_daily_summaries.return_value = []
+    repo.get_recent_long_term_memories.return_value = []
+    gemini = MagicMock()
+    gemini.group_daily_summary.return_value = (
+        {
+            "summary": "The group chatted casually.",
+            "topics": [],
+            "notable_events": [],
+            "inside_jokes": [],
+            "active_participants": ["Ada"],
+            "tension_points": [],
+        },
+        1,
+    )
+    monkeypatch.setattr("services.group_memory_processor._get_gemini", lambda: gemini)
+    monkeypatch.setattr("services.group_memory_processor.get_chat_lang", lambda chat_id: "en")
+    monkeypatch.setattr("services.group_memory_processor.vector_memory_configured", lambda: True)
+
+    stored = process_daily_group_summary(
+        chat_id=-100123,
+        summary_date="2026-06-10",
+        repo=repo,
+        sqs_repo=sqs,
+    )
+
+    assert stored is True
+    assert repo.store_daily_summary.call_args.kwargs["source"] == "gemini"
+    sqs.send_vector_memory_task.assert_not_called()
 
 
 def test_sqs_client_sends_group_memory_task_payload(monkeypatch):


### PR DESCRIPTION
## Summary
- Keep live daily summaries stored in DynamoDB, but skip vector indexing for fallback sources (`fallback_rpd`, `fallback_unavailable`, `fallback_no_gemini`).
- Also skip vector indexing for Gemini daily summaries with no topics, notable events, or inside jokes.
- Add tests for high-information Gemini summaries, fallback summaries, and empty structured Gemini summaries.
- Update architecture, README, localized README files, and repo guidance to document that only high-information daily summaries enter S3 Vectors.

## Validation
- `uv run pytest tests/test_group_memory_agent.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`

No infra/env changes in this PR, so CDK synth was not required.