### PR TITLE
FIX: scope weekly quiz scores to scheduled polls

### DIFF
--- a/src/bot/services/handlers/quiz.py
+++ b/src/bot/services/handlers/quiz.py
@@ -77,10 +77,28 @@ def handle_poll_answer(ctx: Context) -> None:
     selected_option = option_ids[0]
 
     points = int(quiz_record.get("points", 1))
+    record_key = str(quiz_record.get("SK", ""))
+    weekly_points = points if record_key.startswith("DATE#") else 0
 
     if selected_option == correct_option_id:
-        ctx.quiz_repo.update_score_correct(chat_id, user_id, first_name, poll_id=poll_id, points=points)
-        logger.info("Correct answer recorded", extra={"user_id": user_id, "chat_id": chat_id, "points": points})
+        ctx.quiz_repo.update_score_correct(
+            chat_id,
+            user_id,
+            first_name,
+            poll_id=poll_id,
+            points=points,
+            weekly_points=weekly_points,
+        )
+        logger.info(
+            "Correct answer recorded",
+            extra={
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "points": points,
+                "weekly_points": weekly_points,
+                "quiz_record_key": record_key,
+            },
+        )
     else:
         ctx.quiz_repo.update_score_wrong(chat_id, user_id, first_name, poll_id=poll_id)
         logger.info("Wrong answer recorded", extra={"user_id": user_id, "chat_id": chat_id})

--- a/src/bot/services/repositories/quiz.py
+++ b/src/bot/services/repositories/quiz.py
@@ -66,6 +66,7 @@ class QuizRepository:
         *,
         poll_id: str,
         points: int = 1,
+        weekly_points: int | None = None,
     ) -> None:
         """Update user score for a correct answer with streak logic.
 
@@ -84,12 +85,14 @@ class QuizRepository:
             new_streak = 1
         best_streak = max(new_streak, int((current or {}).get("best_streak", 0)))
 
+        week_points = points if weekly_points is None else weekly_points
+
         try:
             self._table.update_item(
                 Key={"PK": f"SCORE#{chat_id}", "SK": f"USER#{user_id}"},
                 UpdateExpression=(
                     "SET total_score = if_not_exists(total_score, :zero) + :pts,"
-                    "    week_score = if_not_exists(week_score, :zero) + :pts,"
+                    "    week_score = if_not_exists(week_score, :zero) + :week_pts,"
                     "    current_streak = :streak,"
                     "    best_streak = :best,"
                     "    last_correct_date = :today,"
@@ -103,6 +106,7 @@ class QuizRepository:
                 ExpressionAttributeValues={
                     ":zero": 0,
                     ":pts": points,
+                    ":week_pts": week_points,
                     ":streak": new_streak,
                     ":best": best_streak,
                     ":today": today,
@@ -114,7 +118,13 @@ class QuizRepository:
             )
             logger.info(
                 "Correct answer recorded",
-                extra={"user_id": user_id, "chat_id": chat_id, "poll_id": poll_id, "points": points},
+                extra={
+                    "user_id": user_id,
+                    "chat_id": chat_id,
+                    "poll_id": poll_id,
+                    "points": points,
+                    "weekly_points": week_points,
+                },
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":

--- a/src/quiz/services/quiz_service.py
+++ b/src/quiz/services/quiz_service.py
@@ -1,5 +1,6 @@
 """Quiz domain services for managing generation, sending and leaderboards."""
 
+import html
 import random
 import re
 import uuid
@@ -115,26 +116,35 @@ class QuizService:
         return text
 
     def build_leaderboard_text(self, lang: str, entries: list[dict]) -> str:
-        """Build the formatted leaderboard text with competition-style tie handling.
-
-        Users with equal scores share the same rank and medal.
-        Example: two users at 7 pts both get 🥈; the next unique score is rank 4.
-        """
+        """Build the formatted leaderboard text, grouping users with equal scores."""
         header = get_translated_text("leaderboard_header", lang)
         if not entries:
             return header + get_translated_text("leaderboard_empty", lang)
 
         lines = []
-        rank = 1
-        for i, entry in enumerate(entries):
-            if i > 0 and int(entry.get("week_score", 0)) < int(entries[i - 1].get("week_score", 0)):
-                rank = i + 1  # standard competition ranking: rank jumps to actual position
+        rank = 0
+        current_score: int | None = None
+        mentions: list[str] = []
+
+        def flush_group() -> None:
+            if current_score is None or not mentions:
+                return
             medal = _MEDALS[rank - 1] if rank - 1 < len(_MEDALS) else f"{rank}."
-            user_id = entry.get("SK", "").replace("USER#", "")
-            first_name = entry.get("first_name", "User")
+            lines.append(f"{medal} {', '.join(mentions)} — <b>{current_score}</b>")
+
+        for entry in entries:
             score = int(entry.get("week_score", 0))
+            if current_score is None or score != current_score:
+                flush_group()
+                rank += 1
+                current_score = score
+                mentions = []
+            user_id = entry.get("SK", "").replace("USER#", "")
+            first_name = html.escape(str(entry.get("first_name", "User")))
             mention = f'<a href="tg://user?id={user_id}">{first_name}</a>'
-            lines.append(f"{medal} {mention} — <b>{score}</b>")
+            mentions.append(mention)
+
+        flush_group()
 
         return header + "\n".join(lines)
 

--- a/tests/test_quiz_handler.py
+++ b/tests/test_quiz_handler.py
@@ -53,6 +53,28 @@ class TestHandlePollAnswer:
             "Test",
             poll_id="poll123",
             points=3,
+            weekly_points=3,
+        )
+
+    def test_on_demand_correct_answer_does_not_add_weekly_points(self):
+        quiz_repo = MagicMock()
+        quiz_repo.lookup_poll.return_value = {
+            "PK": "QUIZ#-100123",
+            "SK": "ONDEMAND#poll123",
+            "correct_option_id": 2,
+            "points": 3,
+        }
+        ctx = self._make_ctx("poll123", 456, 2, quiz_repo)
+
+        handle_poll_answer(ctx)
+
+        quiz_repo.update_score_correct.assert_called_once_with(
+            "-100123",
+            "456",
+            "Test",
+            poll_id="poll123",
+            points=3,
+            weekly_points=0,
         )
 
     def test_wrong_answer_updates_score(self):

--- a/tests/test_quiz_service_on_demand.py
+++ b/tests/test_quiz_service_on_demand.py
@@ -42,6 +42,33 @@ def _make_service() -> QuizService:
     return svc
 
 
+def test_leaderboard_groups_tied_scores_on_one_line() -> None:
+    svc = _make_service()
+
+    text = svc.build_leaderboard_text(
+        "en",
+        [
+            {"SK": "USER#1", "first_name": "Bayashat", "week_score": 15},
+            {"SK": "USER#2", "first_name": "Lio", "week_score": 15},
+            {"SK": "USER#3", "first_name": "Adilet", "week_score": 13},
+            {"SK": "USER#4", "first_name": "Yesbol", "week_score": 12},
+            {"SK": "USER#5", "first_name": "Alikhan", "week_score": 12},
+        ],
+    )
+
+    assert '<a href="tg://user?id=1">Bayashat</a>, <a href="tg://user?id=2">Lio</a> — <b>15</b>' in text
+    assert '🥈 <a href="tg://user?id=3">Adilet</a> — <b>13</b>' in text
+    assert '<a href="tg://user?id=4">Yesbol</a>, <a href="tg://user?id=5">Alikhan</a> — <b>12</b>' in text
+
+
+def test_leaderboard_escapes_user_names() -> None:
+    svc = _make_service()
+
+    text = svc.build_leaderboard_text("en", [{"SK": "USER#1", "first_name": "A&B", "week_score": 1}])
+
+    assert '<a href="tg://user?id=1">A&amp;B</a> — <b>1</b>' in text
+
+
 def _question(points: int = 3) -> dict:
     return {
         "question": "What is Python?",

--- a/tests/test_quiz_streak.py
+++ b/tests/test_quiz_streak.py
@@ -41,12 +41,30 @@ class TestStreakCorrectAnswer:
         call_kwargs = mock_table.update_item.call_args[1]
         vals = call_kwargs["ExpressionAttributeValues"]
         assert vals[":pts"] == 1
+        assert vals[":week_pts"] == 1
         assert vals[":streak"] == 1
         assert vals[":best"] == 1
         assert vals[":poll_id"] == "poll-1"
         assert vals[":poll_list"] == ["poll-1"]
         assert "answered_poll_ids" in call_kwargs["ConditionExpression"]
         assert "last_answered_date <> :today" not in call_kwargs["ConditionExpression"]
+
+    @_PATCH_YESTERDAY
+    @_PATCH_TODAY
+    @patch("services.repositories.quiz.get_dynamodb")
+    def test_on_demand_correct_answer_can_skip_weekly_points(self, mock_dynamo, _m_today, _m_yday):
+        mock_table = MagicMock()
+        mock_dynamo.return_value.Table.return_value = mock_table
+
+        from services.repositories.quiz import QuizRepository
+
+        repo = QuizRepository()
+        repo.get_user_score = MagicMock(return_value=None)
+        repo.update_score_correct("chat1", "user1", "Test", poll_id="poll-1", points=3, weekly_points=0)
+
+        vals = mock_table.update_item.call_args[1]["ExpressionAttributeValues"]
+        assert vals[":pts"] == 3
+        assert vals[":week_pts"] == 0
 
     @_PATCH_YESTERDAY
     @_PATCH_TODAY


### PR DESCRIPTION
## Summary
- keep weekly quiz scores scoped to scheduled DATE# daily polls, while ONDEMAND# /genquiz polls can still update total score and duplicate-answer tracking
- group tied weekly leaderboard users onto one line and escape displayed names for Telegram HTML
- add regression tests for scheduled vs on-demand weekly points and tied leaderboard rendering

## Root Cause
Aman world weekly leaderboard used the shared week_score field for every correct quiz poll answer. /genquiz on-demand polls are stored as ONDEMAND#<poll_id>, but the bot poll_answer handler only looked up the poll_id and passed the full points into update_score_correct. That made on-demand quiz answers count toward the weekly scheduled quiz leaderboard, so users could exceed the expected Mon-Fri maximum of 1+2+3+4+5 = 15.

Production evidence checked on 2026-06-22:
- chat -1001244628965 is Aman world әңгіме
- 2026-06-19 leaderboard sent at 13:00:25 UTC / 18:00:25 Almaty
- quiz table contained ONDEMAND# polls during the prior scoring window, including 2026-06-18 ONDEMAND#5307528311595865963 worth 3 points
- no ONDEMAND# polls exist after the 2026-06-19 18:00 Almaty reset, so current Monday scores did not need DynamoDB correction

## Validation
- uv run pytest tests/test_quiz_handler.py tests/test_quiz_streak.py tests/test_quiz_service_on_demand.py -q
- uv run pytest tests/ -q
