### PR TITLE
fix: keep pending captcha spam out of normal flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, th
 | Reply thread continuity | Records bot answers in short-term `AGENT_REPLY#...` items so follow-up replies know what the bot just said; these rows are not semantic/vector memory. |
 | Social timing | Ordinary proactive replies are delayed briefly, then a Groq model pool decides from capped recent and query-filtered long-term context whether the bot can add value. If yes, the chat daily limit is reserved and Gemini generates with DeepSeek/Groq fallback. Linked channel posts mirrored into discussion groups use a separate zero-delay comment path and may analyze supported attached media. |
 | Ambient reactions | Optional `setMessageReaction` presence feature for funny, useful, thoughtful, warm, or interesting messages; enabled by default. Ordinary messages are sampled/rate-limited, while linked-channel posts force a reaction attempt. |
-| Smart captcha and anti-spam | Mutes new members until verification and routes suspicious messages through rule-based and Groq checks. |
+| Smart captcha and anti-spam | Mutes new members until verification; pending captcha messages stay in captcha handling, while verified users' suspicious messages go through rule-based and Groq checks. |
 | Community voteban | Lets communities vote to ban or forgive by replying with `/voteban`. |
 | Daily AI news | EventBridge-triggered news Lambda summarizes tech news through Gemini/DeepSeek-compatible provider paths. |
 | IT quizzes | Scheduled and on-demand quiz Lambda sends multilingual developer quizzes and tracks scores. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,13 +67,15 @@ flowchart LR
 
 1. `webhook.handle_event` verifies the Telegram webhook secret.
 2. Private chats get a fixed response; non-whitelisted groups are ignored.
-3. Spam screening runs before normal handling unless a captcha is pending.
+3. Spam screening runs before normal handling unless a captcha is pending. Pending captcha messages stay in the captcha path only: spam-like text is deleted as a wrong captcha attempt, not announced as spam or routed into memory/agent flows.
 4. `group_memory.observe_update` stores non-command group messages and queues long-term memory extraction.
 5. If ambient reactions are enabled, eligible group text messages, including command text, are sampled and queued as `PROCESS_AMBIENT_REACTION`; classification runs asynchronously and does not use long-term memory or vector search.
 6. Irrelevant group chatter exits early.
 7. Relevant events route to the group agent or the command dispatcher.
 8. `/ask` is queued as `PROCESS_GROUP_ASK` with requester metadata so Telegram webhook latency stays low and self-reference questions are grounded. When `/ask` explicitly replies to supported media, the webhook adds only a serializable `media_ref`; it does not download bytes.
 9. `agent_enabled` gates non-command group agent participation: ordinary proactive candidates are delayed as `PROCESS_PROACTIVE_CANDIDATE`, linked-channel post comments are queued as zero-delay `PROCESS_PROACTIVE_CANDIDATE` with Gemini retries plus DeepSeek/Groq text-only fallback, and @mentions/reply-to-bot follow-ups stay immediate. Explicit `/ask` remains available while `memory_enabled` is true.
+
+Captcha timeout cleanup removes failed join artifacts only after a successful kick. If the user verifies successfully, the delayed timeout cleans only captcha prompts and preserves Telegram's original join system message.
 
 ZerdeBot does not automatically analyze every group media message. It analyzes media only when explicitly asked via `/ask` or an explicit mention/reply path, plus official linked-channel post comments. Media analysis is ephemeral and is not written into long-term memory or vector storage by default. Normal photos, voice messages, and documents are ignored for multimodal analysis, including ordinary proactive candidates, daily summaries, memory extraction, and vector indexing.
 

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -50,7 +50,7 @@ RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен р
 | Reply thread continuity | Bot жауаптары short-term `AGENT_REPLY#...` ретінде сақталады, сондықтан follow-up сұрақтар алдыңғы жауапты біледі; бұл semantic/vector memory емес. |
 | Social timing | Ordinary proactive жауаптар қысқа delay-ден кейін recent context және query-filtered long-term context негізінде Groq/DeepSeek decision арқылы өтеді. Yes болса, chat daily limit reserve жасалып, жауап Gemini арқылы generate болады, DeepSeek/Groq fallback бар. Linked-channel post zero-delay comment path арқылы бөлек өңделеді және supported attached media-ны ephemeral талдай алады. |
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages sampled және rate-limited, ал linked-channel post міндетті reaction attempt алады. |
-| Captcha және anti-spam | Жаңа мүшелерді тексеру, rule-based және Groq арқылы spam тексеру. |
+| Captcha және anti-spam | Жаңа мүшелерді тексеру; pending captcha хабарлары тек captcha flow ішінде қалады, ал verified users үшін suspicious messages rule-based және Groq spam checks арқылы өтеді. |
 | Community voteban | `/voteban` арқылы қауымдастық дауысымен ban/forgive. |
 | Daily AI news | EventBridge арқылы іске қосылатын news Lambda Gemini/DeepSeek-compatible жолдармен IT news digest жасайды. |
 | IT quizzes | Scheduled және on-demand quiz Lambda көптілді developer quiz жібереді. |

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -50,7 +50,7 @@ RAG означает **Retrieval-Augmented Generation**: сначала найт
 | Reply thread continuity | Ответы бота сохраняются как short-term `AGENT_REPLY#...`, поэтому follow-up вопросы знают предыдущий ответ; эти записи не являются semantic/vector memory. |
 | Social timing | Ordinary proactive replies ждут короткий delay, затем Groq/DeepSeek решает по recent context и query-filtered long-term context, может ли бот добавить пользу. Если да, резервируется chat daily limit, а ответ генерирует Gemini с DeepSeek/Groq fallback. Linked-channel post обрабатывается отдельным zero-delay comment path и может ephemeral анализировать supported attached media. |
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages получают sampled/rate-limited emoji reaction, а linked-channel post всегда получает reaction attempt. |
-| Captcha и anti-spam | Проверка новых участников, rule-based spam screening и Groq checks. |
+| Captcha и anti-spam | Проверка новых участников; сообщения pending captcha идут только в captcha flow, а подозрительные сообщения verified users проходят rule-based spam screening и Groq checks. |
 | Community voteban | `/voteban` позволяет сообществу голосовать за ban/forgive. |
 | Daily AI news | News Lambda по EventBridge делает IT news digest через Gemini/DeepSeek-compatible paths. |
 | IT quizzes | Scheduled и on-demand quiz Lambda отправляет multilingual developer quizzes. |

--- a/src/bot/services/handlers/captcha.py
+++ b/src/bot/services/handlers/captcha.py
@@ -46,14 +46,13 @@ _CAPTCHA_BLOCKED_PERMISSIONS = tuple(key for key, value in _TEXT_ONLY_PERMISSION
 def _delete_timeout_messages(
     bot: TelegramClient,
     chat_id: int | str,
-    join_message_id: int,
-    verification_message_id: int,
+    message_ids: list[int],
 ) -> None:
-    try:
-        bot.delete_message(chat_id, join_message_id)
-        bot.delete_message(chat_id, verification_message_id)
-    except Exception as e:
-        logger.warning("Failed to delete join/verification messages: %s", e)
+    for message_id in message_ids:
+        try:
+            bot.delete_message(chat_id, message_id)
+        except Exception as e:
+            logger.warning("Failed to delete captcha timeout message %s: %s", message_id, e)
 
 
 def _challenge_matches_timeout_task(
@@ -113,9 +112,10 @@ def process_timeout_task(bot: TelegramClient, task_data: dict[str, Any]) -> None
                     },
                 )
                 return
-            should_cleanup_state = True
             if challenge.get("status") == "verified":
-                _delete_timeout_messages(bot, chat_id, join_message_id, verification_message_id)
+                should_cleanup_state = True
+                wrong_message_ids = list(challenge.get("wrong_msg_ids", []))
+                _delete_timeout_messages(bot, chat_id, [verification_message_id, *wrong_message_ids])
                 logger.info("User %s already verified. Ignoring timeout.", user_id)
                 return
             if challenge.get("status") != "pending":
@@ -131,9 +131,12 @@ def process_timeout_task(bot: TelegramClient, task_data: dict[str, Any]) -> None
 
         logger.info("User %s timed out. Kicking.", user_id)
         bot.kick_chat_member(chat_id, user_id)
-        _delete_timeout_messages(bot, chat_id, join_message_id, verification_message_id)
+        should_cleanup_state = True
+        wrong_message_ids = list(challenge.get("wrong_msg_ids", [])) if challenge else []
+        _delete_timeout_messages(bot, chat_id, [join_message_id, verification_message_id, *wrong_message_ids])
     except Exception as e:
         logger.exception("Timeout task error (user may have left or message deleted): %s", e)
+        raise
     finally:
         if should_cleanup_state:
             _delete_pending_state(captcha_repo, chat_id, user_id)

--- a/src/bot/services/spam/rule_filter.py
+++ b/src/bot/services/spam/rule_filter.py
@@ -25,6 +25,11 @@ _RE_URL = re.compile(r"t\.me/|telegram\.me/|https?://", re.IGNORECASE)
 _RE_PROMO = re.compile(r"аренда|продаж|скидк|подписк|аккаунт|гаранти|отзыв|подключени", re.IGNORECASE)
 
 _RE_SCAM_HOOK = re.compile(r"срочно|за пару (движений|минут)|быстрые деньги|легкие деньги", re.IGNORECASE)
+_RE_FINANCE_TOPIC = re.compile(r"деньг|инвестиц|капитал|доход|финанс|заработ", re.IGNORECASE)
+_RE_SOFT_LEAD_BAIT = re.compile(
+    r"кому\s+интересно.{0,40}(?:скину|пишите|напишу|расскажу)|(?:скину|пишите).{0,40}кому\s+интересно",
+    re.IGNORECASE,
+)
 
 
 class RuleBasedSpamFilter:
@@ -47,6 +52,8 @@ class RuleBasedSpamFilter:
         has_url = bool(_RE_URL.search(text))
         has_promo = bool(_RE_PROMO.search(text))
         has_scam_hook = bool(_RE_SCAM_HOOK.search(text))
+        has_finance_topic = bool(_RE_FINANCE_TOPIC.search(text))
+        has_soft_lead_bait = bool(_RE_SOFT_LEAD_BAIT.search(text))
 
         # @username alone is normal group chat; only score as "external" with other risk signals
         risky_mention = has_mention and (has_money or has_vpn or has_job or is_mixed_script or has_url or has_promo)
@@ -81,6 +88,10 @@ class RuleBasedSpamFilter:
         if has_scam_hook:
             score += 0.25
             triggered.append("scam_hook")
+
+        if has_finance_topic and has_soft_lead_bait:
+            score += 0.35
+            triggered.append("finance_soft_lead_bait")
 
         if has_money and has_scam_hook:
             score += 0.20

--- a/tests/test_captcha.py
+++ b/tests/test_captcha.py
@@ -1,6 +1,8 @@
 """Tests for the grid image captcha: answer checking, state transitions."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
+
+import pytest
 
 
 def _make_ctx(text, user_id, chat_id, captcha_repo):
@@ -38,6 +40,7 @@ def test_correct_answer_unrestricts_user():
     ctx.bot.restrict_chat_member.assert_called_once()
     captcha_repo.mark_verified.assert_called_once_with(-100123, 42)
     captcha_repo.delete_pending.assert_not_called()
+    assert call(-100123, 5) not in ctx.bot.delete_message.call_args_list
 
 
 def test_wrong_answer_increments_attempts():
@@ -128,6 +131,7 @@ def test_timeout_with_matching_pending_challenge_kicks_user():
         "status": "pending",
         "join_msg_id": 5,
         "verify_msg_id": 6,
+        "wrong_msg_ids": [7, 8],
     }
 
     process_timeout_task(
@@ -145,7 +149,38 @@ def test_timeout_with_matching_pending_challenge_kicks_user():
     bot.get_chat_member.assert_not_called()
     bot.delete_message.assert_any_call(-100123, 5)
     bot.delete_message.assert_any_call(-100123, 6)
+    bot.delete_message.assert_any_call(-100123, 7)
+    bot.delete_message.assert_any_call(-100123, 8)
     captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
+
+
+def test_timeout_kick_failure_retries_without_clearing_pending_state():
+    from services.handlers.captcha import process_timeout_task
+
+    bot = MagicMock()
+    bot.kick_chat_member.side_effect = ConnectionResetError("connection reset")
+    captcha_repo = MagicMock()
+    captcha_repo.get_challenge.return_value = {
+        "status": "pending",
+        "join_msg_id": 5,
+        "verify_msg_id": 6,
+    }
+
+    with pytest.raises(ConnectionResetError):
+        process_timeout_task(
+            bot,
+            {
+                "chat_id": -100123,
+                "user_id": 42,
+                "join_message_id": 5,
+                "verification_message_id": 6,
+                "_captcha_repo": captcha_repo,
+            },
+        )
+
+    bot.kick_chat_member.assert_called_once_with(-100123, 42)
+    bot.delete_message.assert_not_called()
+    captcha_repo.delete_pending.assert_not_called()
 
 
 def test_timeout_with_verified_challenge_does_not_kick_user():
@@ -157,6 +192,7 @@ def test_timeout_with_verified_challenge_does_not_kick_user():
         "status": "verified",
         "join_msg_id": 5,
         "verify_msg_id": 6,
+        "wrong_msg_ids": [7],
     }
 
     process_timeout_task(
@@ -172,8 +208,9 @@ def test_timeout_with_verified_challenge_does_not_kick_user():
 
     bot.kick_chat_member.assert_not_called()
     bot.get_chat_member.assert_not_called()
-    bot.delete_message.assert_any_call(-100123, 5)
     bot.delete_message.assert_any_call(-100123, 6)
+    bot.delete_message.assert_any_call(-100123, 7)
+    assert call(-100123, 5) not in bot.delete_message.call_args_list
     captcha_repo.delete_pending.assert_called_once_with(-100123, 42)
 
 

--- a/tests/test_spam_rule_filter.py
+++ b/tests/test_spam_rule_filter.py
@@ -91,6 +91,27 @@ def test_cyrillic_ruble_suffix_without_space_triggers_money(f):
     assert score > 0.3
 
 
+def test_finance_soft_lead_bait_queues_for_ai_check(f):
+    text = (
+        "Читаю книгу «Психология денег». Книга не про умные схемы инвестиций, "
+        "а про решения и привычки, которые постепенно влияют на капитал. Кому интересно, скину."
+    )
+    score, rules = f.check(text, _USER_ID, _CHAT_ID)
+    assert "finance_soft_lead_bait" in rules
+    assert score >= 0.15
+    assert score < 0.8
+
+
+def test_plain_finance_book_discussion_stays_low(f):
+    score, rules = f.check(
+        "Кто читал «Психология денег»? Нормальная книга про привычки и капитал.",
+        _USER_ID,
+        _CHAT_ID,
+    )
+    assert "finance_soft_lead_bait" not in rules
+    assert score < 0.15
+
+
 def test_mention_only_does_not_trigger_external_even_if_short(f):
     score, rules = f.check("@user", _USER_ID, _CHAT_ID)
     assert "external_mention" not in rules

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -113,8 +113,14 @@ def test_pending_captcha_message_skips_spam_screening():
     with (
         patch("webhook._spam_screening", return_value=screener),
         patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_group_memory_update") as observe_memory,
+        patch("webhook.maybe_enqueue_ambient_reaction") as ambient_reaction,
+        patch("webhook.handle_group_agent_update") as group_agent,
     ):
         _handle_api_gateway(event, dispatcher, MagicMock())
 
     screener.run.assert_not_called()
+    observe_memory.assert_not_called()
+    ambient_reaction.assert_not_called()
+    group_agent.assert_not_called()
     dispatcher.process_update.assert_called_once_with(body)


### PR DESCRIPTION
## Summary
- keep pending-captcha messages isolated from spam, memory, ambient reaction, and proactive agent flows
- preserve Telegram's join system message after successful captcha verification when the delayed timeout fires
- retry captcha timeout kicks when Telegram `banChatMember` fails instead of clearing pending state and treating the SQS record as complete
- clean captcha/join/wrong-answer artifacts after a successful timeout kick, and add a low-risk AI-review rule for finance soft lead-bait spam from verified users

## Production evidence
- 2026-06-16 13:40:51 UTC: user `8769281045` joined chat `-1001244628965`; captcha timeout task was queued.
- 2026-06-16 13:42:51 UTC: timeout worker logged `User 8769281045 timed out. Kicking.` but Telegram `banChatMember` failed with `ConnectionResetError(104, 'Connection reset by peer')`.
- The old handler swallowed that exception, logged the SQS record as completed, and cleared captcha state.
- 2026-06-16 13:45:52 UTC: the same user posted the soft spam text. Since captcha state was already cleared and the existing rule filter scored it `0.0`, it entered normal memory/ambient/proactive handling instead of spam review.

## Validation
- `uv run pytest tests/test_captcha.py tests/test_webhook.py tests/test_spam_rule_filter.py tests/test_spam_processor.py -q`
- `uv run pytest tests/ -q`
- `uv run pre-commit run --all-files`
