### PR TITLE
FEATURE: improve daily news digest quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, th
 | Ambient reactions | Optional `setMessageReaction` presence feature for funny, useful, thoughtful, warm, or interesting messages; enabled by default. Ordinary messages are sampled/rate-limited, while linked-channel posts force a reaction attempt. |
 | Smart captcha and anti-spam | Mutes new members until verification; pending captcha messages stay in captcha handling, strong high-confidence spam is removed silently, and weak or ambiguous cases go to admin review with optional admin @mentions. |
 | Community voteban | Lets communities vote to ban or forgive by replying with `/voteban`. |
-| Daily AI news | EventBridge-triggered news Lambda summarizes tech news through Gemini/DeepSeek-compatible provider paths. |
+| Daily AI news | EventBridge-triggered news Lambda enriches RSS candidates with article text/images, ranks high-signal developer stories, and sends fact-first multilingual digests through Gemini/DeepSeek-compatible provider paths. |
 | IT quizzes | Scheduled and on-demand quiz Lambda sends multilingual developer quizzes and tracks scores. |
 | Serverless operations | AWS CDK manages Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM, and alarms. |
 

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -52,7 +52,7 @@ RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен р
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages sampled және rate-limited, ал linked-channel post міндетті reaction attempt алады. |
 | Captcha және anti-spam | Жаңа мүшелерді тексеру; pending captcha хабарлары тек captcha flow ішінде қалады, strong high-confidence spam үнсіз өшіріледі, ал weak/ambiguous жағдайлар optional admin @mentions бар admin review-ға жіберіледі. |
 | Community voteban | `/voteban` арқылы қауымдастық дауысымен ban/forgive. |
-| Daily AI news | EventBridge арқылы іске қосылатын news Lambda Gemini/DeepSeek-compatible жолдармен IT news digest жасайды. |
+| Daily AI news | EventBridge арқылы іске қосылатын news Lambda RSS кандидаттарын мақала мәтіні/суретімен толықтырады, developer-ге пайдалы high-signal жаңалықтарды таңдайды және Gemini/DeepSeek-compatible жолдармен fact-first көптілді digest жібереді. |
 | IT quizzes | Scheduled және on-demand quiz Lambda көптілді developer quiz жібереді. |
 | Serverless ops | AWS CDK Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM және alarms ресурстарын басқарады. |
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -52,7 +52,7 @@ RAG означает **Retrieval-Augmented Generation**: сначала найт
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages получают sampled/rate-limited emoji reaction, а linked-channel post всегда получает reaction attempt. |
 | Captcha и anti-spam | Проверка новых участников; сообщения pending captcha идут только в captcha flow, strong high-confidence spam удаляется тихо, а weak/ambiguous случаи уходят на admin review с optional admin @mentions. |
 | Community voteban | `/voteban` позволяет сообществу голосовать за ban/forgive. |
-| Daily AI news | News Lambda по EventBridge делает IT news digest через Gemini/DeepSeek-compatible paths. |
+| Daily AI news | News Lambda по EventBridge обогащает RSS-кандидаты текстом/картинками статей, выбирает high-signal новости для разработчиков и отправляет fact-first multilingual digest через Gemini/DeepSeek-compatible paths. |
 | IT quizzes | Scheduled и on-demand quiz Lambda отправляет multilingual developer quizzes. |
 | Serverless ops | AWS CDK управляет Lambda, API Gateway, DynamoDB, SQS, EventBridge, S3 Vectors, IAM и alarms. |
 

--- a/src/news/services/ai_client.py
+++ b/src/news/services/ai_client.py
@@ -38,14 +38,26 @@ def _map_gemini_api_error(exc: genai_errors.APIError) -> ZerdeProviderError:
 _TOP_NEWS_RESPONSE_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "top_indices": {
+        "top_news": {
             "type": "array",
             "minItems": 3,
             "maxItems": 3,
-            "items": {"type": "integer"},
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "category": {
+                        "type": "string",
+                        "enum": ["global_tech_ai", "hardcore_engineering", "kz_or_regional", "other_high_signal"],
+                    },
+                    "score_reason": {"type": "string"},
+                },
+                "required": ["index", "category", "score_reason"],
+                "additionalProperties": False,
+            },
         },
     },
-    "required": ["top_indices"],
+    "required": ["top_news"],
     "additionalProperties": False,
 }
 
@@ -57,6 +69,9 @@ _ARTICLE_DIGEST_RESPONSE_SCHEMA: dict[str, Any] = {
     "required": ["digest"],
     "additionalProperties": False,
 }
+
+_MIN_SELECTION_QUALITY_SCORE = 1.0
+_MIN_GENERATIVE_TEXT_CHARS = 420
 
 
 class NewsAIClientBase(ABC):
@@ -72,31 +87,161 @@ class NewsAIClientBase(ABC):
     ) -> dict:
         """Call the LLM and return the parsed JSON dict. Raises on failure."""
 
-    def select_top_news(self, news_items: list[dict]) -> list[int]:
-        """Ask the model to pick the top 3 unique news indices."""
+    def _fallback_top_news(
+        self,
+        news_items: list[dict],
+        used_indices: set[int] | None = None,
+        used_domains: set[str] | None = None,
+    ) -> list[dict]:
+        """Deterministically pick high-quality, domain-unique fallback selections."""
+        used_indices = used_indices or set()
+        used_domains = used_domains or set()
+        selections: list[dict] = []
+        sorted_items = sorted(
+            news_items,
+            key=lambda item: (
+                float(item.get("quality_score", 0)),
+                bool(item.get("image_url")),
+                int(item.get("full_text_chars") or 0),
+            ),
+            reverse=True,
+        )
+        for article in sorted_items:
+            index = int(article.get("index", -1))
+            domain = str(article.get("domain") or "")
+            if index in used_indices or (domain and domain in used_domains):
+                continue
+            if len(selections) < 3 and float(article.get("quality_score", 0)) < _MIN_SELECTION_QUALITY_SCORE:
+                continue
+            selections.append(
+                {
+                    "index": index,
+                    "category": (
+                        "kz_or_regional" if article.get("source_region") in {"kz", "regional"} else "other_high_signal"
+                    ),
+                    "score_reason": "local quality-score fallback",
+                }
+            )
+            used_indices.add(index)
+            if domain:
+                used_domains.add(domain)
+            if len(selections) == 3:
+                break
+
+        if len(selections) < min(3, len(news_items)):
+            for article in sorted_items:
+                index = int(article.get("index", -1))
+                domain = str(article.get("domain") or "")
+                if index in used_indices or (domain and domain in used_domains):
+                    continue
+                selections.append(
+                    {
+                        "index": index,
+                        "category": "other_high_signal",
+                        "score_reason": "low-supply local fallback",
+                    }
+                )
+                used_indices.add(index)
+                if domain:
+                    used_domains.add(domain)
+                if len(selections) == min(3, len(news_items)):
+                    break
+        return selections
+
+    def _validate_top_news_response(self, data: dict, news_items: list[dict]) -> list[dict]:
+        """Normalize LLM choices and enforce local uniqueness/quality constraints."""
+        raw_items = data.get("top_news")
+        if raw_items is None:
+            raw_items = [
+                {"index": index, "category": "other_high_signal", "score_reason": "legacy response"}
+                for index in data.get("top_indices", [])
+            ]
+
+        by_index = {int(item["index"]): item for item in news_items if "index" in item}
+        selections: list[dict] = []
+        used_indices: set[int] = set()
+        used_domains: set[str] = set()
+
+        for raw in raw_items or []:
+            try:
+                index = int(raw.get("index"))
+            except (AttributeError, TypeError, ValueError):
+                continue
+            article = by_index.get(index)
+            if not article or index in used_indices:
+                continue
+            domain = str(article.get("domain") or "")
+            if domain and domain in used_domains:
+                continue
+            if float(article.get("quality_score", 0)) < _MIN_SELECTION_QUALITY_SCORE:
+                continue
+            selections.append(
+                {
+                    "index": index,
+                    "category": str(raw.get("category") or "other_high_signal"),
+                    "score_reason": str(raw.get("score_reason") or "selected by AI"),
+                }
+            )
+            used_indices.add(index)
+            if domain:
+                used_domains.add(domain)
+            if len(selections) == min(3, len(news_items)):
+                break
+
+        if len(selections) < min(3, len(news_items)):
+            filler = self._fallback_top_news(
+                news_items,
+                used_indices=set(used_indices),
+                used_domains=set(used_domains),
+            )
+            for item in filler:
+                if item["index"] not in used_indices:
+                    selections.append(item)
+                    used_indices.add(item["index"])
+                if len(selections) == min(3, len(news_items)):
+                    break
+
+        return selections
+
+    def select_top_news(self, news_items: list[dict]) -> list[dict]:
+        """Ask the model to pick the top 3 unique enriched news candidates."""
         if not news_items:
             return []
 
-        payload = [{"index": n["index"], "title": n["title"], "summary": n["summary"]} for n in news_items]
+        payload = [
+            {
+                "index": n["index"],
+                "title": n["title"],
+                "summary": n.get("summary", ""),
+                "domain": n.get("domain", ""),
+                "source_region": n.get("source_region", "global"),
+                "has_image": bool(n.get("image_url")),
+                "full_text_chars": int(n.get("full_text_chars") or 0),
+                "quality_score": float(n.get("quality_score", 0)),
+                "quality_reasons": n.get("quality_reasons", []),
+                "text_preview": (n.get("full_text") or n.get("summary") or "")[:700],
+            }
+            for n in news_items
+        ]
         prompt = (
             "You are an expert IT Editor curating a daily news digest for a hardcore community of Software Engineers (primarily backend, cloud, and AI developers).\n"  # noqa: E501
-            "Analyze the provided JSON list of news items and cluster duplicate or similar stories.\n"
-            "Your task is to select EXACTLY 3 of the most IMPACTFUL, HIGH-SIGNAL, and UNIQUE news items.\n\n"
+            "Analyze the provided enriched JSON list of news items and cluster duplicate or similar stories.\n"
+            "Your task is to select EXACTLY 3 of the most IMPACTFUL, HIGH-SIGNAL, and UNIQUE news items.\n"
+            "Prefer candidates with strong quality_score, concrete article text, "
+            "clear developer relevance, and images.\n\n"
             "**DEFINITION OF 'IMPACTFUL' FOR THIS AUDIENCE:**\n"
             "✅ YES (High Priority): Major framework/tool updates (e.g., AWS, Python, AI models), deep architectural insights, high-profile open-source releases, tech startup funding, or paradigm shifts in software engineering.\n"  # noqa: E501
-            "❌ NO (DO NOT SELECT): Boring technical standards (like raw RFC protocol texts), generic e-government/municipal updates (e.g., citizen portals, public services), pure consumer gadget reviews, or corporate PR fluff.\n\n"  # noqa: E501
-            "To ensure content diversity, select one article from each of the following 3 categories:\n"
+            "❌ NO (DO NOT SELECT): Empty/thin article pages, generic e-government/municipal updates, pure consumer gadget reviews, homepage/project pages with no news angle, or corporate PR fluff.\n\n"  # noqa: E501
+            "Aim for content diversity across these categories when quality supports it:\n"
             "1. Global Tech & AI: Game-changing tech news, major AI model releases, or massive industry shifts that affect how developers build software.\n"  # noqa: E501
             "2. Hardcore Engineering: Practical cloud infrastructure (Serverless, AWS), backend architecture, or DevOps tools.\n"  # noqa: E501
             "3. Kazakhstan IT & Community: Local tech startups, IT business in KZ, Almaty/Astana developer community events, or Kazakhstani tech industry news.\n\n"  # noqa: E501
-            "🛡️ STRICT DIVERSITY & GEOGRAPHY QUOTAS (CRITICAL):\n"
-            "- EXACTLY ONE KAZAKHSTAN ARTICLE: You MUST select exactly 1 article from Kazakhstani sources (often in Russian or Kazakh). This belongs strictly to Category 3.\n"  # noqa: E501
-            "- GLOBAL DOMINANCE: Categories 1 and 2 MUST be fulfilled by international, English-language tech media.\n"
+            "🛡️ LOCAL CONSTRAINTS:\n"
+            "- Kazakhstan/regional content is a SOFT BONUS, not a quota. Include one only when it is genuinely strong for software/AI/cloud/startup developers.\n"  # noqa: E501
+            "- If KZ/local candidates are weak, choose three stronger global engineering/AI stories instead.\n"
             "- DOMAIN UNIQUENESS: Do not select multiple articles from the same website domain.\n\n"
-            "⚠️ FALLBACK RULE: If the news pool lacks quality articles in one of these categories, "
-            "substitute it with another highly engaging article, but NEVER violate the 'EXACTLY ONE KAZAKHSTAN ARTICLE' quota unless the pool has absolutely zero KZ news.\n\n"  # noqa: E501
             "Respond ONLY with a JSON object in this exact format:\n"
-            '{"top_indices": [idx1, idx2, idx3]}\n\n'
+            '{"top_news": [{"index": 0, "category": "global_tech_ai", "score_reason": "concrete reason"}]}\n\n'
             f"DATA:\n{json.dumps(payload, ensure_ascii=False)}"
         )
 
@@ -108,13 +253,15 @@ class NewsAIClientBase(ABC):
                 max_output_tokens=1024,
                 response_json_schema=_TOP_NEWS_RESPONSE_SCHEMA,
             )
-            indices = data.get("top_indices", [0, 1, 2])
-            result = [int(i) for i in indices if 0 <= int(i) < len(news_items)][:3]
-            logger.info("Top news selected", extra={"indices": result, "pool_size": len(news_items)})
+            result = self._validate_top_news_response(data, news_items)
+            logger.info(
+                "Top news selected",
+                extra={"indices": [item["index"] for item in result], "pool_size": len(news_items)},
+            )
             return result
         except ZerdeProviderError:
-            logger.exception("AI failed to select top news; falling back to first items")
-            return list(range(min(3, len(news_items))))
+            logger.exception("AI failed to select top news; falling back to local quality score")
+            return self._fallback_top_news(news_items)
 
     def generate_digests_per_article(self, deep_news_items: list[dict], chat_lang: str) -> list[str]:
         """Generate one HTML digest block per article for pairing with images."""
@@ -142,31 +289,46 @@ class NewsAIClientBase(ABC):
         )
 
         def fallback(article: dict) -> str:
-            return f"<b>{article['title']}</b>\n{article['link']}"
+            summary = (article.get("summary") or article.get("full_text") or "").strip()
+            summary_line = f"\n\n{summary[:420]}" if summary else ""
+            return f'<b>{article["title"]}</b>{summary_line}\n\n<a href="{article["link"]}">{read_full_text}</a>'
 
         def build_prompt(article: dict) -> str:
             payload = {
                 "title": article["title"],
                 "link": article["link"],
+                "source_summary": article.get("summary", ""),
                 "full_text": article.get("full_text", article["summary"]),
+                "full_text_chars": int(article.get("full_text_chars") or 0),
             }
             return (
                 f"You are an expert IT journalist for a {community_name}.\n"
-                "I will give you the FULL text of one IT news article.\n"
-                f"Write ONE digest block in modern {language}. "
+                "I will give you the title, source summary, and extracted article text for one IT news article.\n"
+                f"Write ONE fact-first digest block in modern {language}. "
                 f"CRITICAL: The ENTIRE block, INCLUDING the TITLE, MUST be completely translated and written in {language}.\n\n"  # noqa: E501
                 "FORMAT RULES:\n"
-                f"1. One relevant Emoji, then a <b>Catchy Title TRANSLATED INTO {language}</b>.\n"
-                "2. Add two new lines (\\n\\n) after the title, then write 3-4 sentences of deep analysis based on the full text.\n"  # noqa: E501
+                f"1. One relevant Emoji, then a <b>specific factual title TRANSLATED INTO {language}</b>.\n"
+                "2. Add two new lines (\\n\\n) after the title, then write 3-4 concise sentences based ONLY on the provided title, source summary, and full_text.\n"  # noqa: E501
                 f'3. End with the HTML link: <a href="URL">{read_full_text}</a>.\n'
                 "4. NO raw URLs except inside the href attribute.\n"
                 "5. Keep the block under ~800 characters.\n\n"
+                "CONTENT RULES:\n"
+                "- Say what concretely happened: who did what, which product/model/tool/company is involved, and what changes for developers.\n"  # noqa: E501
+                "- Include at least one concrete detail from the article: a version, number, named feature, affected tool, company, model, API, vulnerability, funding amount, or deployment impact.\n"  # noqa: E501
+                "- Do NOT invent details or write generic hype. Avoid phrases like 'industry benchmark', 'new cornerstone', 'new chapter', 'core driver', or 'urgent challenge' unless the text explicitly supports them.\n"  # noqa: E501
+                "- If evidence is limited, be modest and specific instead of analytical.\n\n"
                 "Respond ONLY with a JSON object:\n"
                 '{"digest": "single html digest block"}\n\n'
                 f"DATA:\n{json.dumps(payload, ensure_ascii=False)}"
             )
 
         def generate_one(index: int, article: dict) -> str:
+            if int(article.get("full_text_chars") or 0) < _MIN_GENERATIVE_TEXT_CHARS:
+                logger.info(
+                    "Skipping AI digest generation for thin article text",
+                    extra={"index": index, "full_text_chars": int(article.get("full_text_chars") or 0)},
+                )
+                return fallback(article)
             logger.info("Generating single article digest", extra={"index": index})
             data = self._generate(
                 build_prompt(article),

--- a/src/news/services/digest.py
+++ b/src/news/services/digest.py
@@ -1,18 +1,181 @@
 """DigestService: orchestrates the full news digest pipeline."""
 
+import re
 from typing import Any
+from urllib.parse import urlsplit
 
 from core.logger import LoggerAdapter, get_logger
 from core.utils import extract_event, get_intro_text
 from services.ai_client import NewsAIClientBase
-from services.news_fetcher import NewsFetcher
+from services.news_fetcher import NewsFetcher, classify_source_region, extract_domain
 from services.telegram import TelegramSender
 
 logger = LoggerAdapter(get_logger(__name__), {})
 
+_MAX_ENRICH_CANDIDATES = 45
+_MIN_SELECTABLE_QUALITY_SCORE = 1.0
+
+_DEVELOPER_TERMS = {
+    "agent",
+    "ai",
+    "api",
+    "architecture",
+    "aws",
+    "backend",
+    "benchmark",
+    "cloud",
+    "container",
+    "cursor",
+    "cybersecurity",
+    "database",
+    "developer",
+    "devops",
+    "docker",
+    "framework",
+    "gemini",
+    "github",
+    "infrastructure",
+    "kubernetes",
+    "lambda",
+    "llm",
+    "mcp",
+    "model",
+    "open source",
+    "python",
+    "rag",
+    "release",
+    "security",
+    "serverless",
+    "sentry",
+    "software",
+    "startup",
+    "tool",
+    "typescript",
+}
+_LOW_SIGNAL_TERMS = {
+    "advertorial",
+    "award",
+    "conference agenda",
+    "discount",
+    "giveaway",
+    "launches campaign",
+    "partnership announcement",
+    "press release",
+    "sponsored",
+}
+_CONSUMER_TERMS = {
+    "smartphone",
+    "tablet",
+    "tv",
+    "headphones",
+    "gaming laptop",
+    "wearable",
+}
+
+
+def _text_for_scoring(article: dict) -> str:
+    return " ".join(str(article.get(key) or "") for key in ("title", "summary", "full_text")).lower()
+
+
+def _term_hits(text: str, terms: set[str]) -> int:
+    return sum(1 for term in terms if term in text)
+
+
+def _title_key(title: str) -> str:
+    return re.sub(r"[^a-z0-9а-яәғқңөұүһіё]+", " ", title.lower()).strip()
+
+
+def _is_homepage_like(article: dict) -> bool:
+    path = urlsplit(str(article.get("link") or "")).path.strip("/")
+    return not path or path in {"news", "feed", "rss"}
+
+
+def _preliminary_score(article: dict) -> float:
+    text = _text_for_scoring(article)
+    score = float(min(_term_hits(text, _DEVELOPER_TERMS), 8))
+    if article.get("source_region") == "kz":
+        score += 0.6
+    if _term_hits(text, _LOW_SIGNAL_TERMS):
+        score -= 2.0
+    if _term_hits(text, _CONSUMER_TERMS):
+        score -= 1.0
+    if _is_homepage_like(article):
+        score -= 1.5
+    return score
+
+
+def _score_article_quality(article: dict) -> tuple[float, list[str]]:
+    """Score local digest quality before asking the LLM to rank candidates."""
+    score = 0.0
+    reasons: list[str] = []
+    text = _text_for_scoring(article)
+    full_text_chars = int(article.get("full_text_chars") or len(str(article.get("full_text") or "")))
+    has_image = bool(article.get("image_url"))
+    dev_hits = _term_hits(text, _DEVELOPER_TERMS)
+
+    if full_text_chars >= 1200:
+        score += 2.0
+        reasons.append("substantial_article_text")
+    elif full_text_chars >= 500:
+        score += 1.2
+        reasons.append("usable_article_text")
+    elif full_text_chars >= 220:
+        score += 0.4
+        reasons.append("short_article_text")
+    else:
+        score -= 1.4
+        reasons.append("weak_or_empty_article_text")
+
+    if has_image:
+        score += 0.8
+        reasons.append("has_image")
+    else:
+        score -= 0.3
+        reasons.append("no_image")
+
+    if dev_hits >= 6:
+        score += 2.0
+        reasons.append("strong_developer_relevance")
+    elif dev_hits >= 3:
+        score += 1.2
+        reasons.append("developer_relevance")
+    elif dev_hits >= 1:
+        score += 0.4
+        reasons.append("weak_developer_relevance")
+    else:
+        score -= 1.0
+        reasons.append("low_developer_relevance")
+
+    low_signal_hits = _term_hits(text, _LOW_SIGNAL_TERMS)
+    if low_signal_hits:
+        score -= 1.2
+        reasons.append("possible_pr_or_low_signal")
+
+    if _term_hits(text, _CONSUMER_TERMS):
+        score -= 0.8
+        reasons.append("consumer_gadget_angle")
+
+    if _is_homepage_like(article):
+        score -= 1.6
+        reasons.append("homepage_or_thin_link")
+
+    if article.get("source_region") == "kz":
+        if full_text_chars >= 350 and dev_hits >= 2:
+            score += 0.7
+            reasons.append("kz_soft_bonus")
+        else:
+            score -= 0.7
+            reasons.append("weak_kz_candidate")
+
+    return round(score, 2), reasons
+
+
+def _selection_indices(selections: list[dict]) -> list[int]:
+    return [int(selection["index"]) for selection in selections if "index" in selection]
+
 
 class DigestService:
-    """Full news digest pipeline: fetch → AI select → deep scrape → generate → send."""
+    """Full news digest pipeline: fetch → enrich/score → AI select → generate → send."""
 
     def __init__(
         self,
@@ -35,6 +198,67 @@ class DigestService:
                     extra={"chat_id": chat_id},
                 )
 
+    def _dedupe_and_limit_candidates(self, raw_news: list[dict]) -> list[dict]:
+        """Remove obvious duplicates and bound deep scraping work."""
+        deduped: list[dict] = []
+        seen_links: set[str] = set()
+        seen_titles: set[str] = set()
+
+        for article in raw_news:
+            link = str(article.get("link") or "").strip()
+            title = str(article.get("title") or "").strip()
+            if not link or not title:
+                continue
+            domain = article.get("domain") or extract_domain(link)
+            candidate = {
+                **article,
+                "domain": domain,
+                "source_region": article.get("source_region") or classify_source_region(link),
+            }
+            link_key = link.split("#", 1)[0].rstrip("/").lower()
+            title_key = f"{domain}:{_title_key(title)}"
+            if link_key in seen_links or title_key in seen_titles:
+                continue
+            seen_links.add(link_key)
+            seen_titles.add(title_key)
+            deduped.append(candidate)
+
+        deduped.sort(key=_preliminary_score, reverse=True)
+        limited = deduped[:_MAX_ENRICH_CANDIDATES]
+        for index, article in enumerate(limited):
+            article["index"] = index
+        logger.info(
+            "News candidates deduped and prefiltered",
+            extra={"raw_count": len(raw_news), "deduped_count": len(deduped), "limited_count": len(limited)},
+        )
+        return limited
+
+    def _enrich_news_candidates(self, raw_news: list[dict]) -> list[dict]:
+        """Fetch article metadata/text before selection so ranking has evidence."""
+        candidates = self._dedupe_and_limit_candidates(raw_news)
+        enriched: list[dict] = []
+        for article in candidates:
+            deep_data = self._fetcher.fetch_deep_article_data(article["link"])
+            article.update(deep_data)
+            article["full_text_chars"] = int(article.get("full_text_chars") or len(article.get("full_text") or ""))
+            article["has_image"] = bool(article.get("image_url"))
+            article["quality_score"], article["quality_reasons"] = _score_article_quality(article)
+            enriched.append(article)
+
+        enriched.sort(key=lambda item: float(item.get("quality_score", 0)), reverse=True)
+        for index, article in enumerate(enriched):
+            article["index"] = index
+        logger.info(
+            "News candidates enriched",
+            extra={
+                "candidate_count": len(enriched),
+                "selectable_count": sum(
+                    1 for item in enriched if float(item.get("quality_score", 0)) >= _MIN_SELECTABLE_QUALITY_SCORE
+                ),
+            },
+        )
+        return enriched
+
     def run(self, event: dict[str, Any]) -> dict[str, Any]:
         """Execute the digest pipeline for a language group.
 
@@ -50,24 +274,24 @@ class DigestService:
                 logger.info("No news items found within TTL; skipping digest")
                 return {"statusCode": 200, "body": "No news"}
 
-            top_indices = self._ai.select_top_news(raw_news)
+            enriched_news = self._enrich_news_candidates(raw_news)
+            if not enriched_news:
+                logger.info("No usable news candidates after enrichment; skipping digest")
+                return {"statusCode": 200, "body": "No usable news"}
+
+            selections = self._ai.select_top_news(enriched_news)
+            top_indices = _selection_indices(selections)
             logger.info(
-                "Top indices selected",
-                extra={"indices": top_indices, "count": len(top_indices)},
+                "Top news selected",
+                extra={
+                    "indices": top_indices,
+                    "count": len(top_indices),
+                    "selection_reasons": [selection.get("score_reason", "")[:120] for selection in selections],
+                },
             )
 
-            deep_news: list[dict] = []
-            for idx in top_indices:
-                article = raw_news[idx]
-                logger.debug(
-                    "Fetching deep article data",
-                    extra={"index": idx, "link": article.get("link")},
-                )
-                deep_data = self._fetcher.fetch_deep_article_data(article["link"])
-                article.update(deep_data)
-                deep_news.append(article)
-
-            logger.info("Deep scrape complete", extra={"articles": len(deep_news)})
+            deep_news = [enriched_news[idx] for idx in top_indices]
+            logger.info("Selected enriched articles", extra={"articles": len(deep_news)})
 
             intro = get_intro_text(lang)
             digests = self._ai.generate_digests_per_article(deep_news, lang)

--- a/src/news/services/news_fetcher.py
+++ b/src/news/services/news_fetcher.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from typing import Optional
-from urllib.parse import quote, urlsplit, urlunsplit
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 
 import feedparser
 import urllib3
@@ -15,6 +15,9 @@ from core.logger import LoggerAdapter, get_logger
 logger = LoggerAdapter(get_logger(__name__), {})
 
 http = urllib3.PoolManager(timeout=urllib3.Timeout(total=10))
+
+_KZ_DOMAINS = ("digitalbusiness.kz", "profit.kz")
+_REGIONAL_DOMAINS = ("tproger.ru",)
 
 
 def normalize_url(url: str) -> str:
@@ -28,6 +31,33 @@ def normalize_url(url: str) -> str:
     query = quote(parts.query, safe="=&?/:,+%")
     fragment = quote(parts.fragment, safe="=&?/:,+%")
     return urlunsplit((parts.scheme, parts.netloc, path, query, fragment))
+
+
+def extract_domain(url: str) -> str:
+    """Return a normalized hostname without a leading www."""
+    netloc = urlsplit(normalize_url(url)).netloc.lower()
+    return netloc[4:] if netloc.startswith("www.") else netloc
+
+
+def classify_source_region(url: str) -> str:
+    """Classify source geography for digest ranking."""
+    domain = extract_domain(url)
+    if domain.endswith(_KZ_DOMAINS):
+        return "kz"
+    if domain.endswith(_REGIONAL_DOMAINS):
+        return "regional"
+    return "global"
+
+
+def clean_html_text(value: str) -> str:
+    """Strip simple RSS/HTML markup into compact text."""
+    if not value:
+        return ""
+    text = re.sub(r"<script[^>]*>.*?</script>", " ", value, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"<style[^>]*>.*?</style>", " ", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = html.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
 
 
 class NewsFetcher:
@@ -83,11 +113,15 @@ class NewsFetcher:
                     pub_date = self._parse_date(pub_date_str)
                     if pub_date is None or pub_date < cutoff_time:
                         continue
+                    link = normalize_url(entry.get("link", ""))
                     local_news.append(
                         {
                             "title": entry.get("title", "No title"),
-                            "link": normalize_url(entry.get("link", "")),
-                            "summary": entry.get("summary", "")[:250],
+                            "link": link,
+                            "summary": clean_html_text(entry.get("summary", ""))[:350],
+                            "domain": extract_domain(link),
+                            "source_region": classify_source_region(link),
+                            "feed_url": feed_url,
                         }
                     )
                     # logger.debug(
@@ -122,8 +156,8 @@ class NewsFetcher:
             resp = http.request("GET", url, headers=headers, timeout=8)
             if resp.status >= 400:
                 logger.warning("Deep scrape HTTP error", extra={"url": url, "status": resp.status})
-                return {"image_url": "", "full_text": ""}
-            html_content = resp.data.decode("utf-8")
+                return {"image_url": "", "full_text": "", "full_text_chars": 0}
+            html_content = resp.data.decode("utf-8", errors="replace")
             image_url = ""
 
             # Prefer og:image / twitter:image, then first content img
@@ -131,26 +165,27 @@ class NewsFetcher:
                 r'<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\']',
                 r'<meta\s+content=["\']([^"\']+)["\']\s+property=["\']og:image["\']',
                 r'<meta\s+name=["\']twitter:image["\']\s+content=["\']([^"\']+)["\']',
-                r'<img[^>]+src=["\'](https?://[^"\']+(?:jpg|jpeg|png|webp))["\']',
+                r'<meta\s+property=["\']twitter:image["\']\s+content=["\']([^"\']+)["\']',
+                r'<img[^>]+src=["\']([^"\']+(?:jpg|jpeg|png|webp)(?:\?[^"\']*)?)["\']',
             ]
             for pattern in patterns:
                 match = re.search(pattern, html_content, re.IGNORECASE)
                 if match:
                     extracted_url = match.group(1).strip()
                     extracted_url = html.unescape(extracted_url)
-
-                    if extracted_url.startswith("http"):
-                        image_url = extracted_url
+                    image_url = urljoin(url, extracted_url)
+                    if image_url.startswith("http"):
                         break
 
             p_tags = re.findall(r"<p[^>]*>(.*?)</p>", html_content, re.IGNORECASE | re.DOTALL)
-            clean_text = " ".join([re.sub(r"<[^>]+>", "", p).strip() for p in p_tags if len(p) > 50])
+            paragraphs = [clean_html_text(p) for p in p_tags]
+            clean_text = " ".join([p for p in paragraphs if len(p) > 50])
             full_text = clean_text[:3000]
             logger.debug("Deep scrape success", extra={"url": url, "image_found": image_url})
-            return {"image_url": image_url, "full_text": full_text}
+            return {"image_url": image_url, "full_text": full_text, "full_text_chars": len(full_text)}
         except Exception as e:
             logger.warning("Deep scrape failed", extra={"url": url, "error": str(e)})
-            return {"image_url": "", "full_text": ""}
+            return {"image_url": "", "full_text": "", "full_text_chars": 0}
 
     def _parse_date(self, date_string: Optional[str]) -> Optional[datetime]:
         """Parse RSS date string to timezone-aware UTC datetime."""

--- a/tests/test_news_delivery.py
+++ b/tests/test_news_delivery.py
@@ -2,12 +2,23 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[1]
 NEWS_ROOT = ROOT / "src" / "news"
 
 
 def _load_news_module(name: str, relative_path: str):
+    shadowed_prefixes = ("core", "services")
+    saved_modules = {
+        module_name: module
+        for module_name, module in sys.modules.items()
+        if module_name in shadowed_prefixes
+        or module_name.startswith(tuple(f"{prefix}." for prefix in shadowed_prefixes))
+    }
+    for module_name in saved_modules:
+        sys.modules.pop(module_name, None)
+
     sys.path.insert(0, str(NEWS_ROOT))
     try:
         spec = importlib.util.spec_from_file_location(name, NEWS_ROOT / relative_path)
@@ -17,6 +28,12 @@ def _load_news_module(name: str, relative_path: str):
         return module
     finally:
         sys.path.pop(0)
+        for module_name in list(sys.modules):
+            if module_name in shadowed_prefixes or module_name.startswith(
+                tuple(f"{prefix}." for prefix in shadowed_prefixes)
+            ):
+                sys.modules.pop(module_name, None)
+        sys.modules.update(saved_modules)
 
 
 class FakeResponse:
@@ -89,3 +106,197 @@ def test_news_fetcher_normalizes_rss_urls_with_whitespace():
     assert news_fetcher.normalize_url("https://example.com/a path/?q=hello world") == (
         "https://example.com/a%20path/?q=hello%20world"
     )
+
+
+class StubNewsAI:
+    def __init__(self, response: dict | None = None) -> None:
+        ai_client = _load_news_module("news_ai_client_base_test", "services/ai_client.py")
+
+        class _Client(ai_client.NewsAIClientBase):
+            def __init__(self, payload: dict | None) -> None:
+                self.payload = payload or {"top_news": []}
+                self.prompts: list[str] = []
+
+            def _generate(self, prompt, temperature, max_output_tokens, response_json_schema=None):
+                self.prompts.append(prompt)
+                if "digest" in str(response_json_schema):
+                    return {
+                        "digest": '<b>Fact title</b>\n\nConcrete fact summary.\n\n<a href="https://x.test">阅读全文</a>'
+                    }
+                return self.payload
+
+        self.client = _Client(response)
+
+
+def _candidate(
+    index: int,
+    domain: str,
+    *,
+    score: float,
+    region: str = "global",
+    image: bool = True,
+    chars: int = 1200,
+) -> dict:
+    return {
+        "index": index,
+        "title": f"Story {index} about AWS Lambda and AI agents",
+        "summary": "Developers get a concrete API change.",
+        "link": f"https://{domain}/story-{index}",
+        "domain": domain,
+        "source_region": region,
+        "image_url": "https://images.test/a.jpg" if image else "",
+        "full_text": "AWS Lambda AI API security developer architecture " * 40,
+        "full_text_chars": chars,
+        "quality_score": score,
+        "quality_reasons": ["test"],
+    }
+
+
+def test_news_selection_treats_weak_kz_as_soft_bonus_not_quota():
+    stub = StubNewsAI(
+        {
+            "top_news": [
+                {"index": 1, "category": "kz_or_regional", "score_reason": "local"},
+                {"index": 0, "category": "global_tech_ai", "score_reason": "global"},
+                {"index": 2, "category": "hardcore_engineering", "score_reason": "engineering"},
+            ]
+        }
+    ).client
+    items = [
+        _candidate(0, "aws.amazon.com", score=5.0),
+        _candidate(1, "digitalbusiness.kz", score=0.2, region="kz", chars=80),
+        _candidate(2, "thenewstack.io", score=4.3),
+        _candidate(3, "cloudflare.com", score=3.9),
+    ]
+
+    selected = stub.select_top_news(items)
+
+    assert [item["index"] for item in selected] == [0, 2, 3]
+
+
+def test_news_selection_allows_major_no_image_article():
+    stub = StubNewsAI(
+        {
+            "top_news": [
+                {"index": 0, "category": "hardcore_engineering", "score_reason": "major but no image"},
+                {"index": 1, "category": "global_tech_ai", "score_reason": "ai"},
+                {"index": 2, "category": "other_high_signal", "score_reason": "security"},
+            ]
+        }
+    ).client
+    items = [
+        _candidate(0, "engineering.example", score=5.8, image=False, chars=2200),
+        _candidate(1, "ai.example", score=4.0),
+        _candidate(2, "security.example", score=3.5),
+    ]
+
+    assert [item["index"] for item in stub.select_top_news(items)] == [0, 1, 2]
+
+
+def test_news_selection_repairs_duplicate_domains_invalid_indices_and_short_lists():
+    stub = StubNewsAI(
+        {
+            "top_news": [
+                {"index": 0, "category": "global_tech_ai", "score_reason": "first"},
+                {"index": 1, "category": "hardcore_engineering", "score_reason": "same domain"},
+                {"index": 99, "category": "other_high_signal", "score_reason": "invalid"},
+            ]
+        }
+    ).client
+    items = [
+        _candidate(0, "example.com", score=5.0),
+        _candidate(1, "example.com", score=4.8),
+        _candidate(2, "unique.dev", score=4.4),
+        _candidate(3, "another.dev", score=4.0),
+    ]
+
+    selected = stub.select_top_news(items)
+
+    assert [item["index"] for item in selected] == [0, 2, 3]
+
+
+def test_news_digest_prompt_requires_fact_first_grounded_summary():
+    stub = StubNewsAI().client
+    article = _candidate(0, "thenewstack.io", score=4.0, chars=1400)
+    article["full_text"] = "Sentry MCP attack affects Claude Code and Cursor through exposed DSN configuration."
+
+    result = stub.generate_digests_per_article([article], "zh")
+
+    assert result[0].startswith("<b>Fact title</b>")
+    prompt = stub.prompts[0]
+    assert "based ONLY on the provided title, source summary, and full_text" in prompt
+    assert "Do NOT invent details or write generic hype" in prompt
+    assert "new cornerstone" in prompt
+
+
+def test_news_digest_uses_conservative_fallback_for_thin_article_text():
+    stub = StubNewsAI().client
+    stub._generate = MagicMock(side_effect=AssertionError("thin articles should not call the LLM"))
+    article = _candidate(0, "apertvs.ai", score=1.8, chars=120)
+    article["full_text"] = "Short page."
+    article["summary"] = "A project page describes an open AI model."
+
+    result = stub.generate_digests_per_article([article], "zh")
+
+    assert "A project page describes an open AI model." in result[0]
+    assert '<a href="https://apertvs.ai/story-0">阅读全文</a>' in result[0]
+    stub._generate.assert_not_called()
+
+
+def test_digest_service_enriches_candidates_before_ai_selection():
+    digest = _load_news_module("news_digest_service_test", "services/digest.py")
+    events: list[str] = []
+
+    class Fetcher:
+        def fetch_raw_news(self):
+            return [
+                {
+                    "title": "AWS Lambda adds AI agent tracing",
+                    "link": "https://aws.amazon.com/story",
+                    "summary": "Developers get tracing for agents.",
+                },
+                {
+                    "title": "Kazakhstan startup builds cloud security tool",
+                    "link": "https://digitalbusiness.kz/story",
+                    "summary": "A local startup ships a developer security tool.",
+                },
+                {
+                    "title": "Sentry MCP issue affects Cursor",
+                    "link": "https://thenewstack.io/story",
+                    "summary": "Security issue for AI coding tools.",
+                },
+            ]
+
+        def fetch_deep_article_data(self, link):
+            events.append(f"deep:{link}")
+            return {
+                "image_url": f"{link}/image.jpg",
+                "full_text": "AWS Lambda AI API security developer architecture " * 35,
+                "full_text_chars": 1800,
+            }
+
+    class AI:
+        def select_top_news(self, articles):
+            events.append("select")
+            assert all("full_text_chars" in article for article in articles)
+            assert all("quality_score" in article for article in articles)
+            return [{"index": 0, "category": "global_tech_ai", "score_reason": "best"}]
+
+        def generate_digests_per_article(self, articles, lang):
+            events.append("digest")
+            return ["<b>Digest</b>"]
+
+    class Sender:
+        def send_message(self, chat_id, text):
+            return True, 200
+
+        def send_message_with_photo(self, chat_id, message, image_url):
+            events.append(f"send:{bool(image_url)}")
+            return True
+
+    result = digest.DigestService(Fetcher(), AI(), Sender()).run({"chat_ids": ["chat"], "lang": "zh"})
+
+    assert result["statusCode"] == 200
+    assert events.index("select") > max(i for i, event in enumerate(events) if event.startswith("deep:"))
+    assert "digest" in events
+    assert "send:True" in events


### PR DESCRIPTION
## Summary
- Enrich and score RSS candidates with domain, source region, article text length, image presence, and quality reasons before AI selection.
- Make Kazakhstan/local coverage a soft bonus instead of a hard quota, with local domain uniqueness and local fallback repair when AI returns weak, duplicate, or invalid choices.
- Rewrite article digest generation toward fact-first summaries and use conservative fallback text for thin/empty scraped article pages.
- Update README feature descriptions for the improved news digest behavior.

## Validation
- uv run pre-commit run --all-files
- uv run pytest tests/test_news_delivery.py -q
- uv run pytest tests/ -q