### PR TITLE
fix: preserve captcha verification state for timeouts

### DIFF
--- a/src/bot/services/handlers/captcha.py
+++ b/src/bot/services/handlers/captcha.py
@@ -40,6 +40,8 @@ _TEXT_ONLY_PERMISSIONS: dict[str, bool] = {
     "can_add_web_page_previews": False,
 }
 
+_CAPTCHA_BLOCKED_PERMISSIONS = tuple(key for key, value in _TEXT_ONLY_PERMISSIONS.items() if value is False)
+
 
 def _delete_timeout_messages(
     bot: TelegramClient,
@@ -54,6 +56,33 @@ def _delete_timeout_messages(
         logger.warning("Failed to delete join/verification messages: %s", e)
 
 
+def _challenge_matches_timeout_task(
+    challenge: dict[str, Any],
+    join_message_id: int,
+    verification_message_id: int,
+) -> bool:
+    return int(challenge.get("join_msg_id", 0)) == int(join_message_id) and int(
+        challenge.get("verify_msg_id", 0)
+    ) == int(verification_message_id)
+
+
+def _is_captcha_text_only_restricted(member: dict[str, Any]) -> bool:
+    if (member.get("status") or "").lower() != "restricted":
+        return False
+    if member.get("can_send_messages") is not True:
+        return False
+    return all(member.get(permission) is False for permission in _CAPTCHA_BLOCKED_PERMISSIONS)
+
+
+def _delete_pending_state(captcha_repo: Any, chat_id: int | str, user_id: int) -> None:
+    if not captcha_repo:
+        return
+    try:
+        captcha_repo.delete_pending(chat_id, user_id)
+    except Exception as e:
+        logger.warning("Failed to clean up captcha state on timeout: %s", e)
+
+
 def process_timeout_task(bot: TelegramClient, task_data: dict[str, Any]) -> None:
     """Process CHECK_TIMEOUT task: kick user if still restricted, clean up captcha state."""
     chat_id = task_data.get("chat_id")
@@ -65,23 +94,39 @@ def process_timeout_task(bot: TelegramClient, task_data: dict[str, Any]) -> None
     if not all([chat_id, user_id, join_message_id, verification_message_id]):
         logger.warning("Timeout task missing required fields", task_data=task_data)
         return
+    should_cleanup_state = False
     try:
-        # Use DynamoDB state as the fast path, but do not treat a missing/expired
-        # pending entry as proof of verification. Timeout tasks can be delayed by
-        # SQS backlog, while the pending captcha record has a short TTL buffer.
+        challenge = None
         if captcha_repo:
-            pending = captcha_repo.get_pending(chat_id, user_id)
-            if pending is None:
-                member = bot.get_chat_member(chat_id, user_id)
-                status = (member.get("status") or "").lower()
-                if status != "restricted":
-                    _delete_timeout_messages(bot, chat_id, join_message_id, verification_message_id)
-                    logger.info("User %s already verified. Ignoring timeout.", user_id)
-                    return
+            challenge = captcha_repo.get_challenge(chat_id, user_id)
+            if challenge is None:
+                should_cleanup_state = True
+                logger.info("Captcha timeout state missing. Ignoring timeout.", extra={"user_id": user_id})
+                return
+            if not _challenge_matches_timeout_task(challenge, join_message_id, verification_message_id):
+                logger.info(
+                    "Stale captcha timeout task ignored",
+                    extra={
+                        "user_id": user_id,
+                        "task_join_message_id": join_message_id,
+                        "task_verification_message_id": verification_message_id,
+                    },
+                )
+                return
+            should_cleanup_state = True
+            if challenge.get("status") == "verified":
+                _delete_timeout_messages(bot, chat_id, join_message_id, verification_message_id)
+                logger.info("User %s already verified. Ignoring timeout.", user_id)
+                return
+            if challenge.get("status") != "pending":
+                logger.warning(
+                    "Captcha timeout state has unexpected status; ignoring timeout",
+                    extra={"user_id": user_id, "captcha_status": challenge.get("status")},
+                )
+                return
         else:
             member = bot.get_chat_member(chat_id, user_id)
-            status = (member.get("status") or "").lower()
-            if status != "restricted":
+            if not _is_captcha_text_only_restricted(member):
                 return
 
         logger.info("User %s timed out. Kicking.", user_id)
@@ -90,11 +135,8 @@ def process_timeout_task(bot: TelegramClient, task_data: dict[str, Any]) -> None
     except Exception as e:
         logger.exception("Timeout task error (user may have left or message deleted): %s", e)
     finally:
-        if captcha_repo:
-            try:
-                captcha_repo.delete_pending(chat_id, user_id)
-            except Exception as e:
-                logger.warning("Failed to clean up captcha state on timeout: %s", e)
+        if should_cleanup_state:
+            _delete_pending_state(captcha_repo, chat_id, user_id)
 
 
 def handle_new_member(ctx: Context) -> None:
@@ -212,7 +254,7 @@ def handle_captcha_answer(ctx: Context) -> None:
     if answer == expected:
         # ── Correct ─────────────────────────────────────────────────────────
         ctx.bot.restrict_chat_member(ctx.chat_id, ctx.user_id, _FULL_PERMISSIONS)
-        ctx.captcha_repo.delete_pending(ctx.chat_id, ctx.user_id)
+        ctx.captcha_repo.mark_verified(ctx.chat_id, ctx.user_id)
 
         # Delete captcha image, wrong-answer messages, and user's answer — keep system join message
         ids_to_delete = [pending["verify_msg_id"], ctx.message_id] + pending.get("wrong_msg_ids", [])

--- a/src/bot/services/repositories/captcha.py
+++ b/src/bot/services/repositories/captcha.py
@@ -11,6 +11,9 @@ from services.repositories._common import get_dynamodb
 logger = LoggerAdapter(get_logger(__name__), {})
 
 _KEY_PREFIX = "captcha_pending#"
+_STATUS_PENDING = "pending"
+_STATUS_VERIFIED = "verified"
+_STATE_TTL_BUFFER_SECONDS = 24 * 60 * 60
 
 
 def _key(chat_id: int | str, user_id: int | str) -> str:
@@ -35,15 +38,20 @@ class CaptchaRepository:
         join_msg_id: int,
         verify_msg_id: int,
     ) -> None:
-        ttl = int(time.time()) + CAPTCHA_TIMEOUT_SECONDS + 60  # grace buffer
+        now = int(time.time())
+        expires_at = now + CAPTCHA_TIMEOUT_SECONDS
+        ttl = expires_at + _STATE_TTL_BUFFER_SECONDS
         try:
             self._table.put_item(
                 Item={
                     "stat_key": _key(chat_id, user_id),
+                    "status": _STATUS_PENDING,
                     "expected": expected,
                     "join_msg_id": join_msg_id,
                     "verify_msg_id": verify_msg_id,
                     "attempts": 0,
+                    "created_at": now,
+                    "expires_at": expires_at,
                     "ttl": ttl,
                 }
             )
@@ -51,7 +59,21 @@ class CaptchaRepository:
             logger.exception("Failed to save pending captcha: %s", e)
             raise
 
-    def get_pending(self, chat_id: int | str, user_id: int | str) -> dict[str, Any] | None:
+    def _format_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "status": item.get("status", _STATUS_PENDING),
+            "expected": item["expected"],
+            "join_msg_id": int(item["join_msg_id"]),
+            "verify_msg_id": int(item["verify_msg_id"]),
+            "attempts": int(item.get("attempts", 0)),
+            "wrong_msg_ids": [int(m) for m in item.get("wrong_msg_ids", [])],
+            "created_at": int(item.get("created_at", 0)),
+            "expires_at": int(item.get("expires_at", item.get("ttl", 0))),
+            "ttl": int(item.get("ttl", 0)),
+        }
+
+    def get_challenge(self, chat_id: int | str, user_id: int | str) -> dict[str, Any] | None:
+        """Return captcha state regardless of pending/verified status."""
         try:
             resp = self._table.get_item(
                 Key={"stat_key": _key(chat_id, user_id)},
@@ -60,19 +82,37 @@ class CaptchaRepository:
             item = resp.get("Item")
             if not item:
                 return None
-            # Guard against expired items not yet removed by DynamoDB TTL sweep
-            if int(item.get("ttl", 0)) < int(time.time()):
-                return None
-            return {
-                "expected": item["expected"],
-                "join_msg_id": int(item["join_msg_id"]),
-                "verify_msg_id": int(item["verify_msg_id"]),
-                "attempts": int(item.get("attempts", 0)),
-                "wrong_msg_ids": [int(m) for m in item.get("wrong_msg_ids", [])],
-            }
+            return self._format_item(item)
         except ClientError as e:
-            logger.exception("Failed to get pending captcha: %s", e)
+            logger.exception("Failed to get captcha challenge: %s", e)
             return None
+
+    def get_pending(self, chat_id: int | str, user_id: int | str) -> dict[str, Any] | None:
+        challenge = self.get_challenge(chat_id, user_id)
+        if not challenge:
+            return None
+        if challenge.get("status") != _STATUS_PENDING:
+            return None
+        # Guard against expired challenges not yet enforced by the delayed timeout task.
+        if int(challenge.get("expires_at", 0)) < int(time.time()):
+            return None
+        return challenge
+
+    def mark_verified(self, chat_id: int | str, user_id: int | str) -> None:
+        now = int(time.time())
+        try:
+            self._table.update_item(
+                Key={"stat_key": _key(chat_id, user_id)},
+                UpdateExpression="SET #status = :verified, verified_at = :now",
+                ConditionExpression="attribute_exists(stat_key)",
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={":verified": _STATUS_VERIFIED, ":now": now},
+            )
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                logger.warning("mark_verified: captcha entry no longer exists for user %s", user_id)
+                return None
+            logger.warning("Failed to mark captcha verified: %s", e)
 
     def append_wrong_message(self, chat_id: int | str, user_id: int | str, msg_id: int) -> None:
         """Append a wrong-answer message ID to the tracked list for later cleanup."""

--- a/tests/test_captcha.py
+++ b/tests/test_captcha.py
@@ -36,7 +36,8 @@ def test_correct_answer_unrestricts_user():
     handle_captcha_answer(ctx)
 
     ctx.bot.restrict_chat_member.assert_called_once()
-    captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
+    captcha_repo.mark_verified.assert_called_once_with(-100123, 42)
+    captcha_repo.delete_pending.assert_not_called()
 
 
 def test_wrong_answer_increments_attempts():
@@ -118,13 +119,16 @@ def test_no_pending_captcha_ignored():
     ctx.bot.kick_chat_member.assert_not_called()
 
 
-def test_timeout_with_expired_pending_still_kicks_restricted_user():
+def test_timeout_with_matching_pending_challenge_kicks_user():
     from services.handlers.captcha import process_timeout_task
 
     bot = MagicMock()
-    bot.get_chat_member.return_value = {"status": "restricted"}
     captcha_repo = MagicMock()
-    captcha_repo.get_pending.return_value = None
+    captcha_repo.get_challenge.return_value = {
+        "status": "pending",
+        "join_msg_id": 5,
+        "verify_msg_id": 6,
+    }
 
     process_timeout_task(
         bot,
@@ -138,18 +142,22 @@ def test_timeout_with_expired_pending_still_kicks_restricted_user():
     )
 
     bot.kick_chat_member.assert_called_once_with(-100123, 42)
+    bot.get_chat_member.assert_not_called()
     bot.delete_message.assert_any_call(-100123, 5)
     bot.delete_message.assert_any_call(-100123, 6)
     captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
 
 
-def test_timeout_with_expired_pending_cleans_up_unrestricted_user():
+def test_timeout_with_verified_challenge_does_not_kick_user():
     from services.handlers.captcha import process_timeout_task
 
     bot = MagicMock()
-    bot.get_chat_member.return_value = {"status": "member"}
     captcha_repo = MagicMock()
-    captcha_repo.get_pending.return_value = None
+    captcha_repo.get_challenge.return_value = {
+        "status": "verified",
+        "join_msg_id": 5,
+        "verify_msg_id": 6,
+    }
 
     process_timeout_task(
         bot,
@@ -163,6 +171,113 @@ def test_timeout_with_expired_pending_cleans_up_unrestricted_user():
     )
 
     bot.kick_chat_member.assert_not_called()
+    bot.get_chat_member.assert_not_called()
     bot.delete_message.assert_any_call(-100123, 5)
     bot.delete_message.assert_any_call(-100123, 6)
     captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
+
+
+def test_timeout_with_missing_challenge_state_does_not_kick_user():
+    from services.handlers.captcha import process_timeout_task
+
+    bot = MagicMock()
+    captcha_repo = MagicMock()
+    captcha_repo.get_challenge.return_value = None
+
+    process_timeout_task(
+        bot,
+        {
+            "chat_id": -100123,
+            "user_id": 42,
+            "join_message_id": 5,
+            "verification_message_id": 6,
+            "_captcha_repo": captcha_repo,
+        },
+    )
+
+    bot.kick_chat_member.assert_not_called()
+    bot.get_chat_member.assert_not_called()
+    bot.delete_message.assert_not_called()
+    captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
+
+
+def test_timeout_with_stale_challenge_ids_does_not_kick_current_pending_user():
+    from services.handlers.captcha import process_timeout_task
+
+    bot = MagicMock()
+    captcha_repo = MagicMock()
+    captcha_repo.get_challenge.return_value = {
+        "status": "pending",
+        "join_msg_id": 50,
+        "verify_msg_id": 60,
+    }
+
+    process_timeout_task(
+        bot,
+        {
+            "chat_id": -100123,
+            "user_id": 42,
+            "join_message_id": 5,
+            "verification_message_id": 6,
+            "_captcha_repo": captcha_repo,
+        },
+    )
+
+    bot.kick_chat_member.assert_not_called()
+    bot.get_chat_member.assert_not_called()
+    bot.delete_message.assert_not_called()
+    captcha_repo.delete_pending.assert_not_called()
+
+
+def test_timeout_without_repo_requires_exact_text_only_restriction():
+    from services.handlers.captcha import process_timeout_task
+
+    bot = MagicMock()
+    bot.get_chat_member.return_value = {
+        "status": "restricted",
+        "can_send_messages": True,
+        "can_send_audios": False,
+        "can_send_documents": False,
+        "can_send_photos": False,
+        "can_send_videos": False,
+        "can_send_video_notes": False,
+        "can_send_voice_notes": False,
+        "can_send_polls": False,
+        "can_send_other_messages": False,
+        "can_add_web_page_previews": False,
+    }
+
+    process_timeout_task(
+        bot,
+        {
+            "chat_id": -100123,
+            "user_id": 42,
+            "join_message_id": 5,
+            "verification_message_id": 6,
+        },
+    )
+
+    bot.kick_chat_member.assert_called_once_with(-100123, 42)
+
+
+def test_timeout_without_repo_does_not_kick_generic_restricted_member():
+    from services.handlers.captcha import process_timeout_task
+
+    bot = MagicMock()
+    bot.get_chat_member.return_value = {
+        "status": "restricted",
+        "can_send_messages": True,
+        "can_send_photos": True,
+    }
+
+    process_timeout_task(
+        bot,
+        {
+            "chat_id": -100123,
+            "user_id": 42,
+            "join_message_id": 5,
+            "verification_message_id": 6,
+        },
+    )
+
+    bot.kick_chat_member.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes a production captcha timeout bug where a user could pass captcha, send normal group messages, and still be kicked by the delayed `CHECK_TIMEOUT` task.

## Root Cause

CloudWatch for user `8730984168` showed two reproductions on 2026-06-13 UTC:

- 19:55:02 joined, 19:55:29 passed captcha, 19:57:03 delayed timeout kicked the user.
- 19:59:16 rejoined, 19:59:32 passed captcha, 20:01:17 delayed timeout kicked the user again.

The old success path deleted the DynamoDB pending captcha row immediately after a correct answer. When the delayed timeout task later ran, the missing row was ambiguous: it could mean verified, expired, or state loss. The timeout then fell back to Telegram `getChatMember` and treated `status == restricted` as proof that the user was still captcha-pending. Telegram can still report `restricted` for users who are no longer in the captcha flow, so the timeout misclassified verified users and kicked them.

## Changes

- Store explicit captcha challenge state with `status=pending`, `expires_at`, and longer cleanup TTL.
- Mark successful answers as `status=verified` instead of deleting the challenge row immediately.
- Make `CHECK_TIMEOUT` act only on the exact matching challenge message ids from its SQS payload.
- Ignore stale timeout tasks so an old task cannot kick or clear a later rejoin challenge.
- Stop using broad `status == restricted` as the normal timeout decision when repository state exists.
- Keep a strict text-only restriction fallback only for no-repository cases.
- Add regression tests for verified, missing-state, stale-task, pending-timeout, and fallback paths.

## Validation

- `uv run pytest tests/test_captcha.py tests/test_sqs_task_router.py -q`
- `uv run pytest tests/ -q` (`417 passed`)
- `uv run pre-commit run --all-files`