### PR TITLE
FEATURE: Add fair Telegram contest draws

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -41,6 +41,7 @@ ZerdeBot started as a simple serverless Telegram bot and LLM wrapper. It is now 
 - Normal bot answers stay in short-term `AGENT_REPLY#...` metadata for thread continuity only; they are not embedded into semantic memory.
 - It answers `/ask`, @mentions, and reply-to-Zerde follow-ups through a retrieval pipeline that gathers requester, profile, recent, long-term, and semantic context from a compact retrieval query that is separate from the full Gemini generation prompt.
 - It supports explicit multimodal `/ask` for replied photos/screenshots, voice/audio, PDFs, and supported text/code/log files. Media is downloaded only in the async worker for explicit requests and official linked-channel post comments, not during generic webhook observation or ordinary proactive analysis.
+- It supports fair Kazakh linked-channel contests: `#конкурс` on the initial official mirror, one direct `қатысамын` entry per personal Telegram user id, creator-only secure draws, two distinct redraws, and anchored public evidence.
 - Reply-thread follow-ups carry the captured quoted source message, previous user request, and previous bot answer when available for generation, while semantic retrieval uses a shorter query based on the current follow-up, previous user request, and original source message.
 - It may proactively answer ordinary group messages only after a short delayed candidate window plus a Groq/DeepSeek AI decision with recent and query-filtered long-term context. Linked channel posts mirrored into discussion groups use a separate immediate comment path.
 - It still supports captcha, anti-spam, voteban, daily news, and quizzes.
@@ -70,6 +71,7 @@ flowchart LR
   VectorIndexer --> Gemini
   EventBridge[EventBridge_schedules] --> NewsLambda[News_Lambda]
   EventBridge --> QuizLambda[Quiz_Lambda]
+  EventBridge --> MainQ
   Layer[zerde_common_layer] -.-> BotLambda
   Layer -.-> VectorIndexer
   Layer -.-> NewsLambda
@@ -89,8 +91,8 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 
 - `main.py` — detects API Gateway vs main SQS tasks and delegates.
 - `vector_indexer_main.py` — consumes only vector memory SQS tasks.
-- `app.py` — lazy wiring for Telegram client, dispatcher, captcha repo, and memory repo.
-- `webhook.py` — verifies Telegram secret, screens spam, observes memory, filters irrelevant events, routes agent/commands.
+- `app.py` — lazy wiring for Telegram client, dispatcher, captcha repo, memory repo, contest repo, and main queue client.
+- `webhook.py` — verifies Telegram secret, screens spam, observes contests before memory/ambient/agent flows, filters irrelevant events, routes agent/commands.
 - `services/sqs_task_router.py` — routes main and vector SQS task families and re-raises failures for retry/DLQ semantics.
 - `services/group_memory.py` — stores recent group context, formats prompt context, requester/target-user profile context, and query-filtered long-term memory.
 - `services/memory_retrieval.py` — Memory Retrieval Pipeline V1 for query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and source tracking.
@@ -98,10 +100,13 @@ Detailed architecture lives in `docs/ARCHITECTURE.md`.
 - `services/group_memory_processor.py` — async long-term extraction task orchestration, cheap Gemini candidate gating, extractor LLM budgets, and daily summaries.
 - `services/group_agent.py` — agent trigger policy, ordinary proactive AI decision orchestration, linked-channel post immediate comments with provider fallback, reply-thread continuity, answer length/style policy.
 - `services/ambient_reactions.py` — ambient emoji reaction eligibility, sampling, bounded context, strict classifier validation, cooldowns, provider fallback, and `setMessageReaction` task processing.
+- `services/contest.py` — strict official-root/entry recognition, secure draw/redraw orchestration, fixed Kazakh rendering, anchored evidence fallback, and resumable retention work.
+- `services/handlers/contest.py` — reply-anchor parsing and live creator/administrator command authorization.
 - `services/telegram_actor.py` — Telegram actor attribution helpers, including linked-channel discussion mirror detection and `sender_chat` actor selection.
 - `services/telegram_media.py` — explicit `/ask` media detection, metadata-only references, bounded worker download preparation, and Gemini media part construction.
 - `services/vector_memory.py` — embedding, S3 Vectors indexing, semantic retrieval, cleanup/backfill.
 - `services/repositories/group_memory.py` — DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters, and targeted memory deletion helpers.
+- `services/repositories/contest.py` — sole contest lifecycle, participant, winner, rules-alias, and expiry truth owner.
 - `services/ai/gemini_client.py` — Gemini calls for agent answers, multimodal linked-channel post comment decisions, summaries, embeddings.
 - `services/ai/proactive_decision.py` — Groq model-pool strict-JSON decision chain for ordinary proactive group answers, with DeepSeek decision fallback disabled by default.
 - `services/ai/group_chat_reply_fallback.py` — DeepSeek then Groq text-only fallback chain for group answer generation when Gemini fails.
@@ -123,6 +128,10 @@ Single table partitioned by `pk=CHAT#<chat_id>`:
 - `TERM#<term>#<created_at_ms>#<source_sk>` — bounded exact-term lexical index rows for long-term memories and daily summaries.
 - `AGENT_REPLY#<bot_message_id>` — short-term bot answer text, triggering/current user message, optional quoted source-message context, optional compact media metadata/summary, parent bot message id, requester metadata, retrieval source metadata with deletion policy, and reason for reply-thread continuity, `/agent why`, `/agent wrong`, `/memory wrong`, and `/memory forget this`; not long-term semantic memory.
 - `AMBIENT_REACTION#<created_at_ms>#<message_id>` — seven-day reaction metadata for cooldowns/debugging only; not long-term semantic memory.
+- `CONTEST#<root_message_id>#META` — fail-closed lifecycle, rules anchor, frozen count, winner history, announcement state, logical expiry, and TTL cursor.
+- `CONTEST#<root_message_id>#PARTICIPANT#<user_id>` — one immutable first eligible comment snapshot per personal Telegram user id.
+- `CONTEST_RULE#<rules_message_id>` — command lookup alias to the contest root.
+- `pk=CONTEST_TTL_OUTBOX`, `sk=CHAT#<chat_id>#ROOT#<root_message_id>` — durable cleanup marker created with first draw/cancel and consumed only after the TTL sweep completes.
 - `BOT_COMMITMENT#...` — reserved future durable bot commitment rows for explicit command/admin flows only.
 - `BOT_CORRECTION#...` — reserved future durable bot correction rows for explicit user/admin correction flows only.
 - `VECTOR_BACKFILL` — cumulative vector backfill status with processed/enqueued/failure totals,
@@ -147,6 +156,8 @@ Memory TTLs are type-specific: raw `MSG#...`, `AGENT_REPLY#...`, long-term memor
 - `PROCESS_AMBIENT_REACTION` — async sampled ambient reaction classifier; uses only bounded recent/reply text context and never writes long-term memory or vectors.
 - `PROCESS_GROUP_MEMORY` — extract/store long-term memory from one message using structured Gemini extraction with rule fallback.
 - `PROCESS_DAILY_GROUP_SUMMARIES` — daily summaries for configured groups.
+- `PROCESS_CONTEST_TTL_SWEEP` — idempotent, cursor-based participant/rules/META expiry stamping after draw or cancellation.
+- `PROCESS_CONTEST_TTL_RECOVERY` — bounded global-outbox recovery page, scheduled independently in production and resumable through SQS.
 - `PROCESS_VECTOR_MEMORY` — embed/index one memory item; consumed by the vector-indexer Lambda.
 - `PROCESS_VECTOR_MEMORY_BACKFILL` — page through vectorizable memory and enqueue indexing; consumed by the vector-indexer Lambda.
 
@@ -179,6 +190,8 @@ both DLQs default to 14 days for incident inspection and redrive. Tune these at 
 - **Memory Retrieval Pipeline V1**: `services.memory_retrieval.build_agent_memory_context` retrieves profile, semantic, lexical, long-term, and recent candidates from `retrieval_query`, scores/dedupes them locally, renders prompt sections only from selected top candidates, and persists compact metadata for the selected retrieval sources used by `/agent why` and wrong-source feedback. Username target profiles use `USERNAME#...` aliases, exact lexical retrieval uses `TERM#...` index rows before falling back to recent legacy candidates, and negative feedback on a source lowers its future retrieval score.
 - **Explicit multimodal boundary**: ZerdeBot does not automatically analyze every group media message. It analyzes media only when explicitly asked through `/ask` or an explicit mention/reply path, plus the official linked-channel post comment path. These flows send only `media_ref` metadata through SQS, download media in the async worker, and store only compact media metadata/summary in `AGENT_REPLY#...`. Raw bytes, downloaded files, OCR/transcripts, and media-derived facts are not long-term memory and are not indexed in S3 Vectors by default.
 - **Ambient reaction boundary**: ambient reactions are enabled by default and must stay ephemeral. Ordinary ambient reactions may use bounded recent/reply text context for Groq-only classification, but must not use long-term memory, vector retrieval/indexing, profile context, media analysis, or persisted classifier context. Command text and sensitive/hostile/serious text may reach the classifier, but prompts must require a strong context-safe reaction and avoid reactions that trivialize, mock, endorse, or escalate harm. Official linked-channel posts force a reaction attempt, bypass sampling/cooldowns/rate caps, and fall back to 👀 when provider output is unavailable or says no. Only short-lived `AMBIENT_REACTION#...` cooldown/debug rows are allowed.
+- **Contest fairness boundary**: keep contest recognition deterministic and ahead of memory/ambient/agent handling but behind captcha/spam short-circuits. Only current official linked-channel mirrors with an initial standalone `#конкурс` may create. Only direct first-level personal-account text replies containing `қатысамын` may register, transactionally once per user id while incrementing the exact participant count. First draw closes registration before a strong full-page `secrets.randbelow` reservoir sample; creator-only mutations, distinct redraws, persisted-before-delivery winners, same-winner replay, and anchored evidence are invariants. Never infer entries from memory/AI, choose from a partial page, grant `ADMIN_USER_ID` a mutation exception, or send a winner result without a reply anchor.
+- **Contest retention boundary**: `OPEN` does not auto-expire. First successful draw/cancel atomically fixes 30-day logical expiry and creates a global durable cleanup marker; redraw never extends it. The idempotent cursor-based `PROCESS_CONTEST_TTL_SWEEP` stamps participants and the rules alias before META TTL, then atomically consumes the marker. Sweep payloads carry only contest identity; META cursor/version is the sole sweep-progress truth. Initial enqueue is best-effort so cleanup outages never block winner/status delivery. An always-on production EventBridge rule queues bounded `PROCESS_CONTEST_TTL_RECOVERY` pages against the global outbox even when no chat remains configured. A known webhook outage beyond Telegram's update-retention window requires cancelling the affected contest rather than drawing from an incomplete list.
 - **Intent-aware retrieval filters**: obvious self-reference and target-user questions narrow semantic/lexical memory to user facts; group-decision questions narrow to group facts and daily summaries; past-event questions narrow to events and daily summaries; joke/meme questions narrow to jokes and daily summaries.
 - **User-facing memory controls**: `/memory about me` shows only the current user's own profile. `/memory forget this` deletes only durable long-term memory (`EVENT#`, `USER_FACT#`, `GROUP_FACT#`, `JOKE#`, allowed `DAILY_SUMMARY#`) from a replied bot answer, or raw/derived memory when replying directly to a source message, with vector cleanup when configured. It must not delete `USER#` profiles, raw `MSG#` items, or recent context through bot-answer retrieval sources. `/agent wrong` and `/memory wrong` mark a replied bot answer's recorded memory sources as wrong without deleting them. Regular users can delete only their own durable memory; the group owner or bot owner can delete group durable memory.
 - **Memory extraction budget**: default `GROUP_MEMORY_EXTRACTOR_MODE=gemini_candidate_only` means ordinary safe chatter falls back to rules without calling Gemini. `GROUP_MEMORY_EXTRACTOR_DAILY_LLM_LIMIT` and `GROUP_MEMORY_EXTRACTOR_PER_CHAT_DAILY_LIMIT` bound candidate Gemini extraction before it can consume shared generate RPD.

--- a/.codex/skills/zerdebot-development/SKILL.md
+++ b/.codex/skills/zerdebot-development/SKILL.md
@@ -34,7 +34,7 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 
 ## Repository Map
 
-- `src/bot/`: Telegram webhook, dispatcher, main SQS worker tasks, captcha, voteban, spam screening, `/ask`, group agent, group memory, vector enqueue/query/delete helpers, and the dedicated vector indexer entrypoint.
+- `src/bot/`: Telegram webhook, dispatcher, main SQS worker tasks, captcha, voteban, spam screening, fair linked-channel contests, `/ask`, group agent, group memory, vector enqueue/query/delete helpers, and the dedicated vector indexer entrypoint.
 - `src/bot/services/group_agent.py`: agent trigger policy, ordinary proactive AI decision orchestration, linked-channel post immediate comments, provider fallback orchestration, reply-thread continuity, response length/style policy.
 - `src/bot/services/group_memory.py`: recent context observation and prompt formatting, requester/target-user profiles, query-filtered long-term context.
 - `src/bot/services/memory_retrieval.py`: Memory Retrieval Pipeline V1 for query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and selected-source tracking.
@@ -49,6 +49,9 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - `src/bot/vector_indexer_main.py`: dedicated vector memory SQS Lambda entrypoint.
 - `src/bot/services/vector_memory.py`: Gemini embeddings, S3 Vectors indexing/retrieval with metadata filters and distance cutoffs, vector cleanup/backfill.
 - `src/bot/services/repositories/group_memory.py`: DynamoDB single-table layout for settings, messages, profiles, long-term memory, agent replies, vector status, proactive counters, and targeted memory deletion helpers.
+- `src/bot/services/contest.py`: official contest-root/entry recognition, secure draw/redraw orchestration, fixed Kazakh output, anchored winner evidence, and TTL sweep processing.
+- `src/bot/services/handlers/contest.py`: `/contest` anchor parsing and exact live Telegram creator/administrator authorization.
+- `src/bot/services/repositories/contest.py`: sole contest lifecycle, participant uniqueness, winner history, rules alias, and retention truth owner.
 - `src/news/`: scheduled news digest Lambda.
 - `src/quiz/`: scheduled and on-demand quiz Lambda.
 - `src/shared/python/zerde_common/`: shared Lambda layer utilities.
@@ -88,6 +91,9 @@ Treat ZerdeBot as a **memory-enabled agentic Telegram bot**, not a simple LLM wr
 - Keep ordinary proactive participation conservative through the AI decision prompt, not local heuristics: queue eligible ordinary group text with `AGENT_PROACTIVE_DELAY_SECONDS`; the worker gathers recent context and query-filtered long-term context, asks the `AGENT_PROACTIVE_DECISION_GROQ_MODELS` pool for strict JSON using capped decision-only context, requires `AGENT_PROACTIVE_FINAL_THRESHOLD`, reserves `AGENT_DAILY_PROACTIVE_LIMIT` only after a yes decision, then generates with Gemini retry plus DeepSeek/Groq fallback. DeepSeek proactive decision fallback is opt-in only through `AGENT_PROACTIVE_DECISION_ALLOW_DEEPSEEK_FALLBACK`.
 - Do not reintroduce local open-question, length, bot-meta, stop-cue, score, recent-bot, or human-answer gates for ordinary proactive answering. Keep only narrow routing guards such as skipping messages that start with a non-bot `@username`, because those are directed at a human rather than the bot or the group. Put a general social-permission rubric into the proactive decision prompt: intended audience, conversation act, concrete bot incremental value, and timing. The prompt should handle multilingual messy questions while staying silent for human-directed side conversations, FYI/status updates, reactions, human-already-answered threads, bot-meta, stop-cue, and sensitive/hostile/serious-content cases where a bot reply would add noise or harm.
 - Keep linked-channel post participation separate from ordinary proactive replies: detect official linked channel discussion mirrors via `is_automatic_forward` or Telegram `777000` plus `sender_chat.type=channel`, use `sender_chat` as the actor, queue a zero-delay `channel_post` worker task, bypass ordinary proactive delay/confidence/daily-limit/text-only rules, and use the dedicated channel-post comment prompt. Supported attached media may be analyzed ephemerally by Gemini in that worker. If Gemini fails after three attempts or cannot be used, fall back to DeepSeek and then Groq with text-only context; if every provider fails, let SQS retry/DLQ instead of returning `False`.
+- Keep contests outside AI and memory inference. Activate only an initial official mirror whose text/media caption has standalone `#конкурс` and whose current linked channel matches `getChat.linked_chat_id`; require Zerde to be an administrator. Accept only direct first-level personal-account text replies containing `қатысамын`, transactionally once per Telegram user id. Only live `creator` may draw/redraw/cancel; live creator/admin may inspect status; `ADMIN_USER_ID` is not an exception.
+- Preserve contest recovery/fairness invariants: `CREATING` and `DRAWING` are fail-closed, the first draw strongly reads every participant page through a uniform `secrets.randbelow` reservoir sample, winners persist before Telegram delivery, pending delivery replays the same winner, redraw excludes prior winners and never extends the 30-day expiry, and missing entry/root anchors must become `ORPHANED` rather than spill a result into the main chat.
+- Treat contest retention as a durable outbox protocol. First draw/cancel atomically creates `pk=CONTEST_TTL_OUTBOX`; sweep SQS payloads carry only contest identity while META cursor/version owns sweep progress; sweep completion atomically sets META TTL and deletes the marker. Initial sweep enqueue is best-effort and must not block winner/status delivery. The production EventBridge recovery rule stays present without configured chats and seeds bounded `PROCESS_CONTEST_TTL_RECOVERY` pages; recovery and sweep failures use normal SQS retry/DLQ semantics.
 - Keep response length proportional to the user's request. Short follow-ups should stay short unless the user asks for detail.
 - Keep chat-level `style_profile` defaults concise and socially safe. Weak selected memory should add uncertainty instructions instead of letting the model sound certain.
 - If cleaning production memory, first back up exact DynamoDB items and vector keys locally, then delete narrowly.
@@ -103,6 +109,8 @@ SQS handler failures should re-raise when retry/DLQ semantics are intended. Curr
 - `PROCESS_AMBIENT_REACTION`
 - `PROCESS_GROUP_MEMORY`
 - `PROCESS_DAILY_GROUP_SUMMARIES`
+- `PROCESS_CONTEST_TTL_SWEEP`
+- `PROCESS_CONTEST_TTL_RECOVERY`
 
 Current vector-indexer SQS task types:
 
@@ -131,6 +139,14 @@ DynamoDB memory key families:
   - Optional compact media metadata/summary for explicit multimodal `/ask` continuity only. Do not store raw media bytes, downloaded files, full OCR/transcripts, or media-derived durable facts here.
 - `AMBIENT_REACTION#...`
   - Short-lived reaction metadata for cooldowns/debugging only. Do not write ambient reaction context to long-term memory or vectors.
+- `CONTEST#<root_message_id>#META`
+  - Lifecycle, rules id, frozen count, winner history, announcement state, logical expiry, and resumable TTL cursor.
+- `CONTEST#<root_message_id>#PARTICIPANT#<user_id>`
+  - Immutable first accepted direct-comment snapshot; exactly one row per Telegram user id.
+- `CONTEST_RULE#<rules_message_id>`
+  - Alias allowing commands to reply to the Bot's rules message or the root.
+- `pk=CONTEST_TTL_OUTBOX`, `sk=CHAT#<chat_id>#ROOT#<root_message_id>`
+  - Global durable cleanup marker; never give it a physical TTL or delete it before the corresponding sweep atomically reaches `COMPLETE`.
 - `BOT_COMMITMENT#...`
 - `BOT_CORRECTION#...`
 - `VECTOR_BACKFILL` with cumulative `processed_total`, `enqueued_total`, `failures_total`,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ RAG means **Retrieval-Augmented Generation**: retrieve relevant memory first, th
 | Reply thread continuity | Records bot answers in short-term `AGENT_REPLY#...` items so follow-up replies know what the bot just said; these rows are not semantic/vector memory. |
 | Social timing | Ordinary proactive replies are delayed briefly, then a Groq model pool decides from capped recent and query-filtered long-term context whether the bot can add value. If yes, the chat daily limit is reserved and Gemini generates with DeepSeek/Groq fallback. Linked channel posts mirrored into discussion groups use a separate zero-delay comment path and may analyze supported attached media. |
 | Ambient reactions | Optional `setMessageReaction` presence feature for funny, useful, thoughtful, warm, or interesting messages; enabled by default. Ordinary messages are sampled/rate-limited, while linked-channel posts force a reaction attempt. |
+| Fair linked-channel contests | An official linked-channel post containing `#конкурс` opens a Kazakh-language contest in its discussion supergroup. Direct personal-account replies containing `қатысамын` are deduplicated by Telegram user id; only the group creator can draw or redraw. |
 | Smart captcha and anti-spam | Mutes new members until verification; pending captcha messages stay in captcha handling, strong high-confidence spam is removed silently, and weak or ambiguous cases go to admin review with optional admin @mentions. |
 | Community voteban | Lets communities vote to ban or forgive by replying with `/voteban`. |
 | Daily AI news | EventBridge-triggered news Lambda enriches RSS candidates with article text/images, ranks high-signal developer stories, and sends fact-first multilingual digests through Gemini/DeepSeek-compatible provider paths. |
@@ -124,6 +125,18 @@ For the deeper developer map, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 | `/memory about me` | Everyone | Show the current user's own stored profile fields without showing other users' claims. |
 | `/memory on/off/status/forget .../wrong` | Group owner or bot owner for settings; users can delete their own memory or mark answer sources wrong | Manage group memory and cleanup. `forget this` deletes durable long-term memory from a replied bot answer, or raw/derived memory when replying directly to a source message; it does not delete `USER#` profiles. `wrong` marks a replied bot answer's memory sources as wrong without deleting them. |
 | `/agent on/off/status/why/wrong` | Group owner or bot owner for settings; everyone can inspect or mark replied answer sources | Manage agent participation and inspect why the bot replied, including memory source types and counts without full memory text. `/agent wrong` marks a replied bot answer's memory sources as wrong. `/agent off` disables proactive, mention, and reply-thread participation; `/ask` remains available if memory is on. |
+| `/contest draw/redraw/cancel` | Current Telegram group creator only | Reply to the contest root or Zerde's rules message. `draw` freezes unique entries and chooses securely; at most two `redraw` commands choose new, previously unselected winners. |
+| `/contest status` | Current Telegram group creator or administrators | Reply to the contest root or rules message to inspect lifecycle, unique participant count, and draw count. |
+
+### Linked-Channel Contests
+
+- The initial official channel post must contain standalone `#конкурс` in its text or media caption. Adding it later by edit does not activate a contest.
+- Participation is fixed Kazakh V1: a personal account must reply directly to the original root post with text containing `қатысамын`, case-insensitively. Replies to other comments, captions, bots, channels, and anonymous administrators do not count.
+- The first accepted entry per Telegram user id is retained and receives the Bot API-supported `🎉` reaction; later entries do not add another chance.
+- The current Telegram group creator manually runs the draw. The result replies to the winner's first accepted comment and publishes the unique participant count and draw ordinal. If that comment was deleted, Zerde falls back to the root with the saved entry snapshot; it never sends an unanchored result into the main chat.
+- The first successful draw or cancellation fixes a 30-day retention window. Drawn contests are closed to new entries, permit at most two distinct redraws, and do not extend that window.
+- Zerde must be an administrator in the discussion supergroup. A known webhook outage longer than Telegram's update-retention window invalidates fairness; cancel the affected open contest instead of drawing it.
+- Incident inspection, DLQ recovery, and exact-row cleanup are documented in [docs/CONTEST_OPERATIONS.md](docs/CONTEST_OPERATIONS.md).
 
 ### Chat Style Settings
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,7 @@ flowchart LR
 
   EB["EventBridge"] --> NEWS["News Lambda"]
   EB --> QUIZ["Quiz Lambda"]
+  EB -- "contest recovery seed" --> MAINQ
   NEWS --> GEMINI
   QUIZ --> GEMINI
   NEWS --> TG
@@ -56,7 +57,9 @@ flowchart LR
 
 | Package | Entry | Main responsibilities |
 |---------|-------|-----------------------|
-| `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles Telegram updates, captcha, voteban, spam checks, group memory, `/ask`, agent replies, semantic retrieval, and cleanup commands. |
+| `src/bot/` | `main.py:lambda_handler` | API Gateway webhook and main SQS worker. Handles Telegram updates, captcha, voteban, spam checks, fair linked-channel contests, group memory, `/ask`, agent replies, semantic retrieval, and cleanup commands. |
+| `src/bot/services/contest.py` | `ContestService` | Validates official contest roots and direct entries, coordinates secure draws/redraws, and publishes anchored winner evidence. |
+| `src/bot/services/repositories/contest.py` | `ContestRepository` | Sole contest lifecycle, participant uniqueness, winner history, rule-anchor, and retention truth owner in the memory table. |
 | `src/bot/services/memory_retrieval.py` | `build_agent_memory_context` | Memory Retrieval Pipeline V1: query intent, raw candidate retrieval, local scoring/dedupe, candidate-driven prompt packing, and selected-source tracking. |
 | `src/bot/` | `vector_indexer_main.py:lambda_handler` | Dedicated vector memory SQS worker for embedding/indexing and vector backfill paging. |
 | `src/news/` | `main.py:lambda_handler` | Scheduled IT news digest and Telegram delivery. |
@@ -69,12 +72,13 @@ flowchart LR
 2. Private chats get a fixed response; non-whitelisted groups are ignored.
 3. Spam screening runs before normal handling unless a captcha is pending. Pending captcha messages stay in the captcha path only: spam-like text is deleted as a wrong captcha attempt, not announced as spam or routed into memory/agent flows.
 4. Spam handled by rule enforcement or queued AI review exits the webhook early, so spam text is not observed as group memory, sampled for reactions, or queued as a proactive candidate. AI spam checks receive structured context for the current message, reply/quote/external reply, bounded recent group messages, and rule signals, but they still classify only the current sender's message. Automatic AI enforcement requires `SPAM`, confidence above `SPAM_AI_CONFIDENCE_THRESHOLD`, and a strong structural signal such as a link, external contact, VPN, DM redirect, job/income hook, finance lead bait, or short text with contact. Weak signals such as `money_pattern` alone go to admin review, and review prompts can optionally @ configured chat admins. Automatic spam enforcement keeps the existing temporary ban path; admin-confirmed review bans are permanent.
-5. `group_memory.observe_update` stores non-command group messages and queues long-term memory extraction.
-6. If ambient reactions are enabled, eligible group text messages, including command text, are sampled and queued as `PROCESS_AMBIENT_REACTION`; classification runs asynchronously and does not use long-term memory or vector search.
-7. Irrelevant group chatter exits early.
-8. Relevant events route to the group agent or the command dispatcher.
-9. `/ask` is queued as `PROCESS_GROUP_ASK` with requester metadata so Telegram webhook latency stays low and self-reference questions are grounded. When `/ask` explicitly replies to supported media, the webhook adds only a serializable `media_ref`; it does not download bytes.
-10. `agent_enabled` gates non-command group agent participation: ordinary proactive candidates are delayed as `PROCESS_PROACTIVE_CANDIDATE`, linked-channel post comments are queued as zero-delay `PROCESS_PROACTIVE_CANDIDATE` with Gemini retries plus DeepSeek/Groq text-only fallback, and @mentions/reply-to-bot follow-ups stay immediate. Explicit `/ask` remains available while `memory_enabled` is true.
+5. `contest.observe_contest_update` recognizes only initial official linked-channel mirrors containing standalone `#конкурс`, and records only direct personal-account text replies containing `қатысамын`. It is non-consuming: accepted contest updates continue through the existing memory, ambient, agent, and dispatcher paths.
+6. `group_memory.observe_update` stores non-command group messages and queues long-term memory extraction.
+7. If ambient reactions are enabled, eligible group text messages, including command text, are sampled and queued as `PROCESS_AMBIENT_REACTION`; classification runs asynchronously and does not use long-term memory or vector search.
+8. Irrelevant group chatter exits early.
+9. Relevant events route to the group agent or the command dispatcher. `/contest` is a normal dispatcher command and does not replace the single captcha plain-message handler.
+10. `/ask` is queued as `PROCESS_GROUP_ASK` with requester metadata so Telegram webhook latency stays low and self-reference questions are grounded. When `/ask` explicitly replies to supported media, the webhook adds only a serializable `media_ref`; it does not download bytes.
+11. `agent_enabled` gates non-command group agent participation: ordinary proactive candidates are delayed as `PROCESS_PROACTIVE_CANDIDATE`, linked-channel post comments are queued as zero-delay `PROCESS_PROACTIVE_CANDIDATE` with Gemini retries plus DeepSeek/Groq text-only fallback, and @mentions/reply-to-bot follow-ups stay immediate. Explicit `/ask` remains available while `memory_enabled` is true.
 
 Captcha timeout cleanup removes failed join artifacts only after a successful kick. If the user verifies successfully, the delayed timeout cleans only captcha prompts and preserves Telegram's original join system message.
 
@@ -93,6 +97,8 @@ The bot Lambda consumes real-time and group-memory tasks. The vector-indexer Lam
 | `PROCESS_AMBIENT_REACTION` | timeout/tasks queue | Bot Lambda async classifier for ambient reactions; ordinary messages are sampled and rate-limited, while linked-channel posts force a reaction attempt and bypass sampling/cooldowns/rate caps. Stores only short-lived `AMBIENT_REACTION#...` metadata. |
 | `PROCESS_GROUP_MEMORY` | timeout/tasks queue | Bot Lambda structured extraction of one long-term memory item from a stored group message, with rule fallback. |
 | `PROCESS_DAILY_GROUP_SUMMARIES` | timeout/tasks queue | Bot Lambda daily summaries for configured groups. |
+| `PROCESS_CONTEST_TTL_SWEEP` | timeout/tasks queue | Bot Lambda stamps the immutable contest expiry on bounded participant pages, persists a DynamoDB continuation cursor before identity-only re-enqueue, then expires the rules alias and META row. Duplicate delivery is idempotent. |
+| `PROCESS_CONTEST_TTL_RECOVERY` | timeout/tasks queue | An always-on production EventBridge rule seeds a bounded page over the global durable outbox. Each marker queues an identity-only sweep; a DynamoDB page cursor is carried only to the next recovery task, keeping recovery independently retryable even after all chats are removed from configuration. |
 | `PROCESS_VECTOR_MEMORY` | vector memory queue | Vector-indexer Lambda embeds and indexes one memory item in S3 Vectors. |
 | `PROCESS_VECTOR_MEMORY_BACKFILL` | vector memory queue | Vector-indexer Lambda pages through historical vectorizable memory items and enqueues indexing. |
 
@@ -122,6 +128,10 @@ The table is single-table by chat partition:
 | `sk=TERM#<term>#<created_at_ms>#<source_sk>` | Lightweight exact-term lexical index row pointing back to a long-term memory or daily summary source item. |
 | `sk=AGENT_REPLY#<bot_message_id>` | Short-term bot answer metadata, answer text, triggering/current user message, optional quoted source-message context, optional compact media metadata/summary, parent bot message id, requester metadata, and compact retrieval source metadata, including deletion policy, for reply-thread continuity, `/agent why`, `/agent wrong`, `/memory wrong`, and `/memory forget this`. These rows are not long-term semantic memory. |
 | `sk=AMBIENT_REACTION#<created_at_ms>#<message_id>` | Seven-day reaction metadata for cooldowns/debugging: chat id, user id, message id, emoji, category, confidence, and TTL. These rows are not semantic/vector memory. |
+| `sk=CONTEST#<root_message_id>#META` | Contest lifecycle (`CREATING`, `OPEN`, internal `DRAWING`, `DRAWN`, `CANCELLED`, terminal `ORPHANED`), exact participant/frozen counts, winner history, rules id, logical expiry, and TTL-sweep cursor. |
+| `sk=CONTEST#<root_message_id>#PARTICIPANT#<user_id>` | One immutable first accepted direct-comment snapshot per Telegram user id. Participant rows are queried strongly and fully before secure selection. |
+| `sk=CONTEST_RULE#<rules_message_id>` | Alias from the Bot's rules reply to the contest root, allowing commands to anchor to either message. |
+| `pk=CONTEST_TTL_OUTBOX`, `sk=CHAT#<chat_id>#ROOT#<root_message_id>` | Durable global cleanup marker created atomically with first draw/cancel and deleted atomically only when the TTL sweep completes. The independent production recovery schedule can discover missed work without scanning participant rows. |
 | `sk=BOT_COMMITMENT#...` | Reserved durable bot-authored commitment key family for a future explicit command/admin flow. Normal answer generation must not write this. |
 | `sk=BOT_CORRECTION#...` | Reserved durable bot-authored correction key family for a future explicit user/admin correction flow. Normal answer generation must not write this. |
 | `sk=VECTOR_BACKFILL` | Cumulative vector backfill status for a chat. Tracks `processed_total`, `enqueued_total`, `failures_total`, `started_at`, `last_updated_at`, optional `finished_at`, and continuation tokens. Legacy `vector_backfill_*` attributes are still written for compatibility. |
@@ -130,6 +140,17 @@ The table is single-table by chat partition:
 Long-term memory items include `extractor_source`, `sensitivity`, `evidence_message_ids`, feedback metadata such as `wrong_feedback_count`, `negative_feedback_count`, `last_feedback_at`, `feedback_status`, a `superseded_by` placeholder for future consolidation, and optional `expires_at` metadata. Long-term memory prefixes are vectorizable, and daily summaries are vectorized only when they are high-information. Raw `MSG#...` items, normal bot answer `AGENT_REPLY#...` items, and `AMBIENT_REACTION#...` rows are not vector memory. The reserved `BOT_COMMITMENT#...` and `BOT_CORRECTION#...` families are placeholders for explicit future durable bot memory flows and are not vectorizable until such flows add review/permission checks and tests.
 
 Memory retention is type-specific. `GROUP_MEMORY_RAW_MESSAGE_RETENTION_DAYS` controls raw `MSG#...` records, `GROUP_MEMORY_AGENT_REPLY_RETENTION_DAYS` controls `AGENT_REPLY#...` thread metadata, `GROUP_MEMORY_LONG_TERM_RETENTION_DAYS` controls `EVENT#...`, `USER_FACT#...`, `GROUP_FACT#...`, and `JOKE#...`, `GROUP_MEMORY_DAILY_SUMMARY_RETENTION_DAYS` controls `DAILY_SUMMARY#...`, and `GROUP_MEMORY_PROACTIVE_COUNTER_RETENTION_DAYS` controls `PROACTIVE#...` counters. `MSG#...`, long-term memory, and `DAILY_SUMMARY#...` retention settings fall back to `GROUP_MEMORY_RETENTION_DAYS` when omitted; `AGENT_REPLY#...` and `PROACTIVE#...` keep their existing short defaults unless explicitly configured. Long-term `expires_in_days` still stores `expires_at`; the DynamoDB `ttl` is the shorter of explicit expiry and configured long-term retention.
+
+## Contest Fairness Boundary
+
+- Activation is fail-closed: validate the current linked channel and Bot administrator status, write `CREATING`, publish fixed Kazakh rules under the root, then atomically attach the rules alias and transition to `OPEN`. `CREATING` never accepts entries.
+- Eligibility is raw-update deterministic and does not call an LLM: initial text/media caption marker only; entry text only; direct first-level root reply only; personal non-Bot `from.id` only. Registration transaction-checks `OPEN` and conditionally writes one participant row per user id.
+- First draw conditionally transitions `OPEN -> DRAWING` before a strongly consistent, fully paginated participant read. A `secrets.randbelow` reservoir sample gives every eligible row equal probability without materializing an unbounded list; zero entrants restore `OPEN`, and persisted winners precede Telegram delivery.
+- `announcement_state=PENDING` replays the same stored winner after delivery ambiguity. A winner announcement replies to the saved entry; an explicit missing-entry error falls back to the root with an escaped bounded snapshot. If both anchors are missing, the contest becomes terminal `ORPHANED`; no unanchored result is allowed.
+- Only live Telegram `creator` status may draw, redraw, or cancel. Live `creator` or `administrator` may inspect status. Anonymous identities and the configured Bot owner have no exception.
+- First successful draw or cancellation fixes `expires_at` at 30 days and atomically writes a durable cleanup outbox marker. At most two redraws append distinct winners and never extend expiry. `PROCESS_CONTEST_TTL_SWEEP` applies the same physical TTL to participant/alias/META rows; META cursor/version is the only sweep-continuation truth. Sweep completion atomically sets META TTL and consumes the marker. Initial enqueue is best-effort so cleanup outages do not block a winner/status response. An independent always-on production EventBridge rule seeds bounded `PROCESS_CONTEST_TTL_RECOVERY` pages, including when no chat remains configured. Logical expiry wins while DynamoDB deletion lags.
+- Operational inspection, DLQ redrive, and exact-row cleanup are defined in [CONTEST_OPERATIONS.md](CONTEST_OPERATIONS.md).
+- Open contests do not auto-expire. If a known webhook outage exceeds Telegram's update-retention window, cancel the affected contest because the participant set can no longer be proven complete.
 
 ## Long-Term Memory Extraction
 

--- a/docs/CONTEST_OPERATIONS.md
+++ b/docs/CONTEST_OPERATIONS.md
@@ -1,0 +1,52 @@
+# Contest Operations Runbook
+
+Use this runbook only for a known webhook outage, an unreachable contest root, or retention work that reached the DLQ. Contest lifecycle truth is in the memory table; ordinary group-memory rows are not a participant source.
+
+## Fairness incident
+
+1. If Telegram updates may have been missing for longer than Telegram's update-retention window, do not draw the affected open contest.
+2. If the root or Zerde rules reply is still reachable, ask the current Telegram group creator to reply with `/contest cancel`.
+3. If neither anchor is reachable, record the exact `(chat_id, root_message_id)` and inspect only that contest's rows. Do not scan messages to reconstruct entrants.
+
+## Read-only inspection
+
+Replace placeholders explicitly; do not use a wildcard chat or table name.
+
+```bash
+aws dynamodb get-item \
+  --table-name '<memory-table>' \
+  --key '{"pk":{"S":"CHAT#<chat_id>"},"sk":{"S":"CONTEST#<13-digit-root-message-id>#META"}}' \
+  --consistent-read
+
+aws dynamodb query \
+  --table-name '<memory-table>' \
+  --key-condition-expression 'pk = :pk AND begins_with(sk, :prefix)' \
+  --expression-attribute-values '{":pk":{"S":"CHAT#<chat_id>"},":prefix":{"S":"CONTEST#<13-digit-root-message-id>#"}}' \
+  --consistent-read
+
+# Read rules_message_id from META, then inspect its exact alias.
+aws dynamodb get-item \
+  --table-name '<memory-table>' \
+  --key '{"pk":{"S":"CHAT#<chat_id>"},"sk":{"S":"CONTEST_RULE#<13-digit-rules-message-id>"}}' \
+  --consistent-read
+
+aws dynamodb get-item \
+  --table-name '<memory-table>' \
+  --key '{"pk":{"S":"CONTEST_TTL_OUTBOX"},"sk":{"S":"CHAT#<chat_id>#ROOT#<13-digit-root-message-id>"}}' \
+  --consistent-read
+```
+
+The expected rows are one `META`, zero or more `PARTICIPANT` rows, an optional `CONTEST_RULE` alias, and—after first draw/cancel until cleanup completes—one global outbox marker.
+
+## Retention recovery
+
+- A surviving outbox marker is authoritative pending work. Do not delete it manually just because an SQS message was sent.
+- Redrive the failed `PROCESS_CONTEST_TTL_SWEEP` DLQ record when possible. Its payload needs only `chat_id` and `root_message_id`; META `ttl_sweep_cursor` and `ttl_sweep_version` own progress.
+- The always-on production EventBridge rule seeds a bounded `PROCESS_CONTEST_TTL_RECOVERY` job. Recovery pages the global outbox and independently queues identity-only sweeps, even if the chat was later removed from configuration; duplicate recovery and sweep messages are expected and safe.
+- Cleanup is complete only when participant rows and the rules alias have the same physical `ttl`, META has `ttl_sweep_status=COMPLETE` plus its physical `ttl`, and the exact outbox marker is absent.
+
+## Precise manual cleanup
+
+For an unreachable `OPEN` or stuck `CREATING` contest, first export the exact query result above to an incident backup. Obtain explicit approval before deleting data. Delete only the exact META, its participant-prefix rows, its stored rules alias, and its exact outbox marker; never delete `CHAT#<chat_id>` broadly. Record the backup location, row count, reason, operator, and UTC timestamp.
+
+After any manual action, repeat the read-only queries and confirm that unrelated contest roots and memory rows remain unchanged.

--- a/docs/README_kk.md
+++ b/docs/README_kk.md
@@ -50,6 +50,7 @@ RAG дегеніміз — **Retrieval-Augmented Generation**: алдымен р
 | Reply thread continuity | Bot жауаптары short-term `AGENT_REPLY#...` ретінде сақталады, сондықтан follow-up сұрақтар алдыңғы жауапты біледі; бұл semantic/vector memory емес. |
 | Social timing | Ordinary proactive жауаптар қысқа delay-ден кейін recent context және query-filtered long-term context негізінде Groq/DeepSeek decision арқылы өтеді. Yes болса, chat daily limit reserve жасалып, жауап Gemini арқылы generate болады, DeepSeek/Groq fallback бар. Linked-channel post zero-delay comment path арқылы бөлек өңделеді және supported attached media-ны ephemeral талдай алады. |
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages sampled және rate-limited, ал linked-channel post міндетті reaction attempt алады. |
+| Әділ linked-channel конкурс | Official linked-channel post ішінде `#конкурс` болса, discussion supergroup-та қазақша конкурс ашылады. `қатысамын` сөзі бар тікелей personal-account replies Telegram user id бойынша бір рет қана саналады; ұтысты тек топ иесі өткізеді. |
 | Captcha және anti-spam | Жаңа мүшелерді тексеру; pending captcha хабарлары тек captcha flow ішінде қалады, strong high-confidence spam үнсіз өшіріледі, ал weak/ambiguous жағдайлар optional admin @mentions бар admin review-ға жіберіледі. |
 | Community voteban | `/voteban` арқылы қауымдастық дауысымен ban/forgive. |
 | Daily AI news | EventBridge арқылы іске қосылатын news Lambda RSS кандидаттарын мақала мәтіні/суретімен толықтырады, developer-ге пайдалы high-signal жаңалықтарды таңдайды және Gemini/DeepSeek-compatible жолдармен fact-first көптілді digest жібереді. |
@@ -124,6 +125,17 @@ Bot Lambda retrieval және memory cleanup үшін S3 Vectors query/delete ж
 | `/memory about me` | Барлығына | Current user-дің өз хабарламаларынан сақталған profile fields көрсету; басқа адамдардың бағасын көрсетпейді. |
 | `/memory on/off/status/forget .../wrong` | Settings үшін group owner немесе bot owner; users өз memory өшіре алады немесе answer source-тарын wrong деп белгілей алады | Group memory басқару және cleanup. `forget this` bot answer-ден durable long-term memory ғана өшіреді немесе source message-ке тікелей reply болса raw/derived memory өшіреді; `USER#` profile өшірмейді. `wrong` reply жасалған bot answer memory source-тарын өшірмей қате деп белгілейді. |
 | `/agent on/off/status/why/wrong` | Settings үшін group owner немесе bot owner; users replied answer source-тарын тексере/белгілей алады | Agent participation басқару және bot неге жауап бергенін көру; memory source түрлері/count көрсетіледі, толық memory text көрсетілмейді. `/agent wrong` reply жасалған bot answer memory source-тарын қате деп белгілейді. `/agent off` proactive, mention және reply-thread қатысуын өшіреді; жад қосулы болса, `/ask` қолжетімді. |
+| `/contest draw/redraw/cancel` | Telegram-дағы қазіргі топ иесіне ғана | Конкурс root жазбасына немесе Zerde ережесіне reply арқылы жіберіледі. `draw` бірегей тізімді бекітіп, қауіпсіз кездейсоқ жеңімпаз таңдайды; ең көбі екі `redraw` бұрын жеңбеген адамды таңдайды. |
+| `/contest status` | Топ иесі немесе administrators | Конкурс root жазбасына не ережеге reply жасап, күйін, бірегей қатысушылар және ұтыс санын көру. |
+
+### Linked-channel конкурс ережесі
+
+- Official channel-дың бастапқы text немесе media caption ішінде standalone `#конкурс` болуы керек. Кейін edit арқылы қосылған hashtag конкурс ашпайды.
+- Қатысу үшін personal account бастапқы root жазбаға тікелей reply жасап, text ішінде `қатысамын` сөзін жазуы керек; регистр маңызды емес. Басқа comment-ке reply, caption, bot, channel және anonymous administrator есептелмейді.
+- Әр Telegram user id үшін алғашқы жарамды comment қана сақталып, оған Bot API қолдайтын `🎉` reaction қойылады. Қайта жазу қосымша мүмкіндік бермейді.
+- Ұтысты Telegram-дағы қазіргі топ иесі қолмен бастайды. Нәтиже жеңімпаздың алғашқы жарамды comment-іне reply болады және қатысушылар саны мен ұтыс ретін көрсетеді. Comment жойылса, Zerde сақталған snapshot-пен root-қа reply жасайды; main chat-қа anchor-сыз нәтиже жібермейді.
+- Алғашқы сәтті draw немесе cancel 30 күндік сақтау мерзімін бекітеді. Конкурс жаңа қатысушылар үшін жабылады, екі ретке дейін distinct redraw рұқсат етіледі және мерзім ұзартылмайды.
+- Zerde discussion supergroup ішінде administrator болуы керек. Белгілі webhook outage Telegram update сақтау терезесінен ұзақ болса, fairness бұзылады: ондай ашық конкурсты draw жасамай тоқтату керек.
 
 ---
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -50,6 +50,7 @@ RAG означает **Retrieval-Augmented Generation**: сначала найт
 | Reply thread continuity | Ответы бота сохраняются как short-term `AGENT_REPLY#...`, поэтому follow-up вопросы знают предыдущий ответ; эти записи не являются semantic/vector memory. |
 | Social timing | Ordinary proactive replies ждут короткий delay, затем Groq/DeepSeek решает по recent context и query-filtered long-term context, может ли бот добавить пользу. Если да, резервируется chat daily limit, а ответ генерирует Gemini с DeepSeek/Groq fallback. Linked-channel post обрабатывается отдельным zero-delay comment path и может ephemeral анализировать supported attached media. |
 | Ambient reactions | Optional `setMessageReaction` presence feature; ordinary funny/useful/thoughtful/warm/interesting messages получают sampled/rate-limited emoji reaction, а linked-channel post всегда получает reaction attempt. |
+| Честные linked-channel конкурсы | Official linked-channel post с `#конкурс` открывает конкурс на казахском языке в discussion supergroup. Прямые replies личных аккаунтов с `қатысамын` учитываются один раз по Telegram user id; розыгрыш запускает только владелец группы. |
 | Captcha и anti-spam | Проверка новых участников; сообщения pending captcha идут только в captcha flow, strong high-confidence spam удаляется тихо, а weak/ambiguous случаи уходят на admin review с optional admin @mentions. |
 | Community voteban | `/voteban` позволяет сообществу голосовать за ban/forgive. |
 | Daily AI news | News Lambda по EventBridge обогащает RSS-кандидаты текстом/картинками статей, выбирает high-signal новости для разработчиков и отправляет fact-first multilingual digest через Gemini/DeepSeek-compatible paths. |
@@ -124,6 +125,17 @@ Bot Lambda может query/delete S3 Vectors для retrieval и memory cleanup
 | `/memory about me` | Все | Показать profile fields текущего пользователя, сохраненные из его собственных сообщений, без чужих оценок. |
 | `/memory on/off/status/forget .../wrong` | Group owner или bot owner для settings; users могут удалить свою memory или отметить answer sources как wrong | Управление group memory и cleanup. `forget this` удаляет durable long-term memory из replied bot answer или raw/derived memory при прямом reply на source message; `USER#` profile не удаляется. `wrong` помечает источники памяти replied bot answer как ошибочные без удаления. |
 | `/agent on/off/status/why/wrong` | Group owner или bot owner для settings; users могут inspect или отметить replied answer sources | Управление участием agent-а и объяснение, почему бот ответил, включая типы/count источников памяти без полного текста memory. `/agent wrong` помечает источники памяти replied bot answer как ошибочные. `/agent off` выключает proactive, mention и reply-thread участие; `/ask` остается доступен, если память включена. |
+| `/contest draw/redraw/cancel` | Только текущий Telegram creator группы | Команда должна быть reply на корневой пост конкурса или правила Zerde. `draw` фиксирует уникальный список и безопасно выбирает победителя; максимум два `redraw` выбирают ранее не выигрывавших участников. |
+| `/contest status` | Creator или administrators | Reply на корневой пост или правила показывает состояние, число уникальных участников и число розыгрышей. |
+
+### Конкурсы linked-channel
+
+- В исходном тексте или media caption официального channel post должен быть отдельный `#конкурс`. Hashtag, добавленный позднее через edit, конкурс не активирует.
+- Личный аккаунт должен ответить непосредственно на корневой пост текстом с `қатысамын`, без учета регистра. Replies на другие comments, captions, bots, channels и anonymous administrators не учитываются.
+- Для каждого Telegram user id сохраняется только первый валидный comment, на который ставится поддерживаемая Bot API reaction `🎉`; повторные сообщения не дают дополнительный шанс.
+- Текущий Telegram creator группы запускает розыгрыш вручную. Результат отвечает на первый валидный comment победителя и публикует число участников и номер розыгрыша. Если comment удален, Zerde отвечает на root с сохраненным snapshot; результат без anchor в main chat не отправляется.
+- Первый успешный draw или cancel фиксирует 30-дневное хранение. Новые участники больше не принимаются, разрешены не более двух distinct redraw, срок при этом не продлевается.
+- Zerde должен быть administrator в discussion supergroup. Если известный webhook outage длиннее окна хранения Telegram updates, fairness потеряна: такой открытый конкурс нужно отменить, а не разыгрывать.
 
 ---
 

--- a/docs/goals/telegram-contest-random-winner/GOAL.md
+++ b/docs/goals/telegram-contest-random-winner/GOAL.md
@@ -1,0 +1,10 @@
+# Goal: Telegram Contest Random Winner
+
+Use Krypton Execution to execute `docs/goals/telegram-contest-random-winner/PLAN.md`.
+
+Core rules:
+- Treat PLAN.md as the source plan.
+- Preserve intent, ownership, contract, cutover, evidence, and kill criteria.
+- Do not add a new dominant path without deleting, redirecting, demoting, or shimming the displaced path.
+- Capture acceptance evidence from the target perspective.
+- Say "implemented but unproven" if that evidence cannot be captured.

--- a/docs/goals/telegram-contest-random-winner/PLAN.md
+++ b/docs/goals/telegram-contest-random-winner/PLAN.md
@@ -1,0 +1,262 @@
+# Telegram Contest Random Winner Implementation Plan
+
+**Intent:** Let a linked Telegram channel run a fair, auditable Kazakh-language contest in its discussion supergroup by marking the original post with `#конкурс`, recording each eligible person once, and allowing only the group creator to draw one winner plus at most two distinct redraws.
+**Current Behavior:** Zerde recognizes official linked-channel mirror posts for AI comments and ambient reactions, and stores ordinary discussion messages for memory, but it has no contest state, participant uniqueness contract, owner-only draw command, frozen entrant boundary, or winner evidence path. A plain-message handler cannot be added safely because the dispatcher currently uses its single handler for captcha answers, and the group-agent path may consume ordinary text before the dispatcher sees it.
+**Expected Outcome:** Every configured linked discussion supergroup can create one contest per official mirrored root post when the initial text or caption contains a case-insensitive standalone `#конкурс`. Eligible first-level text replies containing `қатысамын` are atomically deduplicated by Telegram user id. The current Telegram group creator can close and draw securely, redraw at most twice without repeating winners, cancel an open contest, and admins can inspect status. Results publicly show the unique entrant count and reply to the winner's original entry when it still exists.
+**Target-Perspective Output:** A group member sees a fixed Kazakh rules reply under the channel post, receives the Bot API-supported `🎉` reaction on their first accepted entry, and cannot gain another chance by posting again. The group owner replies to the root or rules message with `/contest draw` and sees a winner announcement anchored to the actual accepted comment, including participant count and draw number. Unauthorized users see no successful state transition.
+**Truth Owner:** `ContestRepository` rows in the existing DynamoDB memory table own contest lifecycle, first accepted participant evidence, frozen counts, winner history, announcement ids, expiry, and rule-message anchors. Telegram messages are presentation/evidence anchors, not lifecycle truth.
+**Contract Boundary:** Raw Telegram `Update.message` payloads cross into contest observation after captcha/spam short-circuiting and before memory/ambient/agent handling. `/contest` commands cross through the existing dispatcher `Context`. Repository operations expose explicit state transitions and registration outcomes; no AI model participates in eligibility or winner selection.
+**Cutover:** Insert one non-consuming contest observation step into the webhook. It records contest state/reactions but then preserves the existing memory, ambient reaction, linked-channel AI-comment, group-agent, and dispatcher paths. Register `/contest` as a normal command without replacing the captcha `on_message` handler. Reuse the existing memory table, main task queue, and IAM; add no table, queue, env var, or webhook update type. Add idempotent `PROCESS_CONTEST_TTL_SWEEP` and bounded `PROCESS_CONTEST_TTL_RECOVERY` tasks, a same-table durable outbox marker, and one always-on production EventBridge recovery seed so missed initial enqueue is recovered without participant scans even after all chats leave configuration.
+**Displaced Path:** No user-visible path is removed. The unsafe alternatives are explicitly displaced: do not route entries through the single dispatcher message handler, do not infer participants from group-memory rows, do not keep participants in one growing DynamoDB list, and do not let the group-agent own contest recognition.
+**Value Density:** One hashtag, one entry phrase, four subcommands, one secure winner path, one existing DynamoDB table/queue, and one small production recovery schedule deliver the requested contest loop without deadlines, exports, DMs, prize workflows, new storage, or new runtime configuration.
+**Acceptance Evidence:** Capture an executable Telegram-shaped acceptance transcript in focused tests: official mirror -> Kazakh rules reply; direct eligible entry -> one conditional participant record and `🎉`; duplicate/nested/anonymous entry -> no extra chance; creator draw -> frozen complete entrant set and winner reply to the saved entry message; two redraws -> distinct winners; deleted-entry fallback -> root reply; missing root -> terminal `ORPHANED`. The integration matrix also covers root/rules anchoring, owner/admin authorization, 0/1-person draws, exhausted redraws, logical expiry, crash recovery, and resumable TTL sweep. Run the complete test suite and pre-commit. Because this task does not authorize deployment to a real Telegram group, report the result as implemented but unproven live.
+**Evidence Lane:** Repository contract tests, webhook/dispatcher integration tests using real Telegram update shapes, Telegram API payload tests, and a target-perspective contest flow test. Live Telegram acceptance is a later deployment gate.
+**Kill Criteria:** There must be exactly one contest truth model and one registration path. No scan of raw memory messages, no second participant store, no alternate draw code, no partial-page random selection, no bot-owner draw exception, no nested-reply eligibility, and no fallthrough winner message into the supergroup main chat.
+**Architecture Slice:** `webhook.py` observation -> `services/contest.py` orchestration -> `repositories/contest.py` state/transactions; `/contest` -> `handlers/contest.py` -> the same service/repository; `TelegramClient` remains the only Bot API boundary.
+**Plan Review Gate:** Requires PRE review before execution.
+
+## Confirmed Product Contract
+
+### Contest creation
+
+- Apply to all supergroups already configured through `CHAT_LANG_MAP`; add no feature flag.
+- Accept only official linked-channel discussion mirrors: supergroup message, linked-channel actor, automatic-forward/fallback marker, and current `getChat(...).linked_chat_id` matching `sender_chat.id`.
+- Match a standalone `#конкурс` case-insensitively in the initial root `text` or `caption` only.
+- Do not subscribe to or process `edited_message`; later edits neither create contests nor change entries.
+- Resolve the current Bot id through a cached Telegram `getMe` call, then require its current chat-member status to be `administrator`; otherwise send a fixed Kazakh configuration error and create no open contest.
+- Reply to the root with deterministic Kazakh rules while preserving all existing linked-post AI comments and reactions.
+
+### Entry eligibility
+
+- Accept only `message.text` containing the case-insensitive substring `қатысамын`.
+- Require `message_thread_id == root_message_id` and `reply_to_message.message_id == root_message_id` so only first-level comments count.
+- Require a real personal `from.id`, `from.is_bot != true`, and no `sender_chat`; exclude bots, anonymous admins, and channel identities.
+- Deduplicate atomically by `(chat_id, root_message_id, user_id)` and retain only the first accepted message snapshot.
+- Ignore later edits/deletions for eligibility. Telegram message deletion is not available as a normal Bot API update.
+- Set the Bot API-supported `🎉` reaction for a newly stored participant; an idempotent redelivery of that exact accepted Telegram message may reassert the same reaction after ambiguous delivery. A different duplicate, late, invalid, nested, or anonymous entry receives no contest feedback. Existing ambient reactions may later replace the `🎉`.
+- Continue the existing group-memory, ambient-reaction, proactive-agent, and command pipeline after contest observation.
+
+### Authorization and commands
+
+- Every command must be sent by a personal account while replying to the root message or the stored rules message.
+- `/contest draw`, `/contest redraw`, and `/contest cancel` require live `getChatMember(...).status == creator`.
+- `/contest status` accepts live `creator` or `administrator` status.
+- Do not grant `ADMIN_USER_ID` / bot owner a contest exception.
+- Commands and all public contest text are fixed Kazakh messages.
+
+### Lifecycle and randomness
+
+- Public lifecycle: `OPEN -> DRAWN` or `OPEN -> CANCELLED`; there is no reopen.
+- Internal fail-closed states are explicit: `CREATING` accepts no entries until the rules-message id and alias are durably attached; `DRAWING` accepts no entries while the complete entrant set is selected; `announcement_state=PENDING|SENT` tracks delivery of an already-persisted winner; and `ORPHANED` is terminal.
+- First draw atomically stops registration before a strongly consistent, fully paginated participant read.
+- Zero participants returns an error and restores/remains `OPEN`; one participant wins normally.
+- Use a uniform `secrets.randbelow` reservoir sample across every strongly consistent participant page. Never choose from a partial page or materialize an unbounded participant list.
+- First draw stores a frozen participant count and closes registration.
+- Allow two redraws within the fixed retention window, exclude all previous winners, and never exceed three winner records total.
+- Repeating `/contest draw` returns the stored first result; only `/contest redraw` may append a new distinct winner.
+- If no unselected participant remains, reject redraw without changing stored winners.
+- A pending winner announcement must be retried with the same persisted winner before any redraw can begin. Retrying a command must never select a replacement winner merely because Telegram delivery failed.
+
+### Evidence, retention, and failure behavior
+
+- Store entry message id, user id, username, first/last name, original accepted text, and acceptance timestamp.
+- HTML-escape every user-controlled display value, create mentions with the safe `tg://user?id=...`/escaped username helper, and deterministically truncate the public fallback snapshot so every message remains below Telegram's limit. Keep the bounded full accepted text only in DynamoDB.
+- Publish winner mention, unique participant count, and draw ordinal (`1/3`, `2/3`, `3/3`) by replying directly to that winner's first accepted comment.
+- If Telegram explicitly reports that the entry reply target is missing, reply to the root with the stored snapshot and original message id.
+- If the root reply target is also missing, mark the contest `ORPHANED`; never use `allow_sending_without_reply=true` and never spill the result into the main chat. `ORPHANED` preserves the frozen count and winner audit, permits authorized `status` only, and rejects draw/redraw/cancel.
+- `OPEN` has no automatic expiry. The first successful draw or cancellation atomically writes one immutable 30-day logical `expires_at` plus a global durable cleanup marker, then enqueues an idempotent paginated TTL sweep; redraws do not extend it.
+- Logical expiry is authoritative even if DynamoDB has not physically removed rows yet. Every command rejects expired state before mutation.
+- A known webhook outage longer than Telegram's 24-hour update retention invalidates live fairness; the operational rule is to cancel the affected contest.
+- If a root disappears before the first draw and Telegram never reports the deletion, leave the unreachable `OPEN` rows for precise operator cleanup by `(chat_id, root_message_id)`; do not add a bot-owner chat command.
+
+### Cross-system recovery protocol
+
+- Creation writes `CREATING`, sends the rules reply, then atomically attaches the returned rules-message alias and transitions to `OPEN`. Registration condition-checks `OPEN`, so a failed rules send can never leave a hidden active contest.
+- If a direct comment webhook overlaps the root webhook before META exists, an unedited embedded official root posted at most five minutes before that comment may request Telegram redelivery while the comment remains within Telegram's 24-hour update-retention window. The nested snapshot never creates a contest itself, so edited roots or old-root/new-comment history cannot be backfilled.
+- A definite rules-delivery failure marks `CREATION_FAILED` with a 30-day cleanup TTL. An ambiguous network failure may mean Telegram displayed a duplicate rules message on retry; exactly-once Telegram delivery is not promised, but the repository still remains fail-closed and never counts entries before one returned message id is attached.
+- First draw transitions `OPEN -> DRAWING` before a strongly consistent participant read. A read/selection failure conditionally restores `OPEN`; a crash may leave `DRAWING`, and the same creator command resumes that frozen attempt rather than opening a second draw.
+- Winner choice is persisted before Telegram delivery with `announcement_state=PENDING`. Delivery success stores the Bot announcement id and changes it to `SENT`. A repeated `/contest draw` or the next `/contest redraw` first replays a pending announcement for the same stored winner; it never reselects.
+- Telegram acknowledgement loss can produce a duplicate announcement for the same winner, because Bot API `sendMessage` has no idempotency key. The invariant is no hidden-open contest, no changed winner, no extra chance, and no main-chat spill—not cross-system exactly-once presentation.
+- First draw/cancel writes `expires_at` and `pk=CONTEST_TTL_OUTBOX` in one transaction, then best-effort enqueues `PROCESS_CONTEST_TTL_SWEEP` without delaying the winner/status response. The worker stamps the same `ttl` on a bounded participant page and persists its continuation key before identity-only re-enqueue. Reprocessing a page is idempotent; second-page failure resumes from the META cursor/version, the only sweep-progress truth. It stamps the rules alias, then atomically marks `ttl_sweep_status=COMPLETE`, applies META physical TTL, and deletes the outbox marker. An always-on production EventBridge rule seeds an independent bounded `PROCESS_CONTEST_TTL_RECOVERY` job; recovery strongly pages the global outbox and queues sweeps, including when a chat—or every chat—was removed from configuration. Recovery-task failures retain normal SQS retry/DLQ behavior and do not share the daily-summary failure domain.
+
+### Non-goals
+
+- Automatic deadline or draw.
+- Multiple simultaneous winners in one draw.
+- Manual participant removal or disqualification.
+- Participant export.
+- Direct-message winner notification.
+- Prize fulfillment/claim tracking.
+- Edit-driven eligibility changes or deleted-message history recovery.
+- Deployment or live production acceptance in this change.
+
+## Architecture Map
+
+### Files to create
+
+- `src/bot/services/repositories/contest.py` — sole DynamoDB contest/participant/anchor repository, conditional writes, transactions, pagination, state transitions, TTL stamping.
+- `src/bot/services/contest.py` — marker/entry recognition, root validation, secure draw/redraw orchestration, fixed Kazakh rendering, winner announcement/fallback behavior.
+- `src/bot/services/handlers/contest.py` — `/contest` parsing, reply-anchor validation, live permission checks, and calls into the contest service.
+- `tests/test_contest_repository.py` — DynamoDB key, condition, transaction, pagination, state, and TTL contract tests.
+- `tests/test_contest_service.py` — recognition, eligibility, reaction, secure draw, announcement, fallback, and state behavior.
+- `tests/test_contest_acceptance.py` — target-perspective Telegram-shaped end-to-end flow across root, entries, commands, and output payloads.
+- `tests/test_contest_wiring.py` — application/Lambda dependency injection for the contest repository and shared queue client.
+- `docs/CONTEST_OPERATIONS.md` — fairness incidents, exact-row inspection, DLQ recovery, and narrow manual-cleanup runbook.
+- `docs/goals/telegram-contest-random-winner/PLAN.md` — this source plan.
+- `docs/goals/telegram-contest-random-winner/GOAL.md` — compact execution handoff.
+
+### Files to modify
+
+- `src/bot/app.py` — lazily construct/inject `ContestRepository` from the existing memory table.
+- `src/bot/main.py`, `src/bot/services/sqs_task_router.py`, `src/bot/services/repositories/sqs.py` — route/enqueue idempotent contest TTL sweep and bounded recovery tasks on the existing main queue.
+- `src/bot/core/dispatcher.py` — carry `contest_repo` in `Dispatcher`/`Context`; do not change single-message-handler semantics.
+- `src/bot/services/repositories/__init__.py` — export `ContestRepository`.
+- `src/bot/services/handlers/__init__.py` — register `/contest` only.
+- `src/bot/webhook.py` — observe contest roots/entries after spam/captcha and before memory/ambient/agent while continuing the normal flow.
+- `src/bot/services/telegram.py` — add only the Bot API identity/reply semantics needed for admin verification and missing-anchor-safe replies.
+- `infra/components/bot.py`, `tests/test_infra_configuration.py` — add and prove the production recovery schedule remains present with zero configured chats.
+- `tests/conftest.py`, `tests/test_dispatcher.py`, `tests/test_webhook.py`, `tests/test_telegram_client.py`, `tests/test_sqs_task_router.py` — update shared wiring, task routing, and boundary expectations.
+- `.codex/AGENTS.md`, `.codex/skills/zerdebot-development/SKILL.md`, `docs/ARCHITECTURE.md` — document the new truth rows, webhook step, command contract, and fairness/failure boundaries.
+- `README.md`, `docs/README_kk.md`, `docs/README_ru.md` — document the user-visible hashtag, entry rule, commands, permissions, and 30-day window.
+
+### Files to avoid
+
+- `src/bot/services/group_agent.py` and AI provider prompts — existing AI behavior remains unchanged.
+- `src/bot/services/group_memory.py` and `repositories/group_memory.py` — contest is not memory extraction or semantic retrieval.
+- `src/bot/services/handlers/captcha.py` — keep the pending-captcha isolation and existing plain-message handler.
+- `.env.example` and GitHub workflows — add no environment configuration; reuse the existing table/main queue/IAM.
+- `scripts/setup_webhook.sh` — edited updates remain out of scope.
+
+### Source of truth
+
+The existing DynamoDB memory table with dedicated non-vectorizable chat rows plus one global cleanup-outbox partition:
+
+```text
+sk=CONTEST#<root_message_id>#META
+sk=CONTEST#<root_message_id>#PARTICIPANT#<telegram_user_id>
+sk=CONTEST_RULE#<rules_message_id>
+pk=CONTEST_TTL_OUTBOX, sk=CHAT#<chat_id>#ROOT#<root_message_id>
+```
+
+### Read path
+
+- Root/entry observation derives the stable contest id from the discussion supergroup root message id.
+- Commands resolve either the root anchor directly or a stored rules-message alias.
+- Draw streams participant keys with strong consistency and full pagination; status reads the exact transactional participant counter.
+- Scheduled retention recovery strongly pages only the global outbox partition, never participant rows.
+
+### Write path
+
+- Conditional contest creation prevents duplicate webhook delivery from creating duplicate activities.
+- Participant registration uses one DynamoDB transaction: conditionally increment the exact META participant counter while `OPEN`, plus conditional put of the per-user participant row.
+- Draw closes registration before reading; conditional completion stores one winner history. Concurrent/retried commands return the persisted result rather than selecting again.
+- First draw/cancel atomically sets logical expiry and creates a durable outbox marker, then best-effort enqueues a cursor-based, idempotent main-queue sweep that stamps participant/alias/META TTLs without extending on redraw. Completion atomically consumes the marker; the independent production recovery schedule seeds bounded, independently retried recovery pages for missed work.
+
+### Integration points
+
+- Telegram `getMe` (cached), `getChat`, `getChatMember`, `sendMessage`, and `setMessageReaction` through `TelegramClient`.
+- Existing main SQS queue for `PROCESS_CONTEST_TTL_SWEEP` and `PROCESS_CONTEST_TTL_RECOVERY`; task failures retain the current retry/DLQ semantics.
+- Existing webhook spam/captcha ordering.
+- Existing dispatcher command parsing and `@botname` normalization.
+- Existing memory table/IAM and DynamoDB TTL attribute `ttl`.
+- One always-on production EventBridge rule targeting the existing main queue with `PROCESS_CONTEST_TTL_RECOVERY`; no new queue, table, role, or environment setting.
+
+### Migration/cutover
+
+No data migration. New key prefixes are ignored by existing memory/vector readers. The feature becomes active when this code is deployed; historical `#конкурс` posts are not backfilled.
+
+### Acceptance evidence gate
+
+Before publication:
+
+1. Targeted repository/service/webhook/dispatcher/Telegram tests pass.
+2. The acceptance/integration matrix proves visible rules, one reaction per user, root/rules command anchoring, owner-only draw/cancel, admin status, 0/1-person behavior, correct winner reply anchoring, unique/exhausted redraws, logical expiry, safe missing-message fallback, and fail-closed delivery recovery.
+3. `uv run pytest tests/ -q` passes.
+4. `uv run pre-commit run --all-files` passes.
+5. Review confirms the only infra diff is the production contest-recovery schedule, there is no env diff, and AI decision behavior is unchanged.
+
+## Execution Tasks
+
+### Task 1 — Establish contest persistence and concurrency contract
+
+**Files:** Create `src/bot/services/repositories/contest.py`, `tests/test_contest_repository.py`; modify repository exports.
+
+**Allowed scope:** Dedicated `CONTEST#`/`CONTEST_RULE#` rows and one `CONTEST_TTL_OUTBOX` partition in the existing memory table; conditional `CREATING -> OPEN`; transactional unique registration/count; strong paginated reservoir reads; begin/complete/abort/resume draw; announcement state; redraw history; cancel/terminal orphan; immutable logical expiry; durable-outbox cursor-based TTL sweeping.
+
+**Expected output:** A repository API that makes duplicate registration, registration-after-close, concurrent draw, partial reads, repeated draws, winner repetition, and TTL extension structurally difficult.
+
+**Verification:** `uv run pytest tests/test_contest_repository.py -q`.
+
+**Acceptance evidence:** Tests inspect exact keys, conditions/transactions, pagination continuation, conditional-failure outcomes, creation/draw crash boundaries, winner/announcement history, second-page TTL retry, alias/participant expiry equality, terminal orphan behavior, and unchanged 30-day expiry across redraws.
+
+**Parallel:** No; this contract is prerequisite for orchestration.
+
+### Task 2 — Implement contest recognition, lifecycle orchestration, and Telegram evidence
+
+**Files:** Create `src/bot/services/contest.py`, `tests/test_contest_service.py`; minimally modify `src/bot/services/telegram.py` and its tests.
+
+**Allowed scope:** Confirmed hashtag/text rules, strict official-root checks, cached `getMe` bot identity and bot-admin prerequisite, participant recognition, `🎉`, uniform `secrets.randbelow` reservoir selection, fixed Kazakh messages, HTML-safe bounded dynamic fields, winner direct reply, deleted-entry root fallback, pending-announcement replay, terminal orphan handling.
+
+**Expected output:** Deterministic eligibility and state behavior with no LLM or memory-retrieval dependency.
+
+**Verification:** `uv run pytest tests/test_contest_service.py tests/test_telegram_client.py -q`.
+
+**Acceptance evidence:** Outgoing Telegram payload assertions show the rules under the root and winner announcement under the saved accepted comment; malicious HTML/max-length snapshots stay safe; failure/retry tests prove the same winner is replayed and no main-chat spill occurs.
+
+**Parallel:** No; depends on Task 1.
+
+### Task 3 — Wire webhook observation and owner/admin commands
+
+**Files:** Create `src/bot/services/handlers/contest.py`; modify `app.py`, `main.py`, `core/dispatcher.py`, repository/handler exports, `repositories/sqs.py`, `sqs_task_router.py`, `webhook.py`, `infra/components/bot.py`, `tests/conftest.py`, `tests/test_dispatcher.py`, `tests/test_webhook.py`, `tests/test_sqs_task_router.py`, and `tests/test_infra_configuration.py`.
+
+**Allowed scope:** Lazy repository injection, one pre-memory observation call when captcha/spam did not short-circuit, `/contest` registration, reply-anchor lookup, live exact Telegram status checks, best-effort main-queue TTL sweep enqueue/routing, webhook 5xx retry for persistence/overlap failures, independent bounded outbox recovery, and its always-on production EventBridge seed.
+
+**Expected output:** Contest updates are recorded before the group agent can consume them, but all existing AI/memory/ambient paths still run; captcha and spam remain higher priority.
+
+**Verification:** `uv run pytest tests/test_webhook.py tests/test_dispatcher.py tests/test_contest_service.py -q`.
+
+**Acceptance evidence:** Tests prove spam/captcha never register entrants, accepted contest messages still reach existing memory/agent mocks, permission/anchor failures do not mutate contest state, and failed/incomplete TTL pages re-enter the existing retry path.
+
+**Parallel:** No; depends on Tasks 1–2.
+
+### Task 4 — Add target-perspective acceptance scenario and documentation
+
+**Files:** Create `tests/test_contest_acceptance.py`; modify architecture/agent skill files and English/Kazakh/Russian READMEs.
+
+**Allowed scope:** One representative multi-user flow and current-state documentation only. Do not add deployment configuration or historical backfill.
+
+**Expected output:** A maintainer and group owner can understand activation, accepted comments, commands, permissions, redraws, retention, and failure limits from current docs.
+
+**Verification:** `uv run pytest tests/test_contest_acceptance.py -q`; documentation links/commands checked by pre-commit.
+
+**Acceptance evidence:** The scenario's captured Bot API calls form the non-live Telegram transcript promised by the plan.
+
+**Parallel:** Documentation can run after the service contract stabilizes; acceptance test depends on Tasks 1–3.
+
+### Task 5 — Integration review and full validation
+
+**Files:** All files changed by Tasks 1–4.
+
+**Allowed scope:** Fix only defects revealed by review/tests; do not broaden V1.
+
+**Expected output:** No duplicate truth path, no partial-page draw, no unauthorized transition, no regression to captcha/spam/AI routing, and no format/lint failures.
+
+**Verification:** `uv run pytest tests/ -q` and `uv run pre-commit run --all-files`.
+
+**Acceptance evidence:** Preserve command output and test counts for the PR summary. If no real Telegram group is exercised, label live acceptance unproven.
+
+**Parallel:** Reviewer may inspect while full tests run, but fixes and final proof are serialized.
+
+### Task 6 — Publish for review
+
+**Files:** Stage only the intentional feature, tests, plan, and docs.
+
+**Allowed scope:** Conventional commit and draft PR against `main`; no merge and no deployment.
+
+**Expected output:** Branch `feat/contest-random-winner`, commit `feat: add fair Telegram contest draws`, pushed to `origin`, with a draft PR describing contract, risks, validation, and live-acceptance limitation.
+
+**Verification:** `git status --short`, `git diff --check`, `git log -1 --oneline`, and PR metadata.
+
+**Acceptance evidence:** Draft PR URL plus exact validation summary.
+
+**Parallel:** No; final gate only.

--- a/infra/components/bot.py
+++ b/infra/components/bot.py
@@ -367,6 +367,21 @@ class BotConstruct(Construct):
             )
         )
 
+        if is_prod:
+            contest_recovery_rule = events.Rule(
+                self,
+                f"{CONSTRUCT_PREFIX}ContestTTLRecoveryRule",
+                rule_name=f"{RESOURCE_PREFIX}-contest-ttl-recovery-{env_name}",
+                description="Recover durable contest TTL cleanup work",
+                schedule=events.Schedule.cron(minute="50", hour="20", day="*", month="*", year="*"),
+            )
+            contest_recovery_rule.add_target(
+                events_targets.SqsQueue(
+                    queue,
+                    message=events.RuleTargetInput.from_object({"task_type": "PROCESS_CONTEST_TTL_RECOVERY"}),
+                )
+            )
+
         if is_prod and chat_lang_map:
             summary_rule = events.Rule(
                 self,

--- a/src/bot/app.py
+++ b/src/bot/app.py
@@ -8,6 +8,7 @@ from core.logger import LoggerAdapter, get_logger
 from services.handlers import register_handlers
 from services.repositories import (
     CaptchaRepository,
+    ContestRepository,
     GroupMemoryRepository,
     LambdaInvoker,
     QuizRepository,
@@ -22,6 +23,8 @@ logger = LoggerAdapter(get_logger(__name__), {})
 _bot: TelegramClient | None = None
 _captcha_repo: CaptchaRepository | None = None
 _memory_repo: GroupMemoryRepository | None = None
+_contest_repo: ContestRepository | None = None
+_sqs_repo: SQSClient | None = None
 _dispatcher: Dispatcher | None = None
 
 
@@ -51,6 +54,24 @@ def get_memory_repo() -> GroupMemoryRepository | None:
     return _memory_repo
 
 
+def get_contest_repo() -> ContestRepository | None:
+    """Return the contest truth owner when the shared memory table is configured."""
+    global _contest_repo
+    if not MEMORY_TABLE_NAME:
+        return None
+    if _contest_repo is None:
+        _contest_repo = ContestRepository()
+    return _contest_repo
+
+
+def get_sqs_repo() -> SQSClient:
+    """Return the shared main-queue client used by webhook and SQS continuations."""
+    global _sqs_repo
+    if _sqs_repo is None:
+        _sqs_repo = SQSClient()
+    return _sqs_repo
+
+
 def get_dispatcher() -> Dispatcher:
     """Wire the webhook dispatcher lazily and reuse it across warm invocations."""
     global _dispatcher
@@ -58,12 +79,13 @@ def get_dispatcher() -> Dispatcher:
         dispatcher = Dispatcher(
             get_bot(),
             StatsRepository(),
-            SQSClient(),
+            get_sqs_repo(),
             VoteRepository(),
             QuizRepository() if QUIZ_TABLE_NAME else None,
             LambdaInvoker() if QUIZ_LAMBDA_NAME else None,
             captcha_repo=get_captcha_repo(),
             memory_repo=get_memory_repo(),
+            contest_repo=get_contest_repo(),
         )
         register_handlers(dispatcher)
         _dispatcher = dispatcher

--- a/src/bot/core/dispatcher.py
+++ b/src/bot/core/dispatcher.py
@@ -7,6 +7,7 @@ from core.logger import LoggerAdapter, get_logger
 from core.utils import check_membership
 from services.repositories import (
     CaptchaRepository,
+    ContestRepository,
     GroupMemoryRepository,
     LambdaInvoker,
     QuizRepository,
@@ -41,6 +42,7 @@ class Context:
         lambda_invoker: LambdaInvoker | None = None,
         captcha_repo: CaptchaRepository | None = None,
         memory_repo: GroupMemoryRepository | None = None,
+        contest_repo: ContestRepository | None = None,
     ):
         self._update = update
         self.bot = bot
@@ -51,6 +53,7 @@ class Context:
         self.lambda_invoker = lambda_invoker
         self.captcha_repo = captcha_repo
         self.memory_repo = memory_repo
+        self.contest_repo = contest_repo
 
         self.callback_query = update.get("callback_query")
         if self.callback_query:
@@ -153,6 +156,7 @@ class Dispatcher:
         lambda_invoker: LambdaInvoker | None = None,
         captcha_repo: CaptchaRepository | None = None,
         memory_repo: GroupMemoryRepository | None = None,
+        contest_repo: ContestRepository | None = None,
     ):
         self.bot = bot
         self.stats_repo = stats_repo
@@ -162,6 +166,7 @@ class Dispatcher:
         self.lambda_invoker = lambda_invoker
         self.captcha_repo = captcha_repo
         self.memory_repo = memory_repo
+        self.contest_repo = contest_repo
 
         self.command_handlers: dict[str, HandlerFunc] = {}
         self.new_chat_members_handler: HandlerFunc | None = None
@@ -223,6 +228,7 @@ class Dispatcher:
             self.lambda_invoker,
             self.captcha_repo,
             self.memory_repo,
+            self.contest_repo,
         )
 
         poll_answer = ctx._update.get("poll_answer")

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -3,7 +3,7 @@
 import time
 from typing import Any
 
-from app import get_bot, get_captcha_repo, get_dispatcher, get_memory_repo
+from app import get_bot, get_captcha_repo, get_contest_repo, get_dispatcher, get_memory_repo, get_sqs_repo
 from core.logger import LoggerAdapter, get_logger
 from services.sqs_task_router import process_sqs_event
 from webhook import handle_event
@@ -24,7 +24,14 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any] | None
         logger.info("Bot Lambda handler called (SQS)", extra=log_extra)
         started = time.monotonic()
         try:
-            process_sqs_event(event, get_bot(), get_captcha_repo(), get_memory_repo())
+            process_sqs_event(
+                event,
+                get_bot(),
+                get_captcha_repo(),
+                get_memory_repo(),
+                contest_repo=get_contest_repo(),
+                sqs_repo=get_sqs_repo(),
+            )
         finally:
             elapsed_ms = int((time.monotonic() - started) * 1000)
             logger.info(

--- a/src/bot/services/contest.py
+++ b/src/bot/services/contest.py
@@ -1,0 +1,897 @@
+"""Fair linked-channel contest orchestration.
+
+This module owns deterministic Telegram-shape recognition and the lifecycle
+between :class:`ContestRepository` and Telegram.  AI and group-memory services
+do not participate in eligibility or winner selection.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import time
+from html import escape
+from typing import Any
+
+from core.logger import LoggerAdapter, get_logger
+from core.utils import format_mention
+from services.repositories.contest import ContestRepository, RegistrationResult
+from services.repositories.sqs import SQSClient
+from services.telegram import TelegramAPIError, TelegramClient
+from services.telegram_actor import is_linked_channel_discussion_post
+
+logger = LoggerAdapter(get_logger(__name__), {})
+
+CONTEST_MARKER = "#конкурс"
+ENTRY_PHRASE = "қатысамын"
+MAX_DRAWS = 3
+TTL_SWEEP_PAGE_SIZE = 50
+TTL_OUTBOX_PAGE_SIZE = 100
+CREATION_ATTEMPT_LEASE_SECONDS = 30
+EMBEDDED_ROOT_OVERLAP_SECONDS = 5 * 60
+TELEGRAM_UPDATE_RETENTION_SECONDS = 24 * 60 * 60
+TELEGRAM_SAFE_HTML_CHARS = 4000
+
+_CONTEST_MARKER_RE = re.compile(r"(?<![\w#])#конкурс(?!\w)", re.IGNORECASE)
+_MISSING_REPLY_DESCRIPTIONS = (
+    "message to be replied not found",
+    "reply message not found",
+)
+
+RULES_MESSAGE_KK = (
+    "🎉 <b>Конкурс басталды!</b>\n\n"
+    "Қатысу үшін осы бастапқы жазбаға тікелей жауап беріп, мәтінде "
+    "«қатысамын» сөзін жазыңыз.\n"
+    "Әр адам бір рет қана қатысады. Тек жеке аккаунттар есепке алынады.\n"
+    "Басқа пікірге немесе осы хабарламаға берілген жауап есептелмейді.\n"
+    "Пікіріңізге 🎉 қойылса, қатысуыңыз тіркелді.\n"
+    "Жеңімпаз қауіпсіз кездейсоқ таңдау арқылы анықталады."
+)
+BOT_ADMIN_REQUIRED_KK = "⚠️ Конкурсты бастау мүмкін болмады: Zerde осы талқылау тобында әкімші болуы керек."
+OWNER_ONLY_KK = "⛔ Бұл әрекетті тек топ иесі орындай алады."
+ADMIN_ONLY_KK = "⛔ Конкурс күйін тек топ иесі немесе әкімші көре алады."
+PERSONAL_ACCOUNT_REQUIRED_KK = "⛔ Команданы жеке аккаунттан жіберіңіз."
+REPLY_ANCHOR_REQUIRED_KK = "ℹ️ Команданы конкурс жазбасына немесе Zerde жариялаған ережелерге жауап ретінде жіберіңіз."
+UNKNOWN_SUBCOMMAND_KK = "ℹ️ Қолдану: /contest draw | redraw | status | cancel"
+NO_PARTICIPANTS_KK = "ℹ️ Әзірге жарамды қатысушы жоқ. Конкурс ашық күйінде қалды."
+USE_DRAW_FIRST_KK = "ℹ️ Алдымен /contest draw командасын қолданыңыз."
+CONTEST_CANCELLED_KK = "🚫 Конкурс тоқтатылды. Жаңа қатысушылар қабылданбайды."
+CONTEST_ALREADY_CANCELLED_KK = "ℹ️ Бұл конкурс бұрын тоқтатылған."
+CONTEST_CLOSED_KK = "ℹ️ Бұл конкурс жабық."
+CONTEST_EXPIRED_KK = "⌛ Конкурстың 30 күндік сақтау мерзімі аяқталды."
+REDRAW_LIMIT_KK = "ℹ️ Қайта ұтыс шегіне жетті: барлығы 3 ұтысқа дейін рұқсат."
+NO_REMAINING_CANDIDATES_KK = "ℹ️ Қайта ұтысқа бұрын жеңбеген қатысушы қалмады."
+ANNOUNCEMENT_RETRIED_KK = "ℹ️ Сақталған нәтиже қайта жарияланды. Қайта ұтыс үшін команданы тағы жіберіңіз."
+ORPHANED_KK = "⚠️ Конкурс дәлел хабарламалары жойылғандықтан жабылды; тек күйін көруге болады."
+CONTEST_NOT_READY_KK = "ℹ️ Конкурс әлі дайын емес. Кейінірек қайталап көріңіз."
+CONTEST_ERROR_KK = "⚠️ Конкурс әрекетін орындау мүмкін болмады. Кейінірек қайталап көріңіз."
+
+
+class AnnouncementOrphanedError(RuntimeError):
+    """Winner and root reply anchors are both unavailable."""
+
+
+class ContestRetryRequiredError(RuntimeError):
+    """A concurrent fail-closed transition requires Telegram redelivery."""
+
+
+def has_contest_marker(message: dict[str, Any]) -> bool:
+    """Return whether the initial text/caption contains standalone ``#конкурс``."""
+    content = message.get("text") or message.get("caption") or ""
+    return isinstance(content, str) and bool(_CONTEST_MARKER_RE.search(content))
+
+
+def is_entry_message(message: dict[str, Any]) -> bool:
+    """Return whether a raw message has the non-repository entry shape."""
+    text = message.get("text")
+    if not isinstance(text, str) or ENTRY_PHRASE.casefold() not in text.casefold():
+        return False
+
+    sender = message.get("from")
+    if not isinstance(sender, dict) or sender.get("id") is None:
+        return False
+    if sender.get("is_bot") is True or message.get("sender_chat"):
+        return False
+
+    root_message_id = message.get("message_thread_id")
+    reply = message.get("reply_to_message")
+    chat = message.get("chat")
+    if (
+        not isinstance(message.get("message_id"), int)
+        or not isinstance(chat, dict)
+        or chat.get("id") is None
+        or not isinstance(root_message_id, int)
+        or not isinstance(reply, dict)
+    ):
+        return False
+    return reply.get("message_id") == root_message_id
+
+
+def is_contest_root_shape(message: dict[str, Any]) -> bool:
+    """Return whether a message has the strict official discussion-root shape."""
+    chat = message.get("chat")
+    sender_chat = message.get("sender_chat")
+    return bool(
+        isinstance(chat, dict)
+        and chat.get("type") == "supergroup"
+        and isinstance(message.get("message_id"), int)
+        and is_linked_channel_discussion_post(message)
+        and isinstance(sender_chat, dict)
+        and sender_chat.get("type") == "channel"
+        and sender_chat.get("id") is not None
+    )
+
+
+def _is_fresh_embedded_root(entry: dict[str, Any], root: dict[str, Any]) -> bool:
+    """Limit missing-META retries to an unedited, currently overlapping root update."""
+    if root.get("edit_date") is not None:
+        return False
+    root_date = root.get("date")
+    entry_date = entry.get("date")
+    if not isinstance(root_date, int) or not isinstance(entry_date, int):
+        return False
+    now = int(time.time())
+    return (
+        0 <= entry_date - root_date <= EMBEDDED_ROOT_OVERLAP_SECONDS
+        and -EMBEDDED_ROOT_OVERLAP_SECONDS <= now - entry_date <= TELEGRAM_UPDATE_RETENTION_SECONDS
+    )
+
+
+def _is_missing_reply_error(exc: TelegramAPIError) -> bool:
+    if exc.status != 400:
+        return False
+    description = str(exc.body or "").casefold()
+    return any(fragment in description for fragment in _MISSING_REPLY_DESCRIPTIONS)
+
+
+def _source_channel_post_id(message: dict[str, Any]) -> int | None:
+    direct = message.get("forward_from_message_id")
+    if isinstance(direct, int):
+        return direct
+    origin = message.get("forward_origin")
+    if isinstance(origin, dict) and isinstance(origin.get("message_id"), int):
+        return origin["message_id"]
+    return None
+
+
+def _winner_at(contest: dict[str, Any], draw_number: int) -> dict[str, Any] | None:
+    winners = contest.get("winners")
+    if not isinstance(winners, list) or draw_number < 1 or len(winners) < draw_number:
+        return None
+    winner = winners[draw_number - 1]
+    return winner if isinstance(winner, dict) else None
+
+
+def _winner_mention(winner: dict[str, Any]) -> str:
+    return format_mention(
+        int(winner["user_id"]),
+        str(winner.get("username") or "") or None,
+        str(winner.get("first_name") or "Қатысушы")[:120],
+        str(winner.get("last_name") or "")[:120] or None,
+    )
+
+
+def _escaped_to_budget(raw_text: str, budget: int) -> tuple[str, bool]:
+    """Escape whole characters without cutting an HTML entity at ``budget``."""
+    rendered: list[str] = []
+    used = 0
+    for index, char in enumerate(raw_text):
+        token = escape(char)
+        if used + len(token) > budget:
+            return "".join(rendered), True
+        rendered.append(token)
+        used += len(token)
+        if index == len(raw_text) - 1:
+            return "".join(rendered), False
+    return "", False
+
+
+def _evidence_excerpt(raw_text: str) -> str:
+    """Keep the qualifying phrase visible when a deleted entry needs fallback evidence."""
+    match = re.search(re.escape(ENTRY_PHRASE), raw_text, re.IGNORECASE)
+    if not match:
+        return raw_text
+    context_chars = 120
+    start = max(0, match.start() - context_chars)
+    end = min(len(raw_text), match.end() + context_chars)
+    if start == 0 and end == len(raw_text):
+        return raw_text
+    return ("…" if start else "") + raw_text[start:end] + ("…" if end < len(raw_text) else "")
+
+
+def _winner_message(contest: dict[str, Any], winner: dict[str, Any], *, include_snapshot: bool) -> str:
+    draw_number = int(winner["draw_number"])
+    participant_count = int(contest.get("frozen_participant_count") or 0)
+    lines = [
+        "🎉 <b>Жеңімпаз анықталды!</b>",
+        f"🏆 {_winner_mention(winner)}",
+        f"👥 Қатысушылар саны: <b>{participant_count}</b>",
+        f"🎲 Ұтыс: <b>{draw_number}/{MAX_DRAWS}</b>",
+    ]
+    if not include_snapshot:
+        return "\n".join(lines)
+
+    lines.append(f"🧾 Алғашқы жарамды пікір: <code>#{int(winner['entry_message_id'])}</code>")
+    prefix = "\n".join([*lines, "<blockquote>"])
+    suffix = "</blockquote>"
+    budget = max(0, TELEGRAM_SAFE_HTML_CHARS - len(prefix) - len(suffix))
+    raw_text = _evidence_excerpt(str(winner.get("text") or ""))
+    snapshot, was_truncated = _escaped_to_budget(raw_text, budget)
+    if was_truncated and budget > 0:
+        snapshot, _ = _escaped_to_budget(raw_text, max(0, budget - 1))
+        snapshot += "…"
+    return f"{prefix}{snapshot}{suffix}"
+
+
+class ContestService:
+    """Coordinate contest recognition, draws, evidence, and retention."""
+
+    def __init__(
+        self,
+        repo: ContestRepository,
+        bot: TelegramClient,
+        sqs_repo: SQSClient | None = None,
+    ) -> None:
+        self.repo = repo
+        self.bot = bot
+        self.sqs_repo = sqs_repo
+
+    def observe_update(self, update: dict[str, Any]) -> None:
+        """Observe one initial Telegram message without consuming normal bot flows."""
+        message = update.get("message")
+        if not isinstance(message, dict):
+            return
+        if has_contest_marker(message):
+            self._observe_root(message)
+        if is_entry_message(message):
+            self._observe_entry(message)
+
+    def _bot_is_administrator(self, chat_id: int | str) -> bool:
+        bot_id = int(self.bot.get_me()["id"])
+        member = self.bot.get_chat_member(chat_id, bot_id)
+        return str(member.get("status") or "").casefold() == "administrator"
+
+    def _send_admin_error(self, chat_id: int | str, root_message_id: int) -> None:
+        try:
+            self.bot.send_message(chat_id, BOT_ADMIN_REQUIRED_KK, reply_to_message_id=root_message_id)
+        except Exception:
+            logger.exception(
+                "Failed to send contest bot-admin prerequisite message",
+                extra={"chat_id": chat_id, "root_message_id": root_message_id},
+            )
+
+    def _observe_root(self, message: dict[str, Any]) -> None:
+        chat = message.get("chat")
+        sender_chat = message.get("sender_chat")
+        root_message_id = message.get("message_id")
+        if not is_contest_root_shape(message):
+            return
+
+        chat_id = chat.get("id")
+        if chat_id is None:
+            return
+        linked_chat = self.bot.get_chat(chat_id)
+        if str(linked_chat.get("linked_chat_id")) != str(sender_chat["id"]):
+            return
+
+        existing = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if existing:
+            if existing.get("status") == "CREATING":
+                self._activate_creating(existing)
+            return
+
+        if not self._bot_is_administrator(chat_id):
+            self._send_admin_error(chat_id, root_message_id)
+            return
+
+        created = self.repo.create_contest(
+            chat_id=chat_id,
+            root_message_id=root_message_id,
+            source_channel_id=sender_chat["id"],
+            source_channel_title=str(sender_chat.get("title") or "") or None,
+            source_channel_username=str(sender_chat.get("username") or "") or None,
+            source_channel_post_id=_source_channel_post_id(message),
+            created_at=message.get("date") if isinstance(message.get("date"), int) else None,
+        )
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if created or (contest and contest.get("status") == "CREATING"):
+            self._activate_creating(contest or {"chat_id": str(chat_id), "root_message_id": root_message_id})
+
+    def _activate_creating(self, contest: dict[str, Any]) -> bool:
+        chat_id = contest["chat_id"]
+        root_message_id = int(contest["root_message_id"])
+        now = int(time.time())
+        attempt_id = secrets.token_hex(16)
+        claimed = self.repo.begin_creation_attempt(
+            chat_id,
+            root_message_id,
+            attempt_id=attempt_id,
+            stale_before=now - CREATION_ATTEMPT_LEASE_SECONDS,
+            now=now,
+        )
+        if not claimed:
+            raise ContestRetryRequiredError("Contest rules publication is already in progress")
+        try:
+            bot_is_administrator = self._bot_is_administrator(chat_id)
+        except Exception:
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+            raise
+        if not bot_is_administrator:
+            self.repo.fail_creation(chat_id, root_message_id, attempt_id=attempt_id)
+            self._send_admin_error(chat_id, root_message_id)
+            return False
+        try:
+            rules = self.bot.send_message(
+                chat_id,
+                RULES_MESSAGE_KK,
+                reply_to_message_id=root_message_id,
+                link_preview_disable=True,
+            )
+        except TelegramAPIError as exc:
+            if exc.status in {400, 403}:
+                self.repo.fail_creation(chat_id, root_message_id, attempt_id=attempt_id)
+                logger.exception(
+                    "Definite Telegram failure while creating contest",
+                    extra={"chat_id": chat_id, "root_message_id": root_message_id},
+                )
+                return False
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+            raise
+        except Exception:
+            # Telegram may have accepted the request before the transport failed.
+            # Release the lease so webhook retry can safely publish again. A
+            # duplicate rules message is preferable to a hidden open contest.
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+            logger.exception(
+                "Ambiguous Telegram failure while creating contest",
+                extra={"chat_id": chat_id, "root_message_id": root_message_id},
+            )
+            raise
+
+        rules_message_id = rules.get("message_id") if isinstance(rules, dict) else None
+        if not isinstance(rules_message_id, int):
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+            logger.error(
+                "Telegram rules response lacked message_id; contest remains CREATING",
+                extra={"chat_id": chat_id, "root_message_id": root_message_id},
+            )
+            raise RuntimeError("Telegram rules response lacked message_id")
+        try:
+            activated = self.repo.activate_contest(
+                chat_id,
+                root_message_id,
+                rules_message_id,
+                attempt_id=attempt_id,
+            )
+        except Exception:
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+            raise
+        if not activated:
+            self.repo.release_creation_attempt(chat_id, root_message_id, attempt_id=attempt_id)
+        return activated
+
+    def _observe_entry(self, message: dict[str, Any]) -> None:
+        chat_id = message.get("chat", {}).get("id")
+        root_message_id = message["message_thread_id"]
+        if chat_id is None:
+            return
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest:
+            replied_root = message.get("reply_to_message")
+            replied_chat = replied_root.get("chat") if isinstance(replied_root, dict) else None
+            if (
+                isinstance(replied_root, dict)
+                and isinstance(replied_chat, dict)
+                and str(replied_chat.get("id")) == str(chat_id)
+                and replied_root.get("message_id") == root_message_id
+                and has_contest_marker(replied_root)
+                and is_contest_root_shape(replied_root)
+                and _is_fresh_embedded_root(message, replied_root)
+            ):
+                # Never create from a nested snapshot: it may be edited or
+                # pre-cutover history. Ask Telegram to redeliver briefly while
+                # the original root invocation owns activation.
+                raise ContestRetryRequiredError("Contest root activation is still in progress")
+        if not contest:
+            return
+        if contest.get("status") == "CREATING":
+            self._activate_creating(contest)
+            contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest or contest.get("status") != "OPEN":
+            return
+
+        sender = message["from"]
+        result = self.repo.register_participant(
+            chat_id=chat_id,
+            root_message_id=root_message_id,
+            user_id=int(sender["id"]),
+            entry_message_id=int(message["message_id"]),
+            username=str(sender.get("username") or "") or None,
+            first_name=str(sender.get("first_name") or "") or None,
+            last_name=str(sender.get("last_name") or "") or None,
+            text=str(message["text"]),
+            accepted_at=message.get("date") if isinstance(message.get("date"), int) else None,
+        )
+        if result in {RegistrationResult.REGISTERED, RegistrationResult.REPLAY}:
+            try:
+                self.bot.set_message_reaction(chat_id, int(message["message_id"]), "🎉")
+            except TelegramAPIError as exc:
+                logger.exception(
+                    "Contest entry stored but acknowledgement reaction failed",
+                    extra={"chat_id": chat_id, "root_message_id": root_message_id, "user_id": sender["id"]},
+                )
+                if exc.status != 400:
+                    raise
+            except Exception:
+                logger.exception(
+                    "Contest entry reaction delivery was ambiguous",
+                    extra={"chat_id": chat_id, "root_message_id": root_message_id, "user_id": sender["id"]},
+                )
+                raise
+
+    def _send_command_reply(self, chat_id: int | str, command_message_id: int, text: str) -> None:
+        self.bot.send_message(chat_id, text, reply_to_message_id=command_message_id)
+
+    def _enqueue_ttl_sweep(self, contest: dict[str, Any]) -> None:
+        if contest.get("ttl_sweep_status") != "PENDING":
+            return
+        if not self.sqs_repo:
+            logger.error(
+                "Contest TTL sweep has no SQS client; durable outbox remains pending",
+                extra={"chat_id": contest.get("chat_id"), "root_message_id": contest.get("root_message_id")},
+            )
+            return
+        try:
+            self.sqs_repo.send_contest_ttl_sweep_task(
+                chat_id=int(contest["chat_id"]),
+                root_message_id=int(contest["root_message_id"]),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue contest TTL sweep; durable outbox will recover it",
+                extra={"chat_id": contest.get("chat_id"), "root_message_id": contest.get("root_message_id")},
+            )
+
+    def _sample_candidate(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        excluded_user_ids: set[str],
+    ) -> tuple[dict[str, Any] | None, int]:
+        """Uniformly sample across every strong page without materializing the set."""
+        selected: dict[str, Any] | None = None
+        participant_count = 0
+        candidate_count = 0
+        for participant in self.repo.iter_participants(chat_id, root_message_id):
+            participant_count += 1
+            if str(participant.get("user_id")) in excluded_user_ids:
+                continue
+            candidate_count += 1
+            if secrets.randbelow(candidate_count) == 0:
+                selected = participant
+        return selected, participant_count
+
+    def _announce_winner(self, contest: dict[str, Any], winner: dict[str, Any]) -> None:
+        chat_id = contest["chat_id"]
+        root_message_id = int(contest["root_message_id"])
+        draw_number = int(winner["draw_number"])
+        try:
+            sent = self.bot.send_message(
+                chat_id,
+                _winner_message(contest, winner, include_snapshot=False),
+                reply_to_message_id=int(winner["entry_message_id"]),
+                link_preview_disable=True,
+            )
+        except TelegramAPIError as entry_error:
+            if not _is_missing_reply_error(entry_error):
+                raise
+            try:
+                sent = self.bot.send_message(
+                    chat_id,
+                    _winner_message(contest, winner, include_snapshot=True),
+                    reply_to_message_id=root_message_id,
+                    link_preview_disable=True,
+                )
+            except TelegramAPIError as root_error:
+                if not _is_missing_reply_error(root_error):
+                    raise
+                self.repo.mark_orphaned(chat_id, root_message_id, draw_number=draw_number)
+                raise AnnouncementOrphanedError("winner entry and contest root are unavailable") from root_error
+
+        announcement_message_id = sent.get("message_id") if isinstance(sent, dict) else None
+        if not isinstance(announcement_message_id, int):
+            raise RuntimeError("Telegram winner announcement response lacked message_id")
+        self.repo.mark_announcement_sent(
+            chat_id,
+            root_message_id,
+            draw_number=draw_number,
+            announcement_message_id=announcement_message_id,
+        )
+
+    def _replay_pending_announcement(
+        self,
+        contest: dict[str, Any],
+        *,
+        command_message_id: int,
+        redraw_requested: bool,
+    ) -> bool:
+        if contest.get("status") != "DRAWN" or contest.get("announcement_state") != "PENDING":
+            return False
+        draw_number = int(contest.get("draw_count") or 0)
+        winner = _winner_at(contest, draw_number)
+        if not winner:
+            raise RuntimeError("Persisted contest winner is missing")
+        self._announce_winner(contest, winner)
+        if redraw_requested:
+            self._send_command_reply(
+                contest["chat_id"],
+                command_message_id,
+                ANNOUNCEMENT_RETRIED_KK,
+            )
+        return True
+
+    def draw(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        command_message_id: int,
+        redraw: bool = False,
+    ) -> None:
+        """Run or resume one secure draw, persisting the winner before delivery."""
+        self._draw(
+            chat_id=chat_id,
+            root_message_id=root_message_id,
+            command_message_id=command_message_id,
+            redraw=redraw,
+            transition_retries=1,
+        )
+
+    def _draw(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        command_message_id: int,
+        redraw: bool,
+        transition_retries: int,
+    ) -> None:
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest:
+            self._send_command_reply(chat_id, command_message_id, REPLY_ANCHOR_REQUIRED_KK)
+            return
+        if self.repo.is_logically_expired(contest):
+            self._send_command_reply(chat_id, command_message_id, CONTEST_EXPIRED_KK)
+            return
+        if contest.get("status") == "ORPHANED":
+            self._send_command_reply(chat_id, command_message_id, ORPHANED_KK)
+            return
+        if self._replay_pending_announcement(
+            contest,
+            command_message_id=command_message_id,
+            redraw_requested=redraw,
+        ):
+            self._enqueue_ttl_sweep(contest)
+            return
+
+        status = contest.get("status")
+        draw_number: int
+        attempt_id: str
+        if status == "DRAWING":
+            draw_number = int(contest.get("pending_draw_number") or 0)
+            attempt_id = str(contest.get("draw_attempt_id") or "")
+            if draw_number < 1 or not attempt_id or (draw_number == 1) == redraw:
+                self._send_command_reply(chat_id, command_message_id, CONTEST_NOT_READY_KK)
+                return
+        elif status == "OPEN":
+            if redraw:
+                self._send_command_reply(chat_id, command_message_id, USE_DRAW_FIRST_KK)
+                return
+            attempt_id = secrets.token_hex(16)
+            if not self.repo.begin_first_draw(
+                chat_id,
+                root_message_id,
+                attempt_id=attempt_id,
+            ):
+                if transition_retries > 0:
+                    return self._draw(
+                        chat_id=chat_id,
+                        root_message_id=root_message_id,
+                        command_message_id=command_message_id,
+                        redraw=redraw,
+                        transition_retries=transition_retries - 1,
+                    )
+                self._send_command_reply(chat_id, command_message_id, CONTEST_NOT_READY_KK)
+                return
+            draw_number = 1
+        elif status == "DRAWN":
+            if not redraw:
+                first_winner = _winner_at(contest, 1)
+                if not first_winner:
+                    raise RuntimeError("Persisted first contest winner is missing")
+                self._send_command_reply(
+                    chat_id,
+                    command_message_id,
+                    "ℹ️ Алғашқы сақталған нәтиже:\n" + _winner_message(contest, first_winner, include_snapshot=False),
+                )
+                self._enqueue_ttl_sweep(contest)
+                return
+            draw_count = int(contest.get("draw_count") or 0)
+            if draw_count >= MAX_DRAWS:
+                self._send_command_reply(chat_id, command_message_id, REDRAW_LIMIT_KK)
+                return
+            attempt_id = secrets.token_hex(16)
+            if not self.repo.begin_redraw(
+                chat_id,
+                root_message_id,
+                expected_draw_count=draw_count,
+                attempt_id=attempt_id,
+            ):
+                if transition_retries > 0:
+                    return self._draw(
+                        chat_id=chat_id,
+                        root_message_id=root_message_id,
+                        command_message_id=command_message_id,
+                        redraw=redraw,
+                        transition_retries=transition_retries - 1,
+                    )
+                self._send_command_reply(chat_id, command_message_id, CONTEST_NOT_READY_KK)
+                return
+            draw_number = draw_count + 1
+        elif status == "CANCELLED":
+            self._send_command_reply(chat_id, command_message_id, CONTEST_ALREADY_CANCELLED_KK)
+            self._enqueue_ttl_sweep(contest)
+            return
+        else:
+            self._send_command_reply(chat_id, command_message_id, CONTEST_NOT_READY_KK)
+            return
+
+        try:
+            prior_ids = {str(value) for value in contest.get("winner_user_ids") or []}
+            winner, participant_count = self._sample_candidate(
+                chat_id,
+                root_message_id,
+                excluded_user_ids=prior_ids,
+            )
+            if draw_number > 1 and self.repo.is_logically_expired(contest):
+                self.repo.abort_draw(
+                    chat_id,
+                    root_message_id,
+                    draw_number=draw_number,
+                    attempt_id=attempt_id,
+                )
+                self._send_command_reply(chat_id, command_message_id, CONTEST_EXPIRED_KK)
+                return
+            if winner is None:
+                self.repo.abort_draw(
+                    chat_id,
+                    root_message_id,
+                    draw_number=draw_number,
+                    attempt_id=attempt_id,
+                )
+                message = NO_PARTICIPANTS_KK if draw_number == 1 else NO_REMAINING_CANDIDATES_KK
+                self._send_command_reply(chat_id, command_message_id, message)
+                return
+            completed = self.repo.complete_draw(
+                chat_id,
+                root_message_id,
+                draw_number=draw_number,
+                attempt_id=attempt_id,
+                participant=winner,
+                frozen_participant_count=participant_count,
+            )
+        except Exception:
+            self.repo.abort_draw(
+                chat_id,
+                root_message_id,
+                draw_number=draw_number,
+                attempt_id=attempt_id,
+            )
+            raise
+
+        if not completed:
+            persisted = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+            if draw_number > 1 and (self.repo.is_logically_expired(persisted or contest)):
+                self.repo.abort_draw(
+                    chat_id,
+                    root_message_id,
+                    draw_number=draw_number,
+                    attempt_id=attempt_id,
+                )
+                self._send_command_reply(chat_id, command_message_id, CONTEST_EXPIRED_KK)
+                return
+            if persisted and persisted.get("status") == "DRAWN":
+                self._replay_pending_announcement(
+                    persisted,
+                    command_message_id=command_message_id,
+                    redraw_requested=False,
+                )
+                self._enqueue_ttl_sweep(persisted)
+                return
+            if (
+                persisted
+                and persisted.get("status") == "DRAWING"
+                and str(persisted.get("draw_attempt_id") or "") == attempt_id
+            ):
+                self.repo.abort_draw(
+                    chat_id,
+                    root_message_id,
+                    draw_number=draw_number,
+                    attempt_id=attempt_id,
+                )
+                raise RuntimeError("Contest draw completion condition failed")
+            return
+
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest:
+            raise RuntimeError("Contest disappeared after winner persistence")
+        persisted_winner = _winner_at(contest, draw_number)
+        if not persisted_winner:
+            raise RuntimeError("Winner disappeared after persistence")
+        self._announce_winner(contest, persisted_winner)
+        self._enqueue_ttl_sweep(contest)
+
+    def cancel(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        command_message_id: int,
+    ) -> None:
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest:
+            self._send_command_reply(chat_id, command_message_id, REPLY_ANCHOR_REQUIRED_KK)
+            return
+        if self.repo.is_logically_expired(contest):
+            self._send_command_reply(chat_id, command_message_id, CONTEST_EXPIRED_KK)
+            return
+        if contest.get("status") == "ORPHANED":
+            self._send_command_reply(chat_id, command_message_id, ORPHANED_KK)
+            return
+        cancelled = self.repo.cancel_contest(chat_id, root_message_id)
+        if not cancelled:
+            message = CONTEST_ALREADY_CANCELLED_KK if contest.get("status") == "CANCELLED" else CONTEST_CLOSED_KK
+            self._send_command_reply(chat_id, command_message_id, message)
+            self._enqueue_ttl_sweep(contest)
+            return
+        self._send_command_reply(chat_id, command_message_id, CONTEST_CANCELLED_KK)
+        self._enqueue_ttl_sweep(cancelled)
+
+    def status(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        command_message_id: int,
+    ) -> None:
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest:
+            self._send_command_reply(chat_id, command_message_id, REPLY_ANCHOR_REQUIRED_KK)
+            return
+        status = str(contest.get("status") or "UNKNOWN")
+        if self.repo.is_logically_expired(contest):
+            state_text = "мерзімі аяқталған"
+        else:
+            state_text = {
+                "CREATING": "дайындалып жатыр",
+                "CREATION_FAILED": "құру сәтсіз аяқталды",
+                "OPEN": "ашық",
+                "DRAWING": "ұтыс орындалып жатыр",
+                "DRAWN": "жабық, жеңімпаз анықталған",
+                "CANCELLED": "тоқтатылған",
+                "ORPHANED": "дәлел хабарламалары жойылған",
+            }.get(status, "белгісіз")
+        participant_count = (
+            int(contest.get("frozen_participant_count") or 0)
+            if status in {"DRAWN", "ORPHANED"}
+            else int(contest.get("participant_count") or 0)
+        )
+        draw_count = int(contest.get("draw_count") or 0)
+        text = (
+            "📊 <b>Конкурс күйі</b>\n"
+            f"Күйі: <b>{escape(state_text)}</b>\n"
+            f"Бірегей қатысушылар: <b>{participant_count}</b>\n"
+            f"Ұтыс саны: <b>{draw_count}/{MAX_DRAWS}</b>"
+        )
+        self._send_command_reply(chat_id, command_message_id, text)
+
+
+class ContestTTLWorker:
+    """Advance retention work without exposing a Telegram-less service state."""
+
+    def __init__(self, repo: ContestRepository, sqs_repo: SQSClient) -> None:
+        self.repo = repo
+        self.sqs_repo = sqs_repo
+
+    def process(self, body: dict[str, Any]) -> None:
+        """Stamp one bounded participant page and durably continue the sweep."""
+        chat_id = body["chat_id"]
+        root_message_id = int(body["root_message_id"])
+        contest = self.repo.get_contest(chat_id, root_message_id, consistent=True)
+        if not contest or contest.get("ttl_sweep_status") == "COMPLETE":
+            return
+        expires_at = contest.get("expires_at")
+        if expires_at is None:
+            return
+
+        durable_cursor = contest.get("ttl_sweep_cursor")
+        start_key = durable_cursor if isinstance(durable_cursor, dict) else None
+        sweep_version = int(contest.get("ttl_sweep_version") or 0)
+        page, next_start_key = self.repo.participant_page(
+            chat_id,
+            root_message_id,
+            limit=TTL_SWEEP_PAGE_SIZE,
+            start_key=start_key if isinstance(start_key, dict) else None,
+        )
+        self.repo.stamp_participant_ttl(page, int(expires_at))
+        if next_start_key:
+            advanced = self.repo.record_ttl_sweep_progress(
+                chat_id,
+                root_message_id,
+                expected_start_key=start_key,
+                expected_version=sweep_version,
+                next_start_key=next_start_key,
+            )
+            if not advanced:
+                return
+            self.sqs_repo.send_contest_ttl_sweep_task(
+                chat_id=int(chat_id),
+                root_message_id=root_message_id,
+            )
+            return
+
+        self.repo.complete_ttl_sweep(
+            chat_id,
+            root_message_id,
+            rules_message_id=(
+                int(contest["rules_message_id"]) if contest.get("rules_message_id") is not None else None
+            ),
+            expires_at=int(expires_at),
+            expected_start_key=start_key,
+            expected_version=sweep_version,
+        )
+
+
+def process_contest_ttl_recovery_task(
+    body: dict[str, Any],
+    *,
+    repo: ContestRepository,
+    sqs_repo: SQSClient,
+) -> None:
+    """Replay one bounded outbox page; sweep completion consumes each marker."""
+    supplied_start_key = body.get("start_key")
+    start_key = supplied_start_key if isinstance(supplied_start_key, dict) else None
+    markers, next_start_key = repo.ttl_outbox_page(
+        limit=TTL_OUTBOX_PAGE_SIZE,
+        start_key=start_key,
+    )
+    for marker in markers:
+        sqs_repo.send_contest_ttl_sweep_task(
+            chat_id=int(marker["chat_id"]),
+            root_message_id=int(marker["root_message_id"]),
+        )
+    if next_start_key:
+        sqs_repo.send_contest_ttl_recovery_task(start_key=next_start_key)
+
+
+def observe_contest_update(
+    repo: ContestRepository | None,
+    bot: TelegramClient,
+    update: dict[str, Any],
+    *,
+    sqs_repo: SQSClient | None = None,
+) -> None:
+    """Convenience boundary used by the webhook."""
+    if repo is not None:
+        ContestService(repo, bot, sqs_repo).observe_update(update)
+
+
+def process_contest_ttl_sweep_task(
+    body: dict[str, Any],
+    *,
+    repo: ContestRepository,
+    sqs_repo: SQSClient,
+) -> None:
+    """Convenience boundary used by the main SQS router."""
+    ContestTTLWorker(repo, sqs_repo).process(body)

--- a/src/bot/services/handlers/__init__.py
+++ b/src/bot/services/handlers/__init__.py
@@ -24,6 +24,7 @@ from services.handlers.commands import (
     handle_support,
     process_group_ask_task,
 )
+from services.handlers.contest import handle_contest
 from services.handlers.quiz import handle_poll_answer, handle_quizstats
 from services.handlers.spam_review import handle_spam_review_callback, is_spam_review_callback
 from services.handlers.voteban import handle_vote_callback, handle_voteban_command
@@ -67,6 +68,7 @@ def register_handlers(dp: Dispatcher) -> None:
     dp.command("agent")(handle_agent)
     dp.command("ask")(handle_ask)
     dp.command("voteban")(handle_voteban_command)
+    dp.command("contest")(handle_contest)
     dp.on_poll_answer(handle_poll_answer)
     dp.command("quizstats")(handle_quizstats)
     dp.command("genquiz")(handle_quiz_generate)

--- a/src/bot/services/handlers/contest.py
+++ b/src/bot/services/handlers/contest.py
@@ -1,0 +1,123 @@
+"""Owner/admin command boundary for Telegram contests."""
+
+from __future__ import annotations
+
+from core.dispatcher import Context
+from core.logger import LoggerAdapter, get_logger
+from services.contest import (
+    ADMIN_ONLY_KK,
+    CONTEST_ERROR_KK,
+    ORPHANED_KK,
+    OWNER_ONLY_KK,
+    PERSONAL_ACCOUNT_REQUIRED_KK,
+    REPLY_ANCHOR_REQUIRED_KK,
+    UNKNOWN_SUBCOMMAND_KK,
+    AnnouncementOrphanedError,
+    ContestRetryRequiredError,
+    ContestService,
+)
+
+logger = LoggerAdapter(get_logger(__name__), {})
+
+_OWNER_COMMANDS = {"draw", "redraw", "cancel"}
+_ALL_COMMANDS = {*_OWNER_COMMANDS, "status"}
+
+
+def _subcommand(text: str) -> str:
+    parts = text.split(maxsplit=1)
+    return parts[1].strip().casefold() if len(parts) == 2 else ""
+
+
+def _reply(ctx: Context, text: str) -> None:
+    ctx.reply(text, ctx.message_id)
+
+
+def handle_contest(ctx: Context) -> None:
+    """Handle ``/contest draw|redraw|status|cancel`` in fixed Kazakh."""
+    if ctx.user_id is None or ctx.user_data.get("is_bot") is True or bool(ctx.message.get("sender_chat")):
+        _reply(ctx, PERSONAL_ACCOUNT_REQUIRED_KK)
+        return
+
+    action = _subcommand(ctx.text)
+    if action not in _ALL_COMMANDS:
+        _reply(ctx, UNKNOWN_SUBCOMMAND_KK)
+        return
+    if ctx.contest_repo is None:
+        _reply(ctx, CONTEST_ERROR_KK)
+        return
+
+    reply = ctx.reply_to_message
+    anchor_message_id = reply.get("message_id") if isinstance(reply, dict) else None
+    if not isinstance(anchor_message_id, int) or ctx.chat_id is None or ctx.message_id is None:
+        _reply(ctx, REPLY_ANCHOR_REQUIRED_KK)
+        return
+    try:
+        contest = ctx.contest_repo.resolve_contest_by_anchor(ctx.chat_id, anchor_message_id)
+    except Exception as exc:
+        logger.exception(
+            "Failed to resolve contest command anchor",
+            extra={"chat_id": ctx.chat_id, "anchor_message_id": anchor_message_id},
+        )
+        raise ContestRetryRequiredError("Contest anchor lookup requires retry") from exc
+    if not contest:
+        _reply(ctx, REPLY_ANCHOR_REQUIRED_KK)
+        return
+
+    try:
+        member = ctx.bot.get_chat_member(ctx.chat_id, int(ctx.user_id))
+        member_status = str(member.get("status") or "").casefold()
+    except Exception:
+        logger.exception(
+            "Failed to verify contest command authorization",
+            extra={"chat_id": ctx.chat_id, "user_id": ctx.user_id, "action": action},
+        )
+        _reply(ctx, ADMIN_ONLY_KK if action == "status" else OWNER_ONLY_KK)
+        return
+
+    if action == "status":
+        if member_status not in {"creator", "administrator"}:
+            _reply(ctx, ADMIN_ONLY_KK)
+            return
+    elif member_status != "creator":
+        _reply(ctx, OWNER_ONLY_KK)
+        return
+
+    root_message_id = int(contest["root_message_id"])
+    service = ContestService(ctx.contest_repo, ctx.bot, ctx.sqs_repo)
+    try:
+        if action == "draw":
+            service.draw(
+                chat_id=ctx.chat_id,
+                root_message_id=root_message_id,
+                command_message_id=ctx.message_id,
+            )
+        elif action == "redraw":
+            service.draw(
+                chat_id=ctx.chat_id,
+                root_message_id=root_message_id,
+                command_message_id=ctx.message_id,
+                redraw=True,
+            )
+        elif action == "cancel":
+            service.cancel(
+                chat_id=ctx.chat_id,
+                root_message_id=root_message_id,
+                command_message_id=ctx.message_id,
+            )
+        else:
+            service.status(
+                chat_id=ctx.chat_id,
+                root_message_id=root_message_id,
+                command_message_id=ctx.message_id,
+            )
+    except AnnouncementOrphanedError:
+        _reply(ctx, ORPHANED_KK)
+    except ContestRetryRequiredError:
+        # Let the webhook return 5xx so Telegram redelivers the exact command.
+        raise
+    except Exception:
+        logger.exception(
+            "Contest command failed",
+            extra={"chat_id": ctx.chat_id, "root_message_id": root_message_id, "action": action},
+        )
+        _reply(ctx, CONTEST_ERROR_KK)

--- a/src/bot/services/repositories/__init__.py
+++ b/src/bot/services/repositories/__init__.py
@@ -1,6 +1,7 @@
 """Data-access layer: DynamoDB repositories and SQS task helpers."""
 
 from services.repositories.captcha import CaptchaRepository
+from services.repositories.contest import ContestRepository
 from services.repositories.group_memory import GroupMemoryRepository
 from services.repositories.lambda_invoker import LambdaInvoker
 from services.repositories.quiz import QuizRepository
@@ -11,6 +12,7 @@ from services.repositories.votes import VoteRepository
 
 __all__ = [
     "CaptchaRepository",
+    "ContestRepository",
     "GroupMemoryRepository",
     "LambdaInvoker",
     "QuizRepository",

--- a/src/bot/services/repositories/contest.py
+++ b/src/bot/services/repositories/contest.py
@@ -1,0 +1,965 @@
+"""DynamoDB truth owner for linked-channel contests."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from enum import StrEnum
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.types import TypeSerializer
+from botocore.exceptions import ClientError
+from core.config import MEMORY_TABLE_NAME
+from services.repositories._common import get_dynamodb
+
+_SECONDS_PER_DAY = 24 * 60 * 60
+CONTEST_RETENTION_DAYS = 30
+_TTL_OUTBOX_PK = "CONTEST_TTL_OUTBOX"
+
+
+class RegistrationResult(StrEnum):
+    """Outcome of one participant registration transaction."""
+
+    REGISTERED = "registered"
+    REPLAY = "replay"
+    DUPLICATE = "duplicate"
+    CLOSED = "closed"
+    MISSING = "missing"
+
+
+class ContestRepository:
+    """Store contest lifecycle and participants in the existing memory table."""
+
+    def __init__(self, table_name: str | None = None):
+        table_name = table_name or MEMORY_TABLE_NAME
+        if not table_name:
+            raise ValueError("MEMORY_TABLE_NAME must be set")
+        self.table = get_dynamodb().Table(table_name)
+        self.table_name = self.table.name
+        self.client = self.table.meta.client
+        self._serializer = TypeSerializer()
+
+    @staticmethod
+    def _chat_pk(chat_id: int | str) -> str:
+        return f"CHAT#{chat_id}"
+
+    @staticmethod
+    def _contest_prefix(root_message_id: int | str) -> str:
+        return f"CONTEST#{int(root_message_id):013d}#"
+
+    @classmethod
+    def _meta_sk(cls, root_message_id: int | str) -> str:
+        return f"{cls._contest_prefix(root_message_id)}META"
+
+    @classmethod
+    def _participant_prefix(cls, root_message_id: int | str) -> str:
+        return f"{cls._contest_prefix(root_message_id)}PARTICIPANT#"
+
+    @classmethod
+    def _participant_sk(cls, root_message_id: int | str, user_id: int | str) -> str:
+        return f"{cls._participant_prefix(root_message_id)}{int(user_id):020d}"
+
+    @staticmethod
+    def _rule_anchor_sk(rules_message_id: int | str) -> str:
+        return f"CONTEST_RULE#{int(rules_message_id):013d}"
+
+    @staticmethod
+    def _ttl_outbox_key(chat_id: int | str, root_message_id: int | str) -> dict[str, str]:
+        return {
+            "pk": _TTL_OUTBOX_PK,
+            "sk": f"CHAT#{chat_id}#ROOT#{int(root_message_id):013d}",
+        }
+
+    @classmethod
+    def _ttl_outbox_item(
+        cls,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        expires_at: int,
+        created_at: int,
+    ) -> dict[str, Any]:
+        return {
+            **cls._ttl_outbox_key(chat_id, root_message_id),
+            "kind": "contest_ttl_outbox",
+            "chat_id": str(chat_id),
+            "root_message_id": int(root_message_id),
+            "expires_at": int(expires_at),
+            "created_at": int(created_at),
+        }
+
+    @staticmethod
+    def _expiry(now: int) -> int:
+        return int(now) + CONTEST_RETENTION_DAYS * _SECONDS_PER_DAY
+
+    def _serialize_map(self, value: dict[str, Any]) -> dict[str, Any]:
+        return {key: self._serializer.serialize(item) for key, item in value.items() if item is not None}
+
+    @staticmethod
+    def _is_condition_failure(exc: ClientError) -> bool:
+        code = exc.response.get("Error", {}).get("Code")
+        if code == "ConditionalCheckFailedException":
+            return True
+        if code != "TransactionCanceledException":
+            return False
+        reasons = exc.response.get("CancellationReasons")
+        if not isinstance(reasons, list) or not reasons:
+            return False
+        reason_codes = {str(reason.get("Code") or "None") for reason in reasons if isinstance(reason, dict)}
+        return "ConditionalCheckFailed" in reason_codes and reason_codes <= {
+            "None",
+            "ConditionalCheckFailed",
+        }
+
+    def create_contest(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        source_channel_id: int | str,
+        source_channel_title: str | None,
+        source_channel_username: str | None,
+        source_channel_post_id: int | None,
+        created_at: int | None = None,
+    ) -> bool:
+        """Create one fail-closed ``CREATING`` contest for a mirrored root."""
+        now = int(created_at or time.time())
+        item: dict[str, Any] = {
+            "pk": self._chat_pk(chat_id),
+            "sk": self._meta_sk(root_message_id),
+            "kind": "contest",
+            "chat_id": str(chat_id),
+            "root_message_id": int(root_message_id),
+            "source_channel_id": str(source_channel_id),
+            "status": "CREATING",
+            "participant_count": 0,
+            "draw_count": 0,
+            "winner_user_ids": [],
+            "winners": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+        if source_channel_title:
+            item["source_channel_title"] = str(source_channel_title)[:200]
+        if source_channel_username:
+            item["source_channel_username"] = str(source_channel_username)[:100]
+        if source_channel_post_id is not None:
+            item["source_channel_post_id"] = int(source_channel_post_id)
+        try:
+            self.table.put_item(Item=item, ConditionExpression="attribute_not_exists(pk)")
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def activate_contest(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        rules_message_id: int,
+        *,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        """Attach the rules anchor and atomically transition ``CREATING -> OPEN``."""
+        now = int(now or time.time())
+        pk = self._chat_pk(chat_id)
+        meta_key = {"pk": pk, "sk": self._meta_sk(root_message_id)}
+        alias = {
+            "pk": pk,
+            "sk": self._rule_anchor_sk(rules_message_id),
+            "kind": "contest_rule_anchor",
+            "chat_id": str(chat_id),
+            "root_message_id": int(root_message_id),
+            "rules_message_id": int(rules_message_id),
+            "created_at": now,
+        }
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._serialize_map(meta_key),
+                            "UpdateExpression": (
+                                "SET #status = :open, rules_message_id = :rules, updated_at = :now "
+                                "REMOVE creation_attempt_id, creation_started_at"
+                            ),
+                            "ConditionExpression": ("#status = :creating AND creation_attempt_id = :attempt"),
+                            "ExpressionAttributeNames": {"#status": "status"},
+                            "ExpressionAttributeValues": self._serialize_map(
+                                {
+                                    ":open": "OPEN",
+                                    ":creating": "CREATING",
+                                    ":attempt": str(attempt_id),
+                                    ":rules": rules_message_id,
+                                    ":now": now,
+                                }
+                            ),
+                        }
+                    },
+                    {
+                        "Put": {
+                            "TableName": self.table_name,
+                            "Item": self._serialize_map(alias),
+                            "ConditionExpression": "attribute_not_exists(pk)",
+                        }
+                    },
+                ]
+            )
+            return True
+        except ClientError as exc:
+            if not self._is_condition_failure(exc):
+                raise
+            current = self.get_contest(chat_id, root_message_id, consistent=True)
+            return bool(
+                current
+                and current.get("status") == "OPEN"
+                and int(current.get("rules_message_id") or 0) == int(rules_message_id)
+            )
+
+    def fail_creation(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        """Close an unannounced contest so it can never accept participants."""
+        now = int(now or time.time())
+        expires_at = self._expiry(now)
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    "SET #status = :failed, failed_at = :now, updated_at = :now, "
+                    "expires_at = :expires, #ttl = :expires"
+                ),
+                ConditionExpression=("#status = :creating AND creation_attempt_id = :attempt"),
+                ExpressionAttributeNames={"#status": "status", "#ttl": "ttl"},
+                ExpressionAttributeValues={
+                    ":failed": "CREATION_FAILED",
+                    ":creating": "CREATING",
+                    ":attempt": str(attempt_id),
+                    ":now": now,
+                    ":expires": expires_at,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def begin_creation_attempt(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        attempt_id: str,
+        stale_before: int,
+        now: int | None = None,
+    ) -> bool:
+        """Claim or replace a stale rules-publication lease."""
+        now = int(now or time.time())
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=("SET creation_attempt_id = :attempt, creation_started_at = :now, updated_at = :now"),
+                ConditionExpression=(
+                    "#status = :creating AND "
+                    "(attribute_not_exists(creation_attempt_id) OR creation_started_at < :stale_before)"
+                ),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":creating": "CREATING",
+                    ":attempt": str(attempt_id),
+                    ":stale_before": int(stale_before),
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def release_creation_attempt(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        """Release only the caller's rules-publication lease after retryable failure."""
+        now = int(now or time.time())
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=("SET updated_at = :now REMOVE creation_attempt_id, creation_started_at"),
+                ConditionExpression=("#status = :creating AND creation_attempt_id = :attempt"),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":creating": "CREATING",
+                    ":attempt": str(attempt_id),
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def get_contest(
+        self,
+        chat_id: int | str,
+        root_message_id: int | str,
+        *,
+        consistent: bool = False,
+    ) -> dict[str, Any] | None:
+        response = self.table.get_item(
+            Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+            ConsistentRead=bool(consistent),
+        )
+        item = response.get("Item")
+        return item if isinstance(item, dict) else None
+
+    def get_participant(
+        self,
+        chat_id: int | str,
+        root_message_id: int | str,
+        user_id: int | str,
+        *,
+        consistent: bool = False,
+    ) -> dict[str, Any] | None:
+        response = self.table.get_item(
+            Key={"pk": self._chat_pk(chat_id), "sk": self._participant_sk(root_message_id, user_id)},
+            ConsistentRead=bool(consistent),
+        )
+        item = response.get("Item")
+        return item if isinstance(item, dict) else None
+
+    def resolve_contest_by_anchor(
+        self,
+        chat_id: int | str,
+        anchor_message_id: int | str,
+    ) -> dict[str, Any] | None:
+        """Resolve either the mirrored root id or the stored rules-message id."""
+        direct = self.get_contest(chat_id, anchor_message_id, consistent=True)
+        if direct:
+            return direct
+        response = self.table.get_item(
+            Key={"pk": self._chat_pk(chat_id), "sk": self._rule_anchor_sk(anchor_message_id)},
+            ConsistentRead=True,
+        )
+        alias = response.get("Item") or {}
+        root_message_id = alias.get("root_message_id")
+        if root_message_id is None:
+            return None
+        return self.get_contest(chat_id, root_message_id, consistent=True)
+
+    def register_participant(
+        self,
+        *,
+        chat_id: int | str,
+        root_message_id: int,
+        user_id: int,
+        entry_message_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+        text: str,
+        accepted_at: int | None = None,
+    ) -> RegistrationResult:
+        """Atomically require ``OPEN`` and insert the user's first entry."""
+        now = int(accepted_at or time.time())
+        pk = self._chat_pk(chat_id)
+        participant_key = {"pk": pk, "sk": self._participant_sk(root_message_id, user_id)}
+        item: dict[str, Any] = {
+            **participant_key,
+            "kind": "contest_participant",
+            "chat_id": str(chat_id),
+            "root_message_id": int(root_message_id),
+            "user_id": str(user_id),
+            "entry_message_id": int(entry_message_id),
+            "text": str(text)[:4096],
+            "accepted_at": now,
+        }
+        if username:
+            item["username"] = str(username)[:100]
+        if first_name:
+            item["first_name"] = str(first_name)[:200]
+        if last_name:
+            item["last_name"] = str(last_name)[:200]
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._serialize_map({"pk": pk, "sk": self._meta_sk(root_message_id)}),
+                            "UpdateExpression": (
+                                "SET participant_count = if_not_exists(participant_count, :zero) + :one"
+                            ),
+                            "ConditionExpression": "#status = :open",
+                            "ExpressionAttributeNames": {"#status": "status"},
+                            "ExpressionAttributeValues": self._serialize_map({":open": "OPEN", ":zero": 0, ":one": 1}),
+                        }
+                    },
+                    {
+                        "Put": {
+                            "TableName": self.table_name,
+                            "Item": self._serialize_map(item),
+                            "ConditionExpression": "attribute_not_exists(pk)",
+                        }
+                    },
+                ]
+            )
+            return RegistrationResult.REGISTERED
+        except ClientError as exc:
+            if not self._is_condition_failure(exc):
+                raise
+            participant = self.get_participant(chat_id, root_message_id, user_id, consistent=True)
+            if participant:
+                if int(participant.get("entry_message_id") or 0) == int(entry_message_id):
+                    return RegistrationResult.REPLAY
+                return RegistrationResult.DUPLICATE
+            contest = self.get_contest(chat_id, root_message_id, consistent=True)
+            if not contest:
+                return RegistrationResult.MISSING
+            if contest.get("status") != "OPEN":
+                return RegistrationResult.CLOSED
+            raise RuntimeError("Contest registration transaction conflicted while contest remained OPEN")
+
+    def participant_page(
+        self,
+        chat_id: int | str,
+        root_message_id: int | str,
+        *,
+        limit: int | None = None,
+        start_key: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        kwargs: dict[str, Any] = {
+            "KeyConditionExpression": Key("pk").eq(self._chat_pk(chat_id))
+            & Key("sk").begins_with(self._participant_prefix(root_message_id)),
+            "ConsistentRead": True,
+        }
+        if limit is not None:
+            kwargs["Limit"] = max(1, int(limit))
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        response = self.table.query(**kwargs)
+        return list(response.get("Items") or []), response.get("LastEvaluatedKey")
+
+    def iter_participants(
+        self,
+        chat_id: int | str,
+        root_message_id: int | str,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield every immutable participant from strongly consistent pages."""
+        start_key: dict[str, Any] | None = None
+        while True:
+            page, start_key = self.participant_page(chat_id, root_message_id, start_key=start_key)
+            yield from page
+            if not start_key:
+                return
+
+    def begin_first_draw(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    "SET #status = :drawing, pending_draw_number = :one, draw_attempt_id = :attempt, "
+                    "draw_started_at = :now, updated_at = :now"
+                ),
+                ConditionExpression="#status = :open AND draw_count = :zero",
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":drawing": "DRAWING",
+                    ":open": "OPEN",
+                    ":zero": 0,
+                    ":one": 1,
+                    ":attempt": str(attempt_id),
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def begin_redraw(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        expected_draw_count: int,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        next_draw = int(expected_draw_count) + 1
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    "SET #status = :drawing, pending_draw_number = :next, draw_attempt_id = :attempt, "
+                    "draw_started_at = :now, updated_at = :now"
+                ),
+                ConditionExpression=(
+                    "#status = :drawn AND draw_count = :expected AND draw_count < :max_draws "
+                    "AND announcement_state = :sent AND expires_at > :now"
+                ),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":drawing": "DRAWING",
+                    ":drawn": "DRAWN",
+                    ":expected": int(expected_draw_count),
+                    ":next": next_draw,
+                    ":attempt": str(attempt_id),
+                    ":max_draws": 3,
+                    ":sent": "SENT",
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def abort_draw(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        draw_number: int,
+        attempt_id: str,
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        restore_status = "OPEN" if int(draw_number) == 1 else "DRAWN"
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    "SET #status = :restore, updated_at = :now "
+                    "REMOVE pending_draw_number, draw_attempt_id, draw_started_at"
+                ),
+                ConditionExpression=(
+                    "#status = :drawing AND pending_draw_number = :draw AND draw_attempt_id = :attempt"
+                ),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":restore": restore_status,
+                    ":drawing": "DRAWING",
+                    ":draw": int(draw_number),
+                    ":attempt": str(attempt_id),
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    @staticmethod
+    def _winner_snapshot(participant: dict[str, Any], *, draw_number: int, selected_at: int) -> dict[str, Any]:
+        snapshot: dict[str, Any] = {
+            "draw_number": int(draw_number),
+            "selected_at": int(selected_at),
+            "user_id": str(participant["user_id"]),
+            "entry_message_id": int(participant["entry_message_id"]),
+            "text": str(participant.get("text") or "")[:4096],
+        }
+        for key, limit in (("username", 100), ("first_name", 200), ("last_name", 200)):
+            if participant.get(key):
+                snapshot[key] = str(participant[key])[:limit]
+        return snapshot
+
+    def complete_draw(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        draw_number: int,
+        attempt_id: str,
+        participant: dict[str, Any],
+        frozen_participant_count: int,
+        now: int | None = None,
+    ) -> bool:
+        """Persist one immutable winner before Telegram announcement delivery."""
+        now = int(now or time.time())
+        draw_number = int(draw_number)
+        winner = self._winner_snapshot(participant, draw_number=draw_number, selected_at=now)
+        values: dict[str, Any] = {
+            ":drawn": "DRAWN",
+            ":drawing": "DRAWING",
+            ":draw": draw_number,
+            ":winner": [winner],
+            ":winner_id": [str(participant["user_id"])],
+            ":attempt": str(attempt_id),
+            ":pending": "PENDING",
+            ":now": now,
+        }
+        if draw_number == 1:
+            expires_at = self._expiry(now)
+            values.update({":zero": 0, ":count": int(frozen_participant_count), ":expires": expires_at})
+            update_expression = (
+                "SET #status = :drawn, draw_count = :draw, winners = :winner, winner_user_ids = :winner_id, "
+                "frozen_participant_count = :count, first_draw_at = :now, expires_at = :expires, "
+                "ttl_sweep_status = :pending, ttl_sweep_version = :zero, "
+                "announcement_state = :pending, updated_at = :now "
+                "REMOVE pending_draw_number, draw_attempt_id, draw_started_at"
+            )
+            condition = (
+                "#status = :drawing AND pending_draw_number = :draw AND draw_attempt_id = :attempt "
+                "AND draw_count = :zero AND participant_count = :count "
+                "AND attribute_not_exists(expires_at)"
+            )
+        else:
+            values.update(
+                {
+                    ":previous": draw_number - 1,
+                    ":single_winner_id": str(participant["user_id"]),
+                }
+            )
+            update_expression = (
+                "SET #status = :drawn, draw_count = :draw, winners = list_append(winners, :winner), "
+                "winner_user_ids = list_append(winner_user_ids, :winner_id), announcement_state = :pending, "
+                "updated_at = :now REMOVE pending_draw_number, draw_attempt_id, draw_started_at"
+            )
+            condition = (
+                "#status = :drawing AND pending_draw_number = :draw AND draw_attempt_id = :attempt "
+                "AND draw_count = :previous "
+                "AND expires_at > :now AND NOT contains(winner_user_ids, :single_winner_id)"
+            )
+        try:
+            if draw_number == 1:
+                outbox = self._ttl_outbox_item(
+                    chat_id,
+                    root_message_id,
+                    expires_at=expires_at,
+                    created_at=now,
+                )
+                self.client.transact_write_items(
+                    TransactItems=[
+                        {
+                            "Update": {
+                                "TableName": self.table_name,
+                                "Key": self._serialize_map(
+                                    {"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)}
+                                ),
+                                "UpdateExpression": update_expression,
+                                "ConditionExpression": condition,
+                                "ExpressionAttributeNames": {"#status": "status"},
+                                "ExpressionAttributeValues": self._serialize_map(values),
+                            }
+                        },
+                        {
+                            "Put": {
+                                "TableName": self.table_name,
+                                "Item": self._serialize_map(outbox),
+                                "ConditionExpression": "attribute_not_exists(pk)",
+                            }
+                        },
+                    ]
+                )
+            else:
+                self.table.update_item(
+                    Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                    UpdateExpression=update_expression,
+                    ConditionExpression=condition,
+                    ExpressionAttributeNames={"#status": "status"},
+                    ExpressionAttributeValues=values,
+                )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def mark_announcement_sent(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        draw_number: int,
+        announcement_message_id: int,
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        index = int(draw_number) - 1
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    f"SET announcement_state = :sent, winners[{index}].announcement_message_id = :message, "
+                    "updated_at = :now"
+                ),
+                ConditionExpression=("#status = :drawn AND draw_count = :draw AND announcement_state = :pending"),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":drawn": "DRAWN",
+                    ":draw": int(draw_number),
+                    ":pending": "PENDING",
+                    ":sent": "SENT",
+                    ":message": int(announcement_message_id),
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def mark_orphaned(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        draw_number: int,
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=("SET #status = :orphaned, orphaned_at = :now, updated_at = :now"),
+                ConditionExpression=("#status = :drawn AND draw_count = :draw AND announcement_state = :pending"),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":drawn": "DRAWN",
+                    ":orphaned": "ORPHANED",
+                    ":draw": int(draw_number),
+                    ":pending": "PENDING",
+                    ":now": now,
+                },
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def cancel_contest(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        now: int | None = None,
+    ) -> dict[str, Any] | None:
+        now = int(now or time.time())
+        expires_at = self._expiry(now)
+        values = {
+            ":cancelled": "CANCELLED",
+            ":open": "OPEN",
+            ":pending": "PENDING",
+            ":zero": 0,
+            ":now": now,
+            ":expires": expires_at,
+        }
+        update_expression = (
+            "SET #status = :cancelled, cancelled_at = :now, expires_at = :expires, "
+            "ttl_sweep_status = :pending, ttl_sweep_version = :zero, updated_at = :now"
+        )
+        condition = "#status = :open AND attribute_not_exists(expires_at)"
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._serialize_map(
+                                {"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)}
+                            ),
+                            "UpdateExpression": update_expression,
+                            "ConditionExpression": condition,
+                            "ExpressionAttributeNames": {"#status": "status"},
+                            "ExpressionAttributeValues": self._serialize_map(values),
+                        }
+                    },
+                    {
+                        "Put": {
+                            "TableName": self.table_name,
+                            "Item": self._serialize_map(
+                                self._ttl_outbox_item(
+                                    chat_id,
+                                    root_message_id,
+                                    expires_at=expires_at,
+                                    created_at=now,
+                                )
+                            ),
+                            "ConditionExpression": "attribute_not_exists(pk)",
+                        }
+                    },
+                ]
+            )
+            return self.get_contest(chat_id, root_message_id, consistent=True)
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return None
+            raise
+
+    def ttl_outbox_page(
+        self,
+        *,
+        limit: int = 100,
+        start_key: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        """Return one strongly consistent page of durably pending sweep markers."""
+        kwargs: dict[str, Any] = {
+            "KeyConditionExpression": Key("pk").eq(_TTL_OUTBOX_PK),
+            "ConsistentRead": True,
+            "Limit": max(1, int(limit)),
+        }
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        response = self.table.query(**kwargs)
+        return list(response.get("Items") or []), response.get("LastEvaluatedKey")
+
+    def record_ttl_sweep_progress(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        expected_start_key: dict[str, Any] | None,
+        expected_version: int,
+        next_start_key: dict[str, Any],
+        now: int | None = None,
+    ) -> bool:
+        now = int(now or time.time())
+        cursor_condition = (
+            "ttl_sweep_cursor = :expected_cursor"
+            if expected_start_key is not None
+            else "attribute_not_exists(ttl_sweep_cursor)"
+        )
+        values: dict[str, Any] = {
+            ":pending": "PENDING",
+            ":cursor": next_start_key,
+            ":version": int(expected_version),
+            ":next_version": int(expected_version) + 1,
+            ":now": now,
+        }
+        if expected_start_key is not None:
+            values[":expected_cursor"] = expected_start_key
+        try:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)},
+                UpdateExpression=(
+                    "SET ttl_sweep_status = :pending, ttl_sweep_cursor = :cursor, "
+                    "ttl_sweep_version = :next_version, ttl_sweep_updated_at = :now"
+                ),
+                ConditionExpression=(
+                    "ttl_sweep_status = :pending AND ttl_sweep_version = :version AND " f"{cursor_condition}"
+                ),
+                ExpressionAttributeValues=values,
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    def stamp_participant_ttl(self, items: list[dict[str, Any]], expires_at: int) -> None:
+        """Idempotently stamp the immutable contest expiry on participant rows."""
+        for item in items:
+            self.table.update_item(
+                Key={"pk": item["pk"], "sk": item["sk"]},
+                UpdateExpression="SET expires_at = :expires, #ttl = :expires",
+                ExpressionAttributeNames={"#ttl": "ttl"},
+                ExpressionAttributeValues={":expires": int(expires_at)},
+            )
+
+    def complete_ttl_sweep(
+        self,
+        chat_id: int | str,
+        root_message_id: int,
+        *,
+        rules_message_id: int | None,
+        expires_at: int,
+        expected_start_key: dict[str, Any] | None,
+        expected_version: int,
+        now: int | None = None,
+    ) -> bool:
+        """Stamp alias then make META physically expirable after every participant page."""
+        now = int(now or time.time())
+        if rules_message_id is not None:
+            self.table.update_item(
+                Key={"pk": self._chat_pk(chat_id), "sk": self._rule_anchor_sk(rules_message_id)},
+                UpdateExpression="SET expires_at = :expires, #ttl = :expires",
+                ExpressionAttributeNames={"#ttl": "ttl"},
+                ExpressionAttributeValues={":expires": int(expires_at)},
+            )
+        cursor_condition = (
+            "ttl_sweep_cursor = :expected_cursor"
+            if expected_start_key is not None
+            else "attribute_not_exists(ttl_sweep_cursor)"
+        )
+        values: dict[str, Any] = {
+            ":complete": "COMPLETE",
+            ":pending": "PENDING",
+            ":version": int(expected_version),
+            ":now": now,
+            ":expires": int(expires_at),
+        }
+        if expected_start_key is not None:
+            values[":expected_cursor"] = expected_start_key
+        try:
+            self.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": self.table_name,
+                            "Key": self._serialize_map(
+                                {"pk": self._chat_pk(chat_id), "sk": self._meta_sk(root_message_id)}
+                            ),
+                            "UpdateExpression": (
+                                "SET ttl_sweep_status = :complete, ttl_sweep_updated_at = :now, #ttl = :expires "
+                                "REMOVE ttl_sweep_cursor"
+                            ),
+                            "ConditionExpression": (
+                                "expires_at = :expires AND ttl_sweep_status = :pending "
+                                "AND ttl_sweep_version = :version AND "
+                                f"{cursor_condition}"
+                            ),
+                            "ExpressionAttributeNames": {"#ttl": "ttl"},
+                            "ExpressionAttributeValues": self._serialize_map(values),
+                        }
+                    },
+                    {
+                        "Delete": {
+                            "TableName": self.table_name,
+                            "Key": self._serialize_map(self._ttl_outbox_key(chat_id, root_message_id)),
+                        }
+                    },
+                ]
+            )
+            return True
+        except ClientError as exc:
+            if self._is_condition_failure(exc):
+                return False
+            raise
+
+    @staticmethod
+    def is_logically_expired(contest: dict[str, Any], *, now: int | None = None) -> bool:
+        expires_at = contest.get("expires_at")
+        if expires_at is None:
+            return False
+        return int(expires_at) <= int(now or time.time())

--- a/src/bot/services/repositories/sqs.py
+++ b/src/bot/services/repositories/sqs.py
@@ -433,3 +433,59 @@ class SQSClient:
                 "Failed to send vector memory backfill task to SQS", extra={"error": e, "chat_id": chat_id}
             )
             raise
+
+    def send_contest_ttl_sweep_task(
+        self,
+        *,
+        chat_id: int,
+        root_message_id: int,
+    ) -> None:
+        """Enqueue one retention page; DynamoDB owns the durable cursor."""
+        payload: dict[str, object] = {
+            "task_type": "PROCESS_CONTEST_TTL_SWEEP",
+            "chat_id": chat_id,
+            "root_message_id": root_message_id,
+        }
+        try:
+            self.sqs_client.send_message(
+                QueueUrl=self.queue_url,
+                MessageBody=json.dumps(payload),
+            )
+            logger.info(
+                "Queued contest TTL sweep page",
+                extra={
+                    "chat_id": chat_id,
+                    "root_message_id": root_message_id,
+                },
+            )
+        except Exception as e:
+            logger.exception(
+                "Failed to enqueue contest TTL sweep",
+                extra={"error": e, "chat_id": chat_id, "root_message_id": root_message_id},
+            )
+            raise
+
+    def send_contest_ttl_recovery_task(
+        self,
+        *,
+        start_key: dict[str, object] | None = None,
+    ) -> None:
+        """Enqueue one bounded page of durable contest cleanup discovery."""
+        payload: dict[str, object] = {"task_type": "PROCESS_CONTEST_TTL_RECOVERY"}
+        if start_key:
+            payload["start_key"] = start_key
+        try:
+            self.sqs_client.send_message(
+                QueueUrl=self.queue_url,
+                MessageBody=json.dumps(payload),
+            )
+            logger.info(
+                "Queued contest TTL outbox recovery page",
+                extra={"has_start_key": bool(start_key)},
+            )
+        except Exception as e:
+            logger.exception(
+                "Failed to enqueue contest TTL outbox recovery",
+                extra={"error": e},
+            )
+            raise

--- a/src/bot/services/sqs_task_router.py
+++ b/src/bot/services/sqs_task_router.py
@@ -9,11 +9,17 @@ from typing import Any
 from core.config import is_configured_group_chat
 from core.logger import LoggerAdapter, get_logger
 from services.ambient_reactions import process_ambient_reaction_task
+from services.contest import (
+    process_contest_ttl_recovery_task,
+    process_contest_ttl_sweep_task,
+)
 from services.group_agent import process_proactive_candidate_task
 from services.group_memory_processor import process_daily_group_summaries_task, process_group_memory_task
 from services.handlers import process_group_ask_task, process_timeout_task
 from services.repositories.captcha import CaptchaRepository
+from services.repositories.contest import ContestRepository
 from services.repositories.group_memory import GroupMemoryRepository
+from services.repositories.sqs import SQSClient
 from services.spam.processor import process_spam_check_task
 from services.telegram import TelegramClient
 from services.vector_memory import process_vector_memory_backfill_task, process_vector_memory_task
@@ -64,6 +70,9 @@ def process_sqs_event(
     bot: TelegramClient,
     captcha_repo: CaptchaRepository,
     memory_repo: GroupMemoryRepository | None = None,
+    *,
+    contest_repo: ContestRepository | None = None,
+    sqs_repo: SQSClient | None = None,
 ) -> None:
     """Process main bot SQS tasks. Vector tasks are handled by the vector-indexer Lambda."""
     logger.debug(
@@ -74,10 +83,13 @@ def process_sqs_event(
     for record in event["Records"]:
         try:
             body = _load_task_body(record)
-            if _should_skip_unconfigured_chat(body):
+            task_type = body.get("task_type")
+            if task_type not in {
+                "PROCESS_CONTEST_TTL_SWEEP",
+                "PROCESS_CONTEST_TTL_RECOVERY",
+            } and _should_skip_unconfigured_chat(body):
                 continue
 
-            task_type = body.get("task_type")
             t0 = time.monotonic()
             if task_type == "CHECK_TIMEOUT":
                 body["_captcha_repo"] = captcha_repo
@@ -100,6 +112,22 @@ def process_sqs_event(
                 process_group_memory_task(body, repo=memory_repo)
             elif task_type == "PROCESS_DAILY_GROUP_SUMMARIES":
                 process_daily_group_summaries_task(body, repo=memory_repo)
+            elif task_type == "PROCESS_CONTEST_TTL_RECOVERY":
+                if contest_repo is None:
+                    raise RuntimeError("PROCESS_CONTEST_TTL_RECOVERY requires contest_repo")
+                process_contest_ttl_recovery_task(
+                    body,
+                    repo=contest_repo,
+                    sqs_repo=sqs_repo or SQSClient(),
+                )
+            elif task_type == "PROCESS_CONTEST_TTL_SWEEP":
+                if contest_repo is None:
+                    raise RuntimeError("PROCESS_CONTEST_TTL_SWEEP requires contest_repo")
+                process_contest_ttl_sweep_task(
+                    body,
+                    repo=contest_repo,
+                    sqs_repo=sqs_repo or SQSClient(),
+                )
             else:
                 logger.warning(
                     "Unexpected SQS record: unsupported task_type, ignoring",

--- a/src/bot/services/telegram.py
+++ b/src/bot/services/telegram.py
@@ -35,6 +35,7 @@ class TelegramClient:
         self.api_base = f"{TELEGRAM_API_BASE}{self.bot_token}"
         file_base = TELEGRAM_API_BASE.replace("/bot", "/file/bot", 1)
         self.file_api_base = f"{file_base}{self.bot_token}"
+        self._me: dict[str, Any] | None = None
         logger.info("TelegramClient initialized", extra={"api_base": TELEGRAM_API_BASE})
 
     def _post(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -254,6 +255,16 @@ class TelegramClient:
         payload: dict[str, Any] = {"chat_id": chat_id}
         result = self._post("getChat", payload)
         return result.get("result", {})
+
+    def get_me(self) -> dict[str, Any]:
+        """Return and cache this Bot's Telegram identity for permission checks."""
+        if self._me is None:
+            result = self._post("getMe", {})
+            me = result.get("result", {})
+            if not isinstance(me, dict) or not me.get("id"):
+                raise TelegramAPIError(502, "Telegram getMe returned an invalid result")
+            self._me = me
+        return dict(self._me)
 
     def get_chat_member(self, chat_id: int | str, user_id: int) -> dict[str, Any]:
         """Get chat member info (use ``result['status']`` for admin check)."""

--- a/src/bot/webhook.py
+++ b/src/bot/webhook.py
@@ -14,6 +14,7 @@ from core.dispatcher import Dispatcher
 from core.logger import LoggerAdapter, get_logger
 from core.translations import get_translated_text
 from services.ambient_reactions import maybe_enqueue_ambient_reaction
+from services.contest import ContestRetryRequiredError, observe_contest_update
 from services.group_agent import handle_update as handle_group_agent_update
 from services.group_memory import observe_update as observe_group_memory_update
 from services.handlers import process_timeout_task
@@ -108,6 +109,14 @@ def _handle_api_gateway(
                 return create_response(200, {"message": "ok"})
 
         if not has_pending_captcha:
+            try:
+                observe_contest_update(dispatcher.contest_repo, bot, body, sqs_repo=_sqs_client)
+            except Exception:
+                logger.exception(
+                    "Contest persistence failed; asking Telegram to retry the update",
+                    extra={"chat_id": chat_id},
+                )
+                return create_response(500, {"message": "Contest update retry required"})
             observe_group_memory_update(dispatcher.memory_repo, body, sqs_repo=_sqs_client)
             maybe_enqueue_ambient_reaction(repo=dispatcher.memory_repo, update=body, sqs_repo=_sqs_client)
 
@@ -128,6 +137,12 @@ def _handle_api_gateway(
         else:
             dispatcher.process_update(body)
 
+    except ContestRetryRequiredError as e:
+        logger.exception(
+            "Contest command requires Telegram redelivery",
+            extra={"error": e, "chat_id": chat_id if "chat_id" in locals() else None},
+        )
+        return create_response(500, {"message": "Contest command retry required"})
     except Exception as e:
         logger.exception("Unexpected error in webhook handler", extra={"error": e})
 

--- a/tests/test_contest_acceptance.py
+++ b/tests/test_contest_acceptance.py
@@ -1,0 +1,295 @@
+"""Target-perspective contest transcript using Telegram-shaped updates."""
+
+from __future__ import annotations
+
+import time
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from core.dispatcher import Dispatcher
+from services.contest import REDRAW_LIMIT_KK, ContestService
+from services.handlers import register_handlers
+from services.repositories.contest import RegistrationResult
+
+CHAT_ID = -100123
+CHANNEL_ID = -100456
+ROOT_ID = 11
+OWNER_ID = 42
+BOT_ID = 9000
+
+
+class AcceptanceContestRepository:
+    """Small stateful double; DynamoDB conditions are covered by repository tests."""
+
+    def __init__(self) -> None:
+        self.contest: dict | None = None
+        self.participants: dict[str, dict] = {}
+        self.rules_alias: dict[int, int] = {}
+
+    def get_contest(self, chat_id, root_message_id, *, consistent=False):
+        if self.contest and int(root_message_id) == int(self.contest["root_message_id"]):
+            return deepcopy(self.contest)
+        return None
+
+    def create_contest(self, **kwargs) -> bool:
+        if self.contest:
+            return False
+        self.contest = {
+            **kwargs,
+            "chat_id": str(kwargs["chat_id"]),
+            "source_channel_id": str(kwargs["source_channel_id"]),
+            "status": "CREATING",
+            "participant_count": 0,
+            "draw_count": 0,
+            "winner_user_ids": [],
+            "winners": [],
+        }
+        return True
+
+    def begin_creation_attempt(
+        self,
+        chat_id,
+        root_message_id,
+        *,
+        attempt_id,
+        stale_before,
+        now,
+    ) -> bool:
+        assert self.contest and self.contest["status"] == "CREATING"
+        if self.contest.get("creation_attempt_id"):
+            return False
+        self.contest["creation_attempt_id"] = attempt_id
+        return True
+
+    def release_creation_attempt(self, chat_id, root_message_id, *, attempt_id) -> bool:
+        assert self.contest
+        if self.contest.get("creation_attempt_id") != attempt_id:
+            return False
+        self.contest.pop("creation_attempt_id", None)
+        return True
+
+    def activate_contest(self, chat_id, root_message_id, rules_message_id, *, attempt_id) -> bool:
+        assert self.contest and self.contest["status"] == "CREATING"
+        assert self.contest["creation_attempt_id"] == attempt_id
+        self.contest["status"] = "OPEN"
+        self.contest["rules_message_id"] = rules_message_id
+        self.contest.pop("creation_attempt_id", None)
+        self.rules_alias[int(rules_message_id)] = int(root_message_id)
+        return True
+
+    def fail_creation(self, chat_id, root_message_id, *, attempt_id) -> bool:
+        assert self.contest
+        assert self.contest["creation_attempt_id"] == attempt_id
+        self.contest["status"] = "CREATION_FAILED"
+        return True
+
+    def resolve_contest_by_anchor(self, chat_id, anchor_message_id):
+        if not self.contest:
+            return None
+        anchor = int(anchor_message_id)
+        if anchor == int(self.contest["root_message_id"]) or self.rules_alias.get(anchor) == ROOT_ID:
+            return deepcopy(self.contest)
+        return None
+
+    def register_participant(self, **kwargs) -> RegistrationResult:
+        assert self.contest
+        if self.contest["status"] != "OPEN":
+            return RegistrationResult.CLOSED
+        user_id = str(kwargs["user_id"])
+        if user_id in self.participants:
+            return RegistrationResult.DUPLICATE
+        self.participants[user_id] = {
+            **kwargs,
+            "chat_id": str(kwargs["chat_id"]),
+            "user_id": user_id,
+        }
+        self.contest["participant_count"] += 1
+        return RegistrationResult.REGISTERED
+
+    def iter_participants(self, chat_id, root_message_id):
+        yield from (deepcopy(value) for value in self.participants.values())
+
+    def begin_first_draw(self, chat_id, root_message_id, *, attempt_id) -> bool:
+        assert self.contest
+        if self.contest["status"] != "OPEN":
+            return False
+        self.contest["status"] = "DRAWING"
+        self.contest["pending_draw_number"] = 1
+        self.contest["draw_attempt_id"] = attempt_id
+        return True
+
+    def begin_redraw(self, chat_id, root_message_id, *, expected_draw_count, attempt_id) -> bool:
+        assert self.contest
+        if self.contest["status"] != "DRAWN" or self.contest["draw_count"] != expected_draw_count:
+            return False
+        self.contest["status"] = "DRAWING"
+        self.contest["pending_draw_number"] = expected_draw_count + 1
+        self.contest["draw_attempt_id"] = attempt_id
+        return True
+
+    def abort_draw(self, chat_id, root_message_id, *, draw_number, attempt_id) -> bool:
+        assert self.contest
+        if self.contest.get("draw_attempt_id") != attempt_id:
+            return False
+        self.contest["status"] = "OPEN" if draw_number == 1 else "DRAWN"
+        self.contest.pop("pending_draw_number", None)
+        self.contest.pop("draw_attempt_id", None)
+        return True
+
+    def complete_draw(
+        self,
+        chat_id,
+        root_message_id,
+        *,
+        draw_number,
+        attempt_id,
+        participant,
+        frozen_participant_count,
+    ) -> bool:
+        assert self.contest and self.contest["status"] == "DRAWING"
+        if self.contest.get("draw_attempt_id") != attempt_id:
+            return False
+        if participant["user_id"] in self.contest["winner_user_ids"]:
+            return False
+        winner = {
+            key: participant[key]
+            for key in ("user_id", "entry_message_id", "username", "first_name", "last_name", "text")
+            if participant.get(key) is not None
+        }
+        winner.update({"draw_number": draw_number, "selected_at": int(time.time())})
+        self.contest["status"] = "DRAWN"
+        self.contest["draw_count"] = draw_number
+        self.contest["winner_user_ids"].append(participant["user_id"])
+        self.contest["winners"].append(winner)
+        self.contest["frozen_participant_count"] = frozen_participant_count
+        self.contest["announcement_state"] = "PENDING"
+        self.contest["ttl_sweep_status"] = "PENDING"
+        self.contest.setdefault("expires_at", int(time.time()) + 30 * 24 * 60 * 60)
+        self.contest.pop("pending_draw_number", None)
+        self.contest.pop("draw_attempt_id", None)
+        return True
+
+    def mark_announcement_sent(
+        self,
+        chat_id,
+        root_message_id,
+        *,
+        draw_number,
+        announcement_message_id,
+    ) -> bool:
+        assert self.contest
+        self.contest["announcement_state"] = "SENT"
+        self.contest["winners"][draw_number - 1]["announcement_message_id"] = announcement_message_id
+        return True
+
+    @staticmethod
+    def is_logically_expired(contest, *, now=None) -> bool:
+        return bool(contest.get("expires_at") and int(contest["expires_at"]) <= int(now or time.time()))
+
+
+def _root() -> dict:
+    return {
+        "message_id": ROOT_ID,
+        "caption": "Үш сыйлық бар! #конкурс",
+        "date": 100,
+        "chat": {"id": CHAT_ID, "type": "supergroup"},
+        "from": {"id": 777000, "is_bot": False, "first_name": "Telegram"},
+        "sender_chat": {"id": CHANNEL_ID, "type": "channel", "title": "Official"},
+        "is_automatic_forward": True,
+        "forward_origin": {"type": "channel", "message_id": 7},
+        "photo": [{"file_id": "photo-id"}],
+    }
+
+
+def _entry(user_id: int, message_id: int, *, reply_id: int = ROOT_ID) -> dict:
+    return {
+        "message_id": message_id,
+        "message_thread_id": ROOT_ID,
+        "reply_to_message": {"message_id": reply_id},
+        "text": "Мен қатысамын!",
+        "date": 200 + message_id,
+        "chat": {"id": CHAT_ID, "type": "supergroup"},
+        "from": {
+            "id": user_id,
+            "is_bot": False,
+            "username": f"user{user_id}",
+            "first_name": f"User {user_id}",
+        },
+    }
+
+
+def _command(action: str, message_id: int, anchor: int) -> dict:
+    return {
+        "message": {
+            "message_id": message_id,
+            "text": f"/contest {action}",
+            "chat": {"id": CHAT_ID, "type": "supergroup"},
+            "from": {"id": OWNER_ID, "is_bot": False, "first_name": "Owner"},
+            "reply_to_message": {"message_id": anchor},
+        }
+    }
+
+
+def test_full_public_flow_has_equal_unique_chances_and_three_distinct_results(mock_stats_repo, mock_vote_repo) -> None:
+    repo = AcceptanceContestRepository()
+    bot = MagicMock()
+    sqs = MagicMock()
+    next_bot_message_id = iter(range(1000, 1100))
+    bot.send_message.side_effect = lambda *args, **kwargs: {"message_id": next(next_bot_message_id)}
+    bot.get_chat.return_value = {"linked_chat_id": CHANNEL_ID}
+    bot.get_me.return_value = {"id": BOT_ID}
+    bot.get_chat_member.side_effect = lambda chat_id, user_id: {
+        "status": "administrator" if user_id == BOT_ID else "creator"
+    }
+    service = ContestService(repo, bot, sqs)
+
+    service.observe_update({"message": _root()})
+    assert repo.contest and repo.contest["status"] == "OPEN"
+    rules_message_id = int(repo.contest["rules_message_id"])
+    assert bot.send_message.call_args_list[0].kwargs["reply_to_message_id"] == ROOT_ID
+    assert "осы бастапқы жазбаға тікелей жауап" in bot.send_message.call_args_list[0].args[1]
+
+    service.observe_update({"message": _entry(OWNER_ID, 12)})
+    service.observe_update({"message": _entry(OWNER_ID, 15)})  # duplicate user
+    service.observe_update({"message": _entry(43, 13)})
+    service.observe_update({"message": _entry(44, 14)})
+    service.observe_update({"message": _entry(45, 16, reply_id=13)})  # nested reply
+
+    assert list(repo.participants) == [str(OWNER_ID), "43", "44"]
+    assert [item.args[2] for item in bot.set_message_reaction.call_args_list] == ["🎉", "🎉", "🎉"]
+    assert [item.args[1] for item in bot.set_message_reaction.call_args_list] == [12, 13, 14]
+
+    dispatcher = Dispatcher(
+        bot,
+        mock_stats_repo,
+        sqs,
+        mock_vote_repo,
+        contest_repo=repo,
+    )
+    register_handlers(dispatcher)
+
+    with patch(
+        "services.contest.secrets.randbelow",
+        side_effect=lambda upper: 0 if upper == 1 else upper - 1,
+    ):
+        dispatcher.process_update(_command("draw", 30, rules_message_id))
+        dispatcher.process_update(_command("redraw", 31, ROOT_ID))
+        dispatcher.process_update(_command("redraw", 32, rules_message_id))
+        dispatcher.process_update(_command("redraw", 33, ROOT_ID))
+
+    assert repo.contest["status"] == "DRAWN"
+    assert repo.contest["draw_count"] == 3
+    assert repo.contest["winner_user_ids"] == [str(OWNER_ID), "43", "44"]
+    assert repo.contest["frozen_participant_count"] == 3
+
+    winner_calls = [
+        item for item in bot.send_message.call_args_list if item.args and "Жеңімпаз анықталды" in item.args[1]
+    ]
+    assert [item.kwargs["reply_to_message_id"] for item in winner_calls] == [12, 13, 14]
+    assert all("Қатысушылар саны: <b>3</b>" in item.args[1] for item in winner_calls)
+    assert [f"Ұтыс: <b>{number}/3</b>" in item.args[1] for number, item in enumerate(winner_calls, 1)] == [
+        True,
+        True,
+        True,
+    ]
+    assert bot.send_message.call_args_list[-1].args[1] == REDRAW_LIMIT_KK

--- a/tests/test_contest_handler.py
+++ b/tests/test_contest_handler.py
@@ -1,0 +1,149 @@
+"""Dispatcher-level contest command and authorization tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from core.dispatcher import Dispatcher
+from services.contest import (
+    ADMIN_ONLY_KK,
+    OWNER_ONLY_KK,
+    PERSONAL_ACCOUNT_REQUIRED_KK,
+    REPLY_ANCHOR_REQUIRED_KK,
+    ContestRetryRequiredError,
+)
+from services.handlers import register_handlers
+
+CHAT_ID = -100123
+ROOT_ID = 11
+RULES_ID = 88
+
+
+def _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, contest_repo):
+    dispatcher = Dispatcher(
+        mock_bot,
+        mock_stats_repo,
+        mock_sqs_repo,
+        mock_vote_repo,
+        contest_repo=contest_repo,
+    )
+    register_handlers(dispatcher)
+    return dispatcher
+
+
+def _command(action: str, *, anchor: int = ROOT_ID, sender_chat: dict | None = None) -> dict:
+    message = {
+        "message_id": 30,
+        "text": f"/contest {action}",
+        "chat": {"id": CHAT_ID, "type": "supergroup"},
+        "from": {"id": 42, "is_bot": False, "first_name": "Owner"},
+        "reply_to_message": {"message_id": anchor},
+    }
+    if sender_chat:
+        message["sender_chat"] = sender_chat
+    return {"message": message}
+
+
+def test_creator_can_draw_via_rules_alias(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo) -> None:
+    repo = MagicMock()
+    repo.resolve_contest_by_anchor.return_value = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+    }
+    mock_bot.get_chat_member.return_value = {"status": "creator"}
+    dispatcher = _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, repo)
+
+    with patch("services.handlers.contest.ContestService.draw") as draw:
+        dispatcher.process_update(_command("draw", anchor=RULES_ID))
+
+    repo.resolve_contest_by_anchor.assert_called_once_with(CHAT_ID, RULES_ID)
+    draw.assert_called_once_with(
+        chat_id=CHAT_ID,
+        root_message_id=ROOT_ID,
+        command_message_id=30,
+    )
+
+
+def test_administrator_can_view_status_but_cannot_draw(
+    mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo
+) -> None:
+    repo = MagicMock()
+    repo.resolve_contest_by_anchor.return_value = {"root_message_id": ROOT_ID, "status": "OPEN"}
+    mock_bot.get_chat_member.return_value = {"status": "administrator"}
+    dispatcher = _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, repo)
+
+    with patch("services.handlers.contest.ContestService.status") as status:
+        dispatcher.process_update(_command("status"))
+    status.assert_called_once()
+
+    mock_bot.send_message.reset_mock()
+    with patch("services.handlers.contest.ContestService.draw") as draw:
+        dispatcher.process_update(_command("draw"))
+    draw.assert_not_called()
+    mock_bot.send_message.assert_called_once_with(
+        CHAT_ID,
+        OWNER_ONLY_KK,
+        reply_markup=None,
+        reply_to_message_id=30,
+        link_preview_disable=None,
+    )
+
+
+def test_member_cannot_view_status(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo) -> None:
+    repo = MagicMock()
+    repo.resolve_contest_by_anchor.return_value = {"root_message_id": ROOT_ID, "status": "OPEN"}
+    mock_bot.get_chat_member.return_value = {"status": "member"}
+    dispatcher = _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, repo)
+
+    dispatcher.process_update(_command("status"))
+
+    mock_bot.send_message.assert_called_once_with(
+        CHAT_ID,
+        ADMIN_ONLY_KK,
+        reply_markup=None,
+        reply_to_message_id=30,
+        link_preview_disable=None,
+    )
+
+
+def test_anonymous_sender_and_wrong_reply_anchor_are_rejected(
+    mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo
+) -> None:
+    repo = MagicMock()
+    dispatcher = _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, repo)
+
+    dispatcher.process_update(_command("draw", sender_chat={"id": CHAT_ID, "type": "supergroup"}))
+    mock_bot.send_message.assert_called_once_with(
+        CHAT_ID,
+        PERSONAL_ACCOUNT_REQUIRED_KK,
+        reply_markup=None,
+        reply_to_message_id=30,
+        link_preview_disable=None,
+    )
+    mock_bot.get_chat_member.assert_not_called()
+
+    mock_bot.send_message.reset_mock()
+    repo.resolve_contest_by_anchor.return_value = None
+    dispatcher.process_update(_command("draw", anchor=999))
+    mock_bot.send_message.assert_called_once_with(
+        CHAT_ID,
+        REPLY_ANCHOR_REQUIRED_KK,
+        reply_markup=None,
+        reply_to_message_id=30,
+        link_preview_disable=None,
+    )
+    mock_bot.get_chat_member.assert_not_called()
+
+
+def test_transient_anchor_lookup_failure_requests_webhook_redelivery(
+    mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo
+) -> None:
+    repo = MagicMock()
+    repo.resolve_contest_by_anchor.side_effect = RuntimeError("DynamoDB unavailable")
+    dispatcher = _dispatcher(mock_bot, mock_stats_repo, mock_sqs_repo, mock_vote_repo, repo)
+
+    with pytest.raises(ContestRetryRequiredError):
+        dispatcher.process_update(_command("draw"))
+
+    mock_bot.send_message.assert_not_called()
+    mock_bot.get_chat_member.assert_not_called()

--- a/tests/test_contest_repository.py
+++ b/tests/test_contest_repository.py
@@ -1,0 +1,467 @@
+"""Contract tests for the DynamoDB contest truth owner."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from botocore.exceptions import ClientError
+from services.repositories.contest import ContestRepository, RegistrationResult
+
+
+def _repo() -> ContestRepository:
+    repo = ContestRepository.__new__(ContestRepository)
+    repo.table = MagicMock()
+    repo.table.name = "memory-table"
+    repo.table_name = "memory-table"
+    repo.client = MagicMock()
+    repo._serializer = TypeSerializer()
+    return repo
+
+
+def _client_error(code: str, *, cancellation_reasons: list[dict] | None = None) -> ClientError:
+    response = {"Error": {"Code": code, "Message": code}}
+    if cancellation_reasons is not None:
+        response["CancellationReasons"] = cancellation_reasons
+    elif code == "TransactionCanceledException":
+        response["CancellationReasons"] = [{"Code": "ConditionalCheckFailed"}, {"Code": "None"}]
+    return ClientError(response, "operation")
+
+
+def _deserialize(item: dict) -> dict:
+    deserializer = TypeDeserializer()
+    return {key: deserializer.deserialize(value) for key, value in item.items()}
+
+
+def test_create_contest_is_fail_closed_and_idempotent() -> None:
+    repo = _repo()
+
+    assert repo.create_contest(
+        chat_id=-100123,
+        root_message_id=11,
+        source_channel_id=-100456,
+        source_channel_title="Official",
+        source_channel_username="official",
+        source_channel_post_id=7,
+        created_at=100,
+    )
+
+    kwargs = repo.table.put_item.call_args.kwargs
+    assert kwargs["ConditionExpression"] == "attribute_not_exists(pk)"
+    assert kwargs["Item"] == {
+        "pk": "CHAT#-100123",
+        "sk": "CONTEST#0000000000011#META",
+        "kind": "contest",
+        "chat_id": "-100123",
+        "root_message_id": 11,
+        "source_channel_id": "-100456",
+        "source_channel_title": "Official",
+        "source_channel_username": "official",
+        "source_channel_post_id": 7,
+        "status": "CREATING",
+        "participant_count": 0,
+        "draw_count": 0,
+        "winner_user_ids": [],
+        "winners": [],
+        "created_at": 100,
+        "updated_at": 100,
+    }
+
+    repo.table.put_item.side_effect = _client_error("ConditionalCheckFailedException")
+    assert not repo.create_contest(
+        chat_id=-100123,
+        root_message_id=11,
+        source_channel_id=-100456,
+        source_channel_title=None,
+        source_channel_username=None,
+        source_channel_post_id=None,
+        created_at=100,
+    )
+
+
+def test_activate_contest_atomically_attaches_rules_alias() -> None:
+    repo = _repo()
+
+    assert repo.activate_contest(-100123, 11, 99, attempt_id="create-a", now=200)
+
+    tx = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    update = tx[0]["Update"]
+    alias = _deserialize(tx[1]["Put"]["Item"])
+    assert update["TableName"] == "memory-table"
+    assert update["ConditionExpression"] == "#status = :creating AND creation_attempt_id = :attempt"
+    assert _deserialize(update["Key"]) == {
+        "pk": "CHAT#-100123",
+        "sk": "CONTEST#0000000000011#META",
+    }
+    assert alias["sk"] == "CONTEST_RULE#0000000000099"
+    assert alias["root_message_id"] == 11
+
+
+def test_resolve_contest_by_rules_anchor_uses_strong_alias_lookup() -> None:
+    repo = _repo()
+    meta = {
+        "pk": "CHAT#-100123",
+        "sk": "CONTEST#0000000000011#META",
+        "root_message_id": 11,
+        "status": "OPEN",
+    }
+    repo.table.get_item.side_effect = [
+        {},
+        {"Item": {"root_message_id": 11}},
+        {"Item": meta},
+    ]
+
+    assert repo.resolve_contest_by_anchor(-100123, 99) == meta
+    assert repo.table.get_item.call_args_list[1].kwargs == {
+        "Key": {"pk": "CHAT#-100123", "sk": "CONTEST_RULE#0000000000099"},
+        "ConsistentRead": True,
+    }
+    assert repo.table.get_item.call_args_list[2].kwargs["ConsistentRead"] is True
+
+
+def test_registration_transaction_checks_open_and_unique_user() -> None:
+    repo = _repo()
+
+    result = repo.register_participant(
+        chat_id=-100123,
+        root_message_id=11,
+        user_id=42,
+        entry_message_id=12,
+        username="ada",
+        first_name="Ada",
+        last_name="Lovelace",
+        text="Мен қатысамын!",
+        accepted_at=300,
+    )
+
+    assert result is RegistrationResult.REGISTERED
+    tx = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    counter = tx[0]["Update"]
+    participant = _deserialize(tx[1]["Put"]["Item"])
+    assert counter["ConditionExpression"] == "#status = :open"
+    assert "participant_count = if_not_exists(participant_count, :zero) + :one" in counter["UpdateExpression"]
+    assert _deserialize(counter["ExpressionAttributeValues"]) == {
+        ":open": "OPEN",
+        ":zero": 0,
+        ":one": 1,
+    }
+    assert participant["sk"] == "CONTEST#0000000000011#PARTICIPANT#00000000000000000042"
+    assert participant["entry_message_id"] == 12
+    assert participant["text"] == "Мен қатысамын!"
+
+
+def test_registration_preserves_full_telegram_text_limit_for_evidence() -> None:
+    repo = _repo()
+    text = "x" * (4096 - len("қатысамын")) + "қатысамын"
+
+    assert (
+        repo.register_participant(
+            chat_id=-100123,
+            root_message_id=11,
+            user_id=42,
+            entry_message_id=12,
+            username=None,
+            first_name="Ada",
+            last_name=None,
+            text=text,
+            accepted_at=300,
+        )
+        is RegistrationResult.REGISTERED
+    )
+
+    tx = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    participant = _deserialize(tx[1]["Put"]["Item"])
+    assert participant["text"] == text
+    assert participant["text"].endswith("қатысамын")
+
+
+def test_registration_condition_failure_distinguishes_duplicate_closed_and_missing() -> None:
+    repo = _repo()
+    repo.client.transact_write_items.side_effect = _client_error("TransactionCanceledException")
+    args = dict(
+        chat_id=-100123,
+        root_message_id=11,
+        user_id=42,
+        entry_message_id=12,
+        username=None,
+        first_name="Ada",
+        last_name=None,
+        text="қатысамын",
+        accepted_at=300,
+    )
+
+    repo.table.get_item.side_effect = [{"Item": {"kind": "contest_participant"}}]
+    assert repo.register_participant(**args) is RegistrationResult.DUPLICATE
+
+    repo.table.get_item.side_effect = [{}, {"Item": {"status": "DRAWN"}}]
+    assert repo.register_participant(**args) is RegistrationResult.CLOSED
+
+    repo.table.get_item.side_effect = [{}, {}]
+    assert repo.register_participant(**args) is RegistrationResult.MISSING
+
+
+def test_transaction_cancel_without_pure_condition_reason_is_retried_not_misclassified() -> None:
+    repo = _repo()
+    repo.client.transact_write_items.side_effect = _client_error(
+        "TransactionCanceledException",
+        cancellation_reasons=[{"Code": "TransactionConflict"}, {"Code": "None"}],
+    )
+
+    with pytest.raises(ClientError):
+        repo.register_participant(
+            chat_id=-100123,
+            root_message_id=11,
+            user_id=42,
+            entry_message_id=12,
+            username=None,
+            first_name="Ada",
+            last_name=None,
+            text="қатысамын",
+            accepted_at=300,
+        )
+    repo.table.get_item.assert_not_called()
+
+
+def test_creation_attempt_lease_guards_activate_and_failure_paths() -> None:
+    repo = _repo()
+
+    assert repo.begin_creation_attempt(
+        -100123,
+        11,
+        attempt_id="create-a",
+        stale_before=90,
+        now=100,
+    )
+    claim = repo.table.update_item.call_args.kwargs
+    assert "attribute_not_exists(creation_attempt_id)" in claim["ConditionExpression"]
+    assert claim["ExpressionAttributeValues"][":attempt"] == "create-a"
+
+    assert repo.fail_creation(-100123, 11, attempt_id="create-a", now=101)
+    failed = repo.table.update_item.call_args.kwargs
+    assert "creation_attempt_id = :attempt" in failed["ConditionExpression"]
+
+
+def test_iter_participants_reads_every_page_strongly_consistently() -> None:
+    repo = _repo()
+    repo.table.query.side_effect = [
+        {"Items": [{"user_id": "1"}], "LastEvaluatedKey": {"pk": "CHAT#-100123", "sk": "one"}},
+        {"Items": [{"user_id": "2"}]},
+    ]
+
+    assert [item["user_id"] for item in repo.iter_participants(-100123, 11)] == ["1", "2"]
+    assert repo.table.query.call_count == 2
+    assert repo.table.query.call_args_list[0].kwargs["ConsistentRead"] is True
+    assert repo.table.query.call_args_list[1].kwargs["ExclusiveStartKey"]["sk"] == "one"
+
+
+def test_first_draw_sets_one_immutable_expiry_and_pending_announcement() -> None:
+    repo = _repo()
+    participant = {"user_id": "42", "entry_message_id": 12, "text": "қатысамын", "first_name": "Ada"}
+
+    assert repo.begin_first_draw(-100123, 11, attempt_id="draw-a", now=400)
+    assert repo.complete_draw(
+        -100123,
+        11,
+        draw_number=1,
+        attempt_id="draw-a",
+        participant=participant,
+        frozen_participant_count=5,
+        now=500,
+    )
+
+    begin = repo.table.update_item.call_args_list[0].kwargs
+    transaction = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    complete = transaction[0]["Update"]
+    outbox = _deserialize(transaction[1]["Put"]["Item"])
+    complete_values = _deserialize(complete["ExpressionAttributeValues"])
+    assert begin["ConditionExpression"] == "#status = :open AND draw_count = :zero"
+    assert begin["ExpressionAttributeValues"][":attempt"] == "draw-a"
+    assert "draw_attempt_id = :attempt" in complete["ConditionExpression"]
+    assert "participant_count = :count" in complete["ConditionExpression"]
+    assert "attribute_not_exists(expires_at)" in complete["ConditionExpression"]
+    assert complete_values[":expires"] == 500 + 30 * 24 * 60 * 60
+    assert complete_values[":pending"] == "PENDING"
+    assert complete_values[":count"] == 5
+    assert ":previous" not in complete_values
+    assert ":single_winner_id" not in complete_values
+    assert outbox == {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+        "kind": "contest_ttl_outbox",
+        "chat_id": "-100123",
+        "root_message_id": 11,
+        "expires_at": 500 + 30 * 24 * 60 * 60,
+        "created_at": 500,
+    }
+    assert "ttl" not in outbox
+
+
+def test_redraw_never_extends_expiry_and_rejects_repeated_winner_at_write_boundary() -> None:
+    repo = _repo()
+    participant = {"user_id": "43", "entry_message_id": 13, "text": "қатысамын"}
+
+    assert repo.begin_redraw(-100123, 11, expected_draw_count=1, attempt_id="draw-b", now=600)
+    assert repo.complete_draw(
+        -100123,
+        11,
+        draw_number=2,
+        attempt_id="draw-b",
+        participant=participant,
+        frozen_participant_count=5,
+        now=700,
+    )
+
+    begin = repo.table.update_item.call_args_list[0].kwargs
+    complete = repo.table.update_item.call_args_list[1].kwargs
+    assert "expires_at > :now" in begin["ConditionExpression"]
+    assert begin["ExpressionAttributeValues"][":attempt"] == "draw-b"
+    assert "draw_attempt_id = :attempt" in complete["ConditionExpression"]
+    assert "expires_at" not in complete["UpdateExpression"]
+    assert "NOT contains(winner_user_ids, :single_winner_id)" in complete["ConditionExpression"]
+    assert "expires_at > :now" in complete["ConditionExpression"]
+
+
+def test_abort_announcement_and_cancel_transitions_are_guarded() -> None:
+    repo = _repo()
+
+    assert repo.abort_draw(-100123, 11, draw_number=2, attempt_id="draw-b", now=710)
+    abort = repo.table.update_item.call_args.kwargs
+    assert "draw_attempt_id = :attempt" in abort["ConditionExpression"]
+    assert abort["ExpressionAttributeValues"][":restore"] == "DRAWN"
+
+    assert repo.mark_announcement_sent(
+        -100123,
+        11,
+        draw_number=2,
+        announcement_message_id=901,
+        now=720,
+    )
+    announcement = repo.table.update_item.call_args.kwargs
+    assert "announcement_state = :pending" in announcement["ConditionExpression"]
+    assert "winners[1].announcement_message_id" in announcement["UpdateExpression"]
+
+    repo.table.get_item.return_value = {
+        "Item": {
+            "chat_id": "-100123",
+            "root_message_id": 11,
+            "status": "CANCELLED",
+            "expires_at": 730 + 30 * 24 * 60 * 60,
+            "ttl_sweep_status": "PENDING",
+        }
+    }
+    cancelled = repo.cancel_contest(-100123, 11, now=730)
+    assert cancelled and cancelled["status"] == "CANCELLED"
+    cancel_tx = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    cancel = cancel_tx[0]["Update"]
+    cancel_values = _deserialize(cancel["ExpressionAttributeValues"])
+    cancel_outbox = _deserialize(cancel_tx[1]["Put"]["Item"])
+    assert cancel["ConditionExpression"] == "#status = :open AND attribute_not_exists(expires_at)"
+    assert cancel_values[":expires"] == 730 + 30 * 24 * 60 * 60
+    assert cancel_outbox["sk"] == "CHAT#-100123#ROOT#0000000000011"
+
+
+def test_orphan_is_terminal_at_repository_transition() -> None:
+    repo = _repo()
+
+    assert repo.mark_orphaned(-100123, 11, draw_number=1, now=800)
+
+    kwargs = repo.table.update_item.call_args.kwargs
+    assert kwargs["ExpressionAttributeValues"][":orphaned"] == "ORPHANED"
+    assert kwargs["ConditionExpression"] == (
+        "#status = :drawn AND draw_count = :draw AND announcement_state = :pending"
+    )
+
+
+def test_ttl_outbox_page_is_global_strong_and_resumable() -> None:
+    repo = _repo()
+    cursor = {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+    }
+    marker = {**cursor, "chat_id": "-100123", "root_message_id": 11}
+    repo.table.query.return_value = {"Items": [marker], "LastEvaluatedKey": cursor}
+
+    page, next_key = repo.ttl_outbox_page(limit=25, start_key=cursor)
+
+    assert page == [marker]
+    assert next_key == cursor
+    kwargs = repo.table.query.call_args.kwargs
+    assert kwargs["ConsistentRead"] is True
+    assert kwargs["Limit"] == 25
+    assert kwargs["ExclusiveStartKey"] == cursor
+
+
+def test_ttl_sweep_is_idempotent_and_completes_alias_before_meta() -> None:
+    repo = _repo()
+    items = [
+        {"pk": "CHAT#-100123", "sk": "CONTEST#0000000000011#PARTICIPANT#00000000000000000042"},
+        {"pk": "CHAT#-100123", "sk": "CONTEST#0000000000011#PARTICIPANT#00000000000000000043"},
+    ]
+
+    repo.stamp_participant_ttl(items, 999)
+    repo.record_ttl_sweep_progress(
+        -100123,
+        11,
+        expected_start_key=None,
+        expected_version=0,
+        next_start_key={"pk": "CHAT#-100123", "sk": items[-1]["sk"]},
+        now=900,
+    )
+    repo.complete_ttl_sweep(
+        -100123,
+        11,
+        rules_message_id=99,
+        expires_at=999,
+        expected_start_key={"pk": "CHAT#-100123", "sk": items[-1]["sk"]},
+        expected_version=1,
+        now=901,
+    )
+
+    assert repo.table.update_item.call_args_list[:2] == [
+        call(
+            Key={"pk": item["pk"], "sk": item["sk"]},
+            UpdateExpression="SET expires_at = :expires, #ttl = :expires",
+            ExpressionAttributeNames={"#ttl": "ttl"},
+            ExpressionAttributeValues={":expires": 999},
+        )
+        for item in items
+    ]
+    alias_call = repo.table.update_item.call_args_list[-1].kwargs
+    sweep_tx = repo.client.transact_write_items.call_args.kwargs["TransactItems"]
+    meta_call = sweep_tx[0]["Update"]
+    outbox_delete = _deserialize(sweep_tx[1]["Delete"]["Key"])
+    assert alias_call["Key"]["sk"] == "CONTEST_RULE#0000000000099"
+    assert _deserialize(meta_call["ExpressionAttributeValues"])[":complete"] == "COMPLETE"
+    assert "REMOVE ttl_sweep_cursor" in meta_call["UpdateExpression"]
+    assert "ttl_sweep_version = :version" in meta_call["ConditionExpression"]
+    assert outbox_delete == {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+    }
+
+
+def test_stale_ttl_worker_cannot_move_cursor_or_reopen_complete_sweep() -> None:
+    repo = _repo()
+    repo.table.update_item.side_effect = _client_error("ConditionalCheckFailedException")
+
+    assert not repo.record_ttl_sweep_progress(
+        -100123,
+        11,
+        expected_start_key={"pk": "CHAT#-100123", "sk": "old"},
+        expected_version=1,
+        next_start_key={"pk": "CHAT#-100123", "sk": "next"},
+    )
+    repo.client.transact_write_items.side_effect = _client_error("TransactionCanceledException")
+    assert not repo.complete_ttl_sweep(
+        -100123,
+        11,
+        rules_message_id=None,
+        expires_at=999,
+        expected_start_key={"pk": "CHAT#-100123", "sk": "old"},
+        expected_version=1,
+    )
+
+
+def test_logical_expiry_wins_before_physical_ttl_deletion() -> None:
+    assert ContestRepository.is_logically_expired({"expires_at": 100}, now=100)
+    assert not ContestRepository.is_logically_expired({"expires_at": 101}, now=100)
+    assert not ContestRepository.is_logically_expired({}, now=100)

--- a/tests/test_contest_service.py
+++ b/tests/test_contest_service.py
@@ -1,0 +1,932 @@
+"""Contest recognition, fairness, and Telegram evidence tests."""
+
+import json
+from unittest.mock import ANY, MagicMock, call, patch
+
+import pytest
+from services.contest import (
+    BOT_ADMIN_REQUIRED_KK,
+    CONTEST_EXPIRED_KK,
+    ENTRY_PHRASE,
+    NO_PARTICIPANTS_KK,
+    NO_REMAINING_CANDIDATES_KK,
+    RULES_MESSAGE_KK,
+    TELEGRAM_UPDATE_RETENTION_SECONDS,
+    AnnouncementOrphanedError,
+    ContestRetryRequiredError,
+    ContestService,
+    ContestTTLWorker,
+    has_contest_marker,
+    is_entry_message,
+    process_contest_ttl_recovery_task,
+)
+from services.repositories.contest import RegistrationResult
+from services.repositories.sqs import SQSClient
+from services.telegram import TelegramAPIError
+
+CHAT_ID = -100123
+CHANNEL_ID = -100456
+ROOT_ID = 11
+
+
+def _root_message(content_key: str = "text", content: str = "Сыйлық #КоНкУрС") -> dict:
+    return {
+        "message_id": ROOT_ID,
+        content_key: content,
+        "date": 100,
+        "chat": {"id": CHAT_ID, "type": "supergroup"},
+        "from": {"id": 777000, "is_bot": False, "first_name": "Telegram"},
+        "sender_chat": {"id": CHANNEL_ID, "type": "channel", "title": "Official"},
+        "is_automatic_forward": True,
+        "forward_origin": {"type": "channel", "message_id": 7},
+    }
+
+
+def _entry(user_id: int = 42, message_id: int = 12, text: str = "Мен ҚАТЫСАМЫН!") -> dict:
+    return {
+        "message_id": message_id,
+        "message_thread_id": ROOT_ID,
+        "reply_to_message": {"message_id": ROOT_ID},
+        "text": text,
+        "date": 200,
+        "chat": {"id": CHAT_ID, "type": "supergroup"},
+        "from": {
+            "id": user_id,
+            "is_bot": False,
+            "username": f"user{user_id}",
+            "first_name": "User",
+            "last_name": str(user_id),
+        },
+    }
+
+
+def _participant(user_id: int, message_id: int) -> dict:
+    return {
+        "user_id": str(user_id),
+        "entry_message_id": message_id,
+        "username": f"user{user_id}",
+        "first_name": "User",
+        "last_name": str(user_id),
+        "text": ENTRY_PHRASE,
+        "accepted_at": 200,
+    }
+
+
+def _winner(participant: dict, draw_number: int) -> dict:
+    return {**participant, "draw_number": draw_number, "selected_at": 300}
+
+
+def _service(repo: MagicMock | None = None, bot: MagicMock | None = None, sqs: MagicMock | None = None):
+    repo = repo or MagicMock()
+    bot = bot or MagicMock()
+    sqs = sqs or MagicMock()
+    repo.is_logically_expired.return_value = False
+    bot.send_message.return_value = {"message_id": 999}
+    return ContestService(repo, bot, sqs), repo, bot, sqs
+
+
+def test_marker_is_standalone_case_insensitive_and_accepts_media_caption() -> None:
+    assert has_contest_marker(_root_message())
+    assert has_contest_marker(_root_message("caption", "Фото: #КОНКУРС!"))
+    assert not has_contest_marker(_root_message(content="prefix#конкурс"))
+    assert not has_contest_marker(_root_message(content="##конкурс"))
+    assert not has_contest_marker(_root_message(content="#конкурстық"))
+
+
+def test_entry_shape_requires_personal_direct_text_reply() -> None:
+    assert is_entry_message(_entry(text="қатысамынба"))
+
+    nested = _entry()
+    nested["reply_to_message"] = {"message_id": 99}
+    assert not is_entry_message(nested)
+
+    caption = _entry()
+    caption.pop("text")
+    caption["caption"] = ENTRY_PHRASE
+    assert not is_entry_message(caption)
+
+    anonymous = _entry()
+    anonymous["sender_chat"] = {"id": CHAT_ID, "type": "supergroup"}
+    assert not is_entry_message(anonymous)
+
+    bot_entry = _entry()
+    bot_entry["from"]["is_bot"] = True
+    assert not is_entry_message(bot_entry)
+
+
+def test_official_linked_root_creates_fail_closed_then_posts_rules() -> None:
+    service, repo, bot, _ = _service()
+    creating = {"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID, "status": "CREATING"}
+    repo.get_contest.side_effect = [None, creating]
+    repo.create_contest.return_value = True
+    repo.activate_contest.return_value = True
+    bot.get_chat.return_value = {"linked_chat_id": CHANNEL_ID}
+    bot.get_me.return_value = {"id": 9000}
+    bot.get_chat_member.return_value = {"status": "administrator"}
+    bot.send_message.return_value = {"message_id": 88}
+
+    service.observe_update({"message": _root_message()})
+
+    repo.create_contest.assert_called_once_with(
+        chat_id=CHAT_ID,
+        root_message_id=ROOT_ID,
+        source_channel_id=CHANNEL_ID,
+        source_channel_title="Official",
+        source_channel_username=None,
+        source_channel_post_id=7,
+        created_at=100,
+    )
+    bot.send_message.assert_called_once_with(
+        str(CHAT_ID),
+        RULES_MESSAGE_KK,
+        reply_to_message_id=ROOT_ID,
+        link_preview_disable=True,
+    )
+    repo.activate_contest.assert_called_once_with(str(CHAT_ID), ROOT_ID, 88, attempt_id=ANY)
+
+
+def test_unlinked_or_non_admin_root_never_opens_contest() -> None:
+    service, repo, bot, _ = _service()
+    bot.get_chat.return_value = {"linked_chat_id": -100999}
+
+    service.observe_update({"message": _root_message()})
+
+    repo.create_contest.assert_not_called()
+
+    repo.reset_mock()
+    bot.reset_mock()
+    bot.get_chat.return_value = {"linked_chat_id": CHANNEL_ID}
+    bot.get_me.return_value = {"id": 9000}
+    bot.get_chat_member.return_value = {"status": "member"}
+    repo.get_contest.return_value = None
+
+    service.observe_update({"message": _root_message()})
+
+    repo.create_contest.assert_not_called()
+    bot.send_message.assert_called_once_with(CHAT_ID, BOT_ADMIN_REQUIRED_KK, reply_to_message_id=ROOT_ID)
+
+
+def test_definite_rules_failure_marks_creation_failed() -> None:
+    service, repo, bot, _ = _service()
+    creating = {"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID, "status": "CREATING"}
+    repo.get_contest.side_effect = [None, creating]
+    repo.create_contest.return_value = True
+    bot.get_chat.return_value = {"linked_chat_id": CHANNEL_ID}
+    bot.get_me.return_value = {"id": 9000}
+    bot.get_chat_member.return_value = {"status": "administrator"}
+    bot.send_message.side_effect = TelegramAPIError(400, "Bad Request: message to be replied not found")
+
+    service.observe_update({"message": _root_message()})
+
+    repo.fail_creation.assert_called_once_with(str(CHAT_ID), ROOT_ID, attempt_id=ANY)
+    repo.activate_contest.assert_not_called()
+
+
+def test_concurrent_creation_loser_never_sends_or_fails_winner_attempt() -> None:
+    service, repo, bot, _ = _service()
+    repo.begin_creation_attempt.return_value = False
+
+    with pytest.raises(ContestRetryRequiredError):
+        service._activate_creating({"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID, "status": "CREATING"})
+
+    bot.send_message.assert_not_called()
+    repo.fail_creation.assert_not_called()
+    repo.activate_contest.assert_not_called()
+
+
+def test_transient_creation_delivery_failure_releases_lease_and_propagates_for_retry() -> None:
+    service, repo, bot, _ = _service()
+    repo.begin_creation_attempt.return_value = True
+    bot.get_me.return_value = {"id": 9000}
+    bot.get_chat_member.return_value = {"status": "administrator"}
+    bot.send_message.side_effect = TelegramAPIError(429, "Too Many Requests")
+
+    with pytest.raises(TelegramAPIError):
+        service._activate_creating({"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID, "status": "CREATING"})
+
+    repo.release_creation_attempt.assert_called_once_with(str(CHAT_ID), ROOT_ID, attempt_id=ANY)
+    repo.fail_creation.assert_not_called()
+
+
+def test_first_direct_entry_is_stored_once_and_gets_check_reaction() -> None:
+    service, repo, bot, _ = _service()
+    repo.get_contest.return_value = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+    }
+    repo.register_participant.return_value = RegistrationResult.REGISTERED
+
+    service.observe_update({"message": _entry()})
+
+    repo.register_participant.assert_called_once_with(
+        chat_id=CHAT_ID,
+        root_message_id=ROOT_ID,
+        user_id=42,
+        entry_message_id=12,
+        username="user42",
+        first_name="User",
+        last_name="42",
+        text="Мен ҚАТЫСАМЫН!",
+        accepted_at=200,
+    )
+    bot.set_message_reaction.assert_called_once_with(CHAT_ID, 12, "🎉")
+
+    bot.reset_mock()
+    repo.register_participant.return_value = RegistrationResult.DUPLICATE
+    service.observe_update({"message": _entry(message_id=13)})
+    bot.set_message_reaction.assert_not_called()
+
+    repo.register_participant.return_value = RegistrationResult.REPLAY
+    service.observe_update({"message": _entry(message_id=12)})
+    bot.set_message_reaction.assert_called_once_with(CHAT_ID, 12, "🎉")
+
+
+def test_early_direct_entry_retries_until_original_root_activation_finishes() -> None:
+    service, repo, bot, _ = _service()
+    opened = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+        "rules_message_id": 88,
+    }
+    repo.register_participant.return_value = RegistrationResult.REGISTERED
+    entry = _entry()
+    entry["reply_to_message"] = _root_message()
+
+    repo.get_contest.return_value = None
+    with (
+        patch("services.contest.time.time", return_value=200),
+        pytest.raises(ContestRetryRequiredError),
+    ):
+        service.observe_update({"message": entry})
+
+    repo.create_contest.assert_not_called()
+    repo.register_participant.assert_not_called()
+
+    repo.get_contest.return_value = opened
+    service.observe_update({"message": entry})
+
+    repo.register_participant.assert_called_once()
+    bot.set_message_reaction.assert_called_once_with(CHAT_ID, 12, "🎉")
+
+
+def test_backlogged_early_entry_still_retries_within_telegram_retention() -> None:
+    service, repo, _, _ = _service()
+    repo.get_contest.return_value = None
+    entry = _entry()
+    entry["reply_to_message"] = _root_message()
+
+    with (
+        patch(
+            "services.contest.time.time",
+            return_value=entry["date"] + TELEGRAM_UPDATE_RETENTION_SECONDS - 1,
+        ),
+        pytest.raises(ContestRetryRequiredError),
+    ):
+        service.observe_update({"message": entry})
+
+    repo.create_contest.assert_not_called()
+    repo.register_participant.assert_not_called()
+
+
+def test_embedded_root_stops_retrying_after_telegram_retention() -> None:
+    service, repo, _, _ = _service()
+    repo.get_contest.return_value = None
+    entry = _entry()
+    entry["reply_to_message"] = _root_message()
+
+    with patch(
+        "services.contest.time.time",
+        return_value=entry["date"] + TELEGRAM_UPDATE_RETENTION_SECONDS + 1,
+    ):
+        service.observe_update({"message": entry})
+
+    repo.create_contest.assert_not_called()
+    repo.register_participant.assert_not_called()
+
+
+@pytest.mark.parametrize("root_mutation", ["edited", "historical"])
+def test_embedded_root_never_backfills_edited_or_historical_post(root_mutation: str) -> None:
+    service, repo, bot, _ = _service()
+    repo.get_contest.return_value = None
+    entry = _entry()
+    root = _root_message()
+    if root_mutation == "edited":
+        root["edit_date"] = 150
+    else:
+        entry["date"] = 10_000
+    entry["reply_to_message"] = root
+
+    with patch("services.contest.time.time", return_value=10_000 if root_mutation == "historical" else 200):
+        service.observe_update({"message": entry})
+
+    repo.create_contest.assert_not_called()
+    repo.register_participant.assert_not_called()
+    bot.set_message_reaction.assert_not_called()
+
+
+def test_first_draw_freezes_full_set_and_replies_to_saved_winner_comment() -> None:
+    service, repo, bot, sqs = _service()
+    one = _participant(1, 21)
+    two = _participant(2, 22)
+    open_contest = {"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID, "status": "OPEN", "draw_count": 0}
+    drawn = {
+        **open_contest,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 2,
+        "winner_user_ids": ["2"],
+        "winners": [_winner(two, 1)],
+        "announcement_state": "PENDING",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.side_effect = [open_contest, drawn]
+    repo.begin_first_draw.return_value = True
+    repo.iter_participants.return_value = [one, two]
+    repo.complete_draw.return_value = True
+    bot.send_message.return_value = {"message_id": 901}
+
+    with patch("services.contest.secrets.randbelow", side_effect=[0, 0]) as randbelow:
+        service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    assert randbelow.call_args_list == [call(1), call(2)]
+    repo.complete_draw.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        draw_number=1,
+        attempt_id=ANY,
+        participant=two,
+        frozen_participant_count=2,
+    )
+    sent = bot.send_message.call_args
+    assert sent.kwargs["reply_to_message_id"] == 22
+    assert "Қатысушылар саны: <b>2</b>" in sent.args[1]
+    assert "Ұтыс: <b>1/3</b>" in sent.args[1]
+    repo.mark_announcement_sent.assert_called_once_with(
+        str(CHAT_ID), ROOT_ID, draw_number=1, announcement_message_id=901
+    )
+    sqs.send_contest_ttl_sweep_task.assert_called_once_with(chat_id=CHAT_ID, root_message_id=ROOT_ID)
+
+
+def test_zero_person_draw_reopens_and_keeps_contest_available() -> None:
+    service, repo, bot, _ = _service()
+    repo.get_contest.return_value = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+        "draw_count": 0,
+    }
+    repo.begin_first_draw.return_value = True
+    repo.iter_participants.return_value = []
+
+    service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    repo.abort_draw.assert_called_once_with(CHAT_ID, ROOT_ID, draw_number=1, attempt_id=ANY)
+    repo.complete_draw.assert_not_called()
+    bot.send_message.assert_called_once_with(CHAT_ID, NO_PARTICIPANTS_KK, reply_to_message_id=30)
+
+
+def test_one_person_draw_selects_the_only_participant_normally() -> None:
+    service, repo, bot, _ = _service()
+    only = _participant(1, 21)
+    open_contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+        "participant_count": 1,
+        "draw_count": 0,
+    }
+    drawn = {
+        **open_contest,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(only, 1)],
+        "announcement_state": "PENDING",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.side_effect = [open_contest, drawn]
+    repo.begin_first_draw.return_value = True
+    repo.iter_participants.return_value = [only]
+    repo.complete_draw.return_value = True
+
+    with patch("services.contest.secrets.randbelow", return_value=0) as randbelow:
+        service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    randbelow.assert_called_once_with(1)
+    repo.complete_draw.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        draw_number=1,
+        attempt_id=ANY,
+        participant=only,
+        frozen_participant_count=1,
+    )
+    assert bot.send_message.call_args.kwargs["reply_to_message_id"] == 21
+
+
+def test_drawing_crash_resumes_the_same_attempt_token() -> None:
+    service, repo, _, _ = _service()
+    only = _participant(1, 21)
+    drawing = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWING",
+        "draw_count": 0,
+        "pending_draw_number": 1,
+        "draw_attempt_id": "persisted-attempt",
+    }
+    drawn = {
+        **drawing,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(only, 1)],
+        "announcement_state": "PENDING",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.side_effect = [drawing, drawn]
+    repo.iter_participants.return_value = [only]
+    repo.complete_draw.return_value = True
+
+    service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    repo.begin_first_draw.assert_not_called()
+    assert repo.complete_draw.call_args.kwargs["attempt_id"] == "persisted-attempt"
+
+
+def test_same_attempt_completion_conflict_aborts_instead_of_sticking_drawing() -> None:
+    service, repo, _, _ = _service()
+    only = _participant(1, 21)
+    open_contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+        "draw_count": 0,
+    }
+    still_drawing = {
+        **open_contest,
+        "status": "DRAWING",
+        "pending_draw_number": 1,
+        "draw_attempt_id": "fixed-attempt",
+    }
+    repo.get_contest.side_effect = [open_contest, still_drawing]
+    repo.begin_first_draw.return_value = True
+    repo.iter_participants.return_value = [only]
+    repo.complete_draw.return_value = False
+
+    with (
+        patch("services.contest.secrets.token_hex", return_value="fixed-attempt"),
+        patch("services.contest.secrets.randbelow", return_value=0),
+        pytest.raises(RuntimeError, match="completion condition failed"),
+    ):
+        service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    repo.abort_draw.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        draw_number=1,
+        attempt_id="fixed-attempt",
+    )
+
+
+def test_redraw_excludes_previous_winner_and_preserves_frozen_count() -> None:
+    service, repo, bot, _ = _service()
+    one = _participant(1, 21)
+    two = _participant(2, 22)
+    drawn_once = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 2,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(one, 1)],
+        "announcement_state": "SENT",
+        "expires_at": 9_999_999_999,
+    }
+    drawn_twice = {
+        **drawn_once,
+        "draw_count": 2,
+        "winner_user_ids": ["1", "2"],
+        "winners": [_winner(one, 1), _winner(two, 2)],
+        "announcement_state": "PENDING",
+    }
+    repo.get_contest.side_effect = [drawn_once, drawn_twice]
+    repo.iter_participants.return_value = [one, two]
+    repo.begin_redraw.return_value = True
+    repo.complete_draw.return_value = True
+
+    with patch("services.contest.secrets.randbelow", return_value=0) as randbelow:
+        service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=31, redraw=True)
+
+    randbelow.assert_called_once_with(1)
+    repo.complete_draw.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        draw_number=2,
+        attempt_id=ANY,
+        participant=two,
+        frozen_participant_count=2,
+    )
+
+
+def test_redraw_without_remaining_candidate_preserves_existing_winner() -> None:
+    service, repo, bot, _ = _service()
+    only = _participant(1, 21)
+    drawn = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(only, 1)],
+        "announcement_state": "SENT",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "COMPLETE",
+    }
+    repo.get_contest.return_value = drawn
+    repo.begin_redraw.return_value = True
+    repo.iter_participants.return_value = [only]
+
+    service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=31, redraw=True)
+
+    repo.abort_draw.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        draw_number=2,
+        attempt_id=ANY,
+    )
+    repo.complete_draw.assert_not_called()
+    bot.send_message.assert_called_once_with(
+        CHAT_ID,
+        NO_REMAINING_CANDIDATES_KK,
+        reply_to_message_id=31,
+    )
+
+
+def test_redraw_crossing_fixed_expiry_aborts_before_selection_commit() -> None:
+    service, repo, bot, _ = _service()
+    one = _participant(1, 21)
+    two = _participant(2, 22)
+    contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 2,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(one, 1)],
+        "announcement_state": "SENT",
+        "expires_at": 500,
+    }
+    repo.get_contest.return_value = contest
+    repo.iter_participants.return_value = [one, two]
+    repo.begin_redraw.return_value = True
+    repo.is_logically_expired.side_effect = [False, True]
+
+    service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=31, redraw=True)
+
+    repo.complete_draw.assert_not_called()
+    repo.abort_draw.assert_called_once_with(CHAT_ID, ROOT_ID, draw_number=2, attempt_id=ANY)
+    bot.send_message.assert_called_once_with(CHAT_ID, CONTEST_EXPIRED_KK, reply_to_message_id=31)
+
+
+def test_pending_announcement_replays_same_winner_without_reselection() -> None:
+    service, repo, bot, sqs = _service()
+    one = _participant(1, 21)
+    pending = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(one, 1)],
+        "announcement_state": "PENDING",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.return_value = pending
+
+    with patch("services.contest.secrets.randbelow") as randbelow:
+        service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=31, redraw=True)
+
+    randbelow.assert_not_called()
+    repo.begin_redraw.assert_not_called()
+    assert bot.send_message.call_args_list[0].kwargs["reply_to_message_id"] == 21
+    assert bot.send_message.call_args_list[1].kwargs["reply_to_message_id"] == 31
+    sqs.send_contest_ttl_sweep_task.assert_called_once_with(chat_id=CHAT_ID, root_message_id=ROOT_ID)
+
+
+def test_first_ttl_enqueue_failure_does_not_block_persisted_winner_announcement() -> None:
+    service, repo, bot, sqs = _service()
+    only = _participant(1, 21)
+    open_contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "OPEN",
+        "draw_count": 0,
+    }
+    drawn = {
+        **open_contest,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winner_user_ids": ["1"],
+        "winners": [_winner(only, 1)],
+        "announcement_state": "PENDING",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.side_effect = [open_contest, drawn]
+    repo.begin_first_draw.return_value = True
+    repo.iter_participants.return_value = [only]
+    repo.complete_draw.return_value = True
+    sqs.send_contest_ttl_sweep_task.side_effect = RuntimeError("SQS unavailable")
+
+    service.draw(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=30)
+
+    repo.complete_draw.assert_called_once()
+    repo.mark_announcement_sent.assert_called_once_with(
+        str(CHAT_ID),
+        ROOT_ID,
+        draw_number=1,
+        announcement_message_id=999,
+    )
+    assert bot.send_message.call_args.kwargs["reply_to_message_id"] == 21
+
+
+def test_repeated_cancel_recovers_missed_ttl_enqueue_without_extending_expiry() -> None:
+    service, repo, bot, sqs = _service()
+    cancelled = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "CANCELLED",
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    repo.get_contest.return_value = cancelled
+    repo.cancel_contest.return_value = None
+
+    service.cancel(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=32)
+
+    sqs.send_contest_ttl_sweep_task.assert_called_once_with(chat_id=CHAT_ID, root_message_id=ROOT_ID)
+    repo.cancel_contest.assert_called_once_with(CHAT_ID, ROOT_ID)
+    assert bot.send_message.call_args.kwargs["reply_to_message_id"] == 32
+
+
+def test_status_is_independent_from_cleanup_queue_availability() -> None:
+    service, repo, bot, sqs = _service()
+    repo.get_contest.return_value = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 7,
+        "expires_at": 9_999_999_999,
+        "ttl_sweep_status": "PENDING",
+    }
+    sqs.send_contest_ttl_sweep_task.side_effect = RuntimeError("SQS unavailable")
+
+    service.status(chat_id=CHAT_ID, root_message_id=ROOT_ID, command_message_id=33)
+
+    sqs.send_contest_ttl_sweep_task.assert_not_called()
+    assert "Бірегей қатысушылар: <b>7</b>" in bot.send_message.call_args.args[1]
+
+
+def test_deleted_winner_comment_falls_back_to_root_with_safe_bounded_snapshot() -> None:
+    service, repo, bot, _ = _service()
+    participant = _participant(1, 21)
+    participant.pop("username")
+    participant["first_name"] = "&" * 200
+    participant["last_name"] = '"' * 200
+    participant["text"] = '"' * (4096 - len(ENTRY_PHRASE)) + ENTRY_PHRASE
+    winner = _winner(participant, 1)
+    contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winners": [winner],
+        "announcement_state": "PENDING",
+    }
+    bot.send_message.side_effect = [
+        TelegramAPIError(400, "Bad Request: message to be replied not found"),
+        {"message_id": 902},
+    ]
+
+    service._announce_winner(contest, winner)
+
+    assert bot.send_message.call_args_list[0].kwargs["reply_to_message_id"] == 21
+    fallback = bot.send_message.call_args_list[1]
+    assert fallback.kwargs["reply_to_message_id"] == ROOT_ID
+    assert "&quot;" in fallback.args[1]
+    assert ENTRY_PHRASE in fallback.args[1].casefold()
+    assert len(fallback.args[1]) < 4096
+    repo.mark_announcement_sent.assert_called_once()
+
+
+def test_missing_winner_and_root_marks_terminal_orphan_without_unanchored_send() -> None:
+    service, repo, bot, _ = _service()
+    winner = _winner(_participant(1, 21), 1)
+    contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "status": "DRAWN",
+        "draw_count": 1,
+        "frozen_participant_count": 1,
+        "winners": [winner],
+        "announcement_state": "PENDING",
+    }
+    missing = TelegramAPIError(400, "Bad Request: message to be replied not found")
+    bot.send_message.side_effect = [missing, missing]
+
+    with pytest.raises(AnnouncementOrphanedError):
+        service._announce_winner(contest, winner)
+
+    assert bot.send_message.call_args_list == [
+        call(
+            str(CHAT_ID),
+            bot.send_message.call_args_list[0].args[1],
+            reply_to_message_id=21,
+            link_preview_disable=True,
+        ),
+        call(
+            str(CHAT_ID),
+            bot.send_message.call_args_list[1].args[1],
+            reply_to_message_id=ROOT_ID,
+            link_preview_disable=True,
+        ),
+    ]
+    repo.mark_orphaned.assert_called_once_with(str(CHAT_ID), ROOT_ID, draw_number=1)
+
+
+def test_ttl_sweep_persists_cursor_before_requeue_and_finishes_alias_last() -> None:
+    _, repo, _, sqs = _service()
+    worker = ContestTTLWorker(repo, sqs)
+    contest = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "rules_message_id": 88,
+        "expires_at": 999,
+        "ttl_sweep_status": "PENDING",
+    }
+    page = [{"pk": "CHAT#-100123", "sk": "participant"}]
+    cursor = {"pk": "CHAT#-100123", "sk": "participant"}
+    repo.get_contest.return_value = contest
+    repo.participant_page.return_value = (page, cursor)
+
+    worker.process({"chat_id": CHAT_ID, "root_message_id": ROOT_ID})
+
+    repo.stamp_participant_ttl.assert_called_once_with(page, 999)
+    repo.record_ttl_sweep_progress.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        expected_start_key=None,
+        expected_version=0,
+        next_start_key=cursor,
+    )
+    sqs.send_contest_ttl_sweep_task.assert_called_once_with(chat_id=CHAT_ID, root_message_id=ROOT_ID)
+    repo.complete_ttl_sweep.assert_not_called()
+
+    repo.reset_mock()
+    sqs.reset_mock()
+    repo.get_contest.return_value = contest
+    repo.participant_page.return_value = (page, None)
+    worker.process({"chat_id": CHAT_ID, "root_message_id": ROOT_ID})
+    repo.complete_ttl_sweep.assert_called_once_with(
+        CHAT_ID,
+        ROOT_ID,
+        rules_message_id=88,
+        expires_at=999,
+        expected_start_key=None,
+        expected_version=0,
+    )
+
+
+def test_stale_ttl_worker_does_not_enqueue_a_regressed_cursor() -> None:
+    _, repo, _, sqs = _service()
+    worker = ContestTTLWorker(repo, sqs)
+    repo.get_contest.return_value = {
+        "chat_id": str(CHAT_ID),
+        "root_message_id": ROOT_ID,
+        "expires_at": 999,
+        "ttl_sweep_status": "PENDING",
+        "ttl_sweep_version": 2,
+        "ttl_sweep_cursor": {"pk": "CHAT#-100123", "sk": "current"},
+    }
+    repo.participant_page.return_value = (
+        [{"pk": "CHAT#-100123", "sk": "participant"}],
+        {"pk": "CHAT#-100123", "sk": "next"},
+    )
+    repo.record_ttl_sweep_progress.return_value = False
+
+    worker.process({"chat_id": CHAT_ID, "root_message_id": ROOT_ID})
+
+    sqs.send_contest_ttl_sweep_task.assert_not_called()
+
+
+def test_contest_ttl_queue_payload_uses_dynamo_cursor_as_single_truth() -> None:
+    sqs = SQSClient.__new__(SQSClient)
+    sqs.queue_url = "queue-url"
+    sqs.vector_queue_url = "vector-url"
+    sqs_client = MagicMock()
+    sqs.__dict__["sqs_client"] = sqs_client
+    with patch.object(SQSClient, "sqs_client", sqs_client):
+        sqs.send_contest_ttl_sweep_task(
+            chat_id=CHAT_ID,
+            root_message_id=ROOT_ID,
+        )
+
+    payload = json.loads(sqs_client.send_message.call_args.kwargs["MessageBody"])
+    assert payload == {
+        "task_type": "PROCESS_CONTEST_TTL_SWEEP",
+        "chat_id": CHAT_ID,
+        "root_message_id": ROOT_ID,
+    }
+
+
+def test_ttl_recovery_replays_one_bounded_outbox_page_then_enqueues_continuation() -> None:
+    repo = MagicMock()
+    sqs = MagicMock()
+    cursor = {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+    }
+    repo.ttl_outbox_page.return_value = (
+        [{"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID}],
+        cursor,
+    )
+
+    process_contest_ttl_recovery_task({}, repo=repo, sqs_repo=sqs)
+
+    repo.ttl_outbox_page.assert_called_once_with(limit=100, start_key=None)
+    sqs.send_contest_ttl_sweep_task.assert_called_once_with(
+        chat_id=CHAT_ID,
+        root_message_id=ROOT_ID,
+    )
+    sqs.send_contest_ttl_recovery_task.assert_called_once_with(start_key=cursor)
+
+
+def test_ttl_recovery_resumes_supplied_cursor_and_stops_at_last_page() -> None:
+    repo = MagicMock()
+    sqs = MagicMock()
+    cursor = {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+    }
+    repo.ttl_outbox_page.return_value = ([], None)
+
+    process_contest_ttl_recovery_task(
+        {"start_key": cursor},
+        repo=repo,
+        sqs_repo=sqs,
+    )
+
+    repo.ttl_outbox_page.assert_called_once_with(limit=100, start_key=cursor)
+    sqs.send_contest_ttl_sweep_task.assert_not_called()
+    sqs.send_contest_ttl_recovery_task.assert_not_called()
+
+
+def test_daily_ttl_recovery_send_failure_bubbles_without_consuming_marker() -> None:
+    repo = MagicMock()
+    sqs = MagicMock()
+    repo.ttl_outbox_page.return_value = (
+        [{"chat_id": str(CHAT_ID), "root_message_id": ROOT_ID}],
+        None,
+    )
+    sqs.send_contest_ttl_sweep_task.side_effect = RuntimeError("SQS unavailable")
+
+    with pytest.raises(RuntimeError, match="SQS unavailable"):
+        process_contest_ttl_recovery_task({}, repo=repo, sqs_repo=sqs)
+
+    repo.ttl_outbox_page.assert_called_once_with(limit=100, start_key=None)
+
+
+def test_contest_ttl_recovery_queue_payload_carries_only_its_page_cursor() -> None:
+    sqs = SQSClient.__new__(SQSClient)
+    sqs.queue_url = "queue-url"
+    sqs.vector_queue_url = "vector-url"
+    sqs_client = MagicMock()
+    sqs.__dict__["sqs_client"] = sqs_client
+    cursor = {
+        "pk": "CONTEST_TTL_OUTBOX",
+        "sk": "CHAT#-100123#ROOT#0000000000011",
+    }
+
+    with patch.object(SQSClient, "sqs_client", sqs_client):
+        sqs.send_contest_ttl_recovery_task(start_key=cursor)
+
+    assert json.loads(sqs_client.send_message.call_args.kwargs["MessageBody"]) == {
+        "task_type": "PROCESS_CONTEST_TTL_RECOVERY",
+        "start_key": cursor,
+    }

--- a/tests/test_contest_wiring.py
+++ b/tests/test_contest_wiring.py
@@ -1,0 +1,81 @@
+"""Contest dependency wiring at the Lambda application boundaries."""
+
+from unittest.mock import MagicMock, patch
+
+import app
+import main
+
+
+def test_app_dispatcher_reuses_and_injects_contest_and_queue_dependencies(monkeypatch) -> None:
+    bot = MagicMock()
+    captcha = MagicMock()
+    memory = MagicMock()
+    contest = MagicMock()
+    sqs = MagicMock()
+
+    monkeypatch.setattr(app, "MEMORY_TABLE_NAME", "memory-table")
+    monkeypatch.setattr(app, "QUIZ_TABLE_NAME", "")
+    monkeypatch.setattr(app, "QUIZ_LAMBDA_NAME", "")
+    monkeypatch.setattr(app, "_bot", None)
+    monkeypatch.setattr(app, "_captcha_repo", None)
+    monkeypatch.setattr(app, "_memory_repo", None)
+    monkeypatch.setattr(app, "_contest_repo", None)
+    monkeypatch.setattr(app, "_sqs_repo", None)
+    monkeypatch.setattr(app, "_dispatcher", None)
+
+    with (
+        patch.object(app, "TelegramClient", return_value=bot),
+        patch.object(app, "CaptchaRepository", return_value=captcha),
+        patch.object(app, "GroupMemoryRepository", return_value=memory),
+        patch.object(app, "ContestRepository", return_value=contest),
+        patch.object(app, "SQSClient", return_value=sqs),
+        patch.object(app, "StatsRepository", return_value=MagicMock()),
+        patch.object(app, "VoteRepository", return_value=MagicMock()),
+    ):
+        dispatcher = app.get_dispatcher()
+
+    assert dispatcher.bot is bot
+    assert dispatcher.captcha_repo is captcha
+    assert dispatcher.memory_repo is memory
+    assert dispatcher.contest_repo is contest
+    assert dispatcher.sqs_repo is sqs
+    assert app.get_dispatcher() is dispatcher
+    assert app.get_contest_repo() is contest
+    assert app.get_sqs_repo() is sqs
+
+
+def test_main_sqs_boundary_passes_contest_and_shared_queue_dependencies() -> None:
+    event = {
+        "Records": [
+            {
+                "eventSource": "aws:sqs",
+                "messageId": "mid-1",
+                "body": "{}",
+            }
+        ]
+    }
+    bot = MagicMock()
+    captcha = MagicMock()
+    memory = MagicMock()
+    contest = MagicMock()
+    sqs = MagicMock()
+    context = MagicMock(aws_request_id="request-1")
+
+    with (
+        patch.object(main, "get_bot", return_value=bot),
+        patch.object(main, "get_captcha_repo", return_value=captcha),
+        patch.object(main, "get_memory_repo", return_value=memory),
+        patch.object(main, "get_contest_repo", return_value=contest),
+        patch.object(main, "get_sqs_repo", return_value=sqs),
+        patch.object(main, "process_sqs_event") as process,
+    ):
+        assert main.lambda_handler(event, context) is None
+
+    process.assert_called_once_with(
+        event,
+        bot,
+        captcha,
+        memory,
+        contest_repo=contest,
+        sqs_repo=sqs,
+    )

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -41,6 +41,7 @@ def test_registered_public_command_surface(mock_bot, mock_stats_repo, mock_sqs_r
     assert "/memory" in dp.command_handlers
     assert "/agent" in dp.command_handlers
     assert "/ask" in dp.command_handlers
+    assert "/contest" in dp.command_handlers
     assert "/wtf" not in dp.command_handlers
     assert "/explain" not in dp.command_handlers
     assert "/memory_on" not in dp.command_handlers

--- a/tests/test_infra_configuration.py
+++ b/tests/test_infra_configuration.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -36,15 +37,19 @@ def _stub_python_function(scope: Any, construct_id: str, **kwargs: Any) -> lambd
     )
 
 
-def _dev_template(monkeypatch: Any) -> Template:
+def _template(monkeypatch: Any, *, env_name: str) -> Template:
     monkeypatch.setattr(bot_component, "PythonFunction", _stub_python_function)
     monkeypatch.setattr(news_component, "PythonFunction", _stub_python_function)
     monkeypatch.setattr(quiz_component, "PythonFunction", _stub_python_function)
     monkeypatch.setattr(vector_indexer_component, "PythonFunction", _stub_python_function)
 
     app = App()
-    stack = ZerdeTelegramBotStack(app, "TestStack", env_name="dev")
+    stack = ZerdeTelegramBotStack(app, "TestStack", env_name=env_name)
     return Template.from_stack(stack)
+
+
+def _dev_template(monkeypatch: Any) -> Template:
+    return _template(monkeypatch, env_name="dev")
 
 
 def _resources(template: Template) -> dict[str, Any]:
@@ -197,6 +202,74 @@ def test_main_and_vector_queues_have_separate_lambda_consumers(monkeypatch: Any)
 
     assert _event_source_targets(template, main_queue_id) == [{"Ref": bot_lambda_id}]
     assert _event_source_targets(template, vector_queue_id) == [{"Ref": vector_indexer_lambda_id}]
+
+
+def test_prod_contest_recovery_schedule_exists_without_configured_chats(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr("stack.load_dotenv", lambda *args, **kwargs: None)
+    for key in (
+        "CHATS_KK",
+        "CHATS_ZH",
+        "CHATS_RU",
+        "NEWS_CHATS_KK",
+        "NEWS_CHATS_ZH",
+        "NEWS_CHATS_RU",
+        "QUIZ_CHATS_KK",
+        "QUIZ_CHATS_ZH",
+        "QUIZ_CHATS_RU",
+    ):
+        monkeypatch.setenv(key, "")
+
+    template = _template(monkeypatch, env_name="prod")
+    rule_id, rule = _find_resource_by_property(
+        template,
+        "AWS::Events::Rule",
+        "Name",
+        "zerde-serverless-contest-ttl-recovery-prod",
+    )
+    queue_id, _ = _find_resource_by_property(
+        template,
+        "AWS::SQS::Queue",
+        "QueueName",
+        "zerde-serverless-timeout-tasks-queue-prod",
+    )
+
+    properties = rule["Properties"]
+    assert properties["ScheduleExpression"] == "cron(50 20 * * ? *)"
+    assert json.loads(properties["Targets"][0]["Input"]) == {"task_type": "PROCESS_CONTEST_TTL_RECOVERY"}
+    assert properties["Targets"][0]["Arn"] == {"Fn::GetAtt": [queue_id, "Arn"]}
+    assert not any(
+        resource.get("Type") == "AWS::Events::Rule"
+        and resource.get("Properties", {}).get("Name") == "zerde-serverless-group-memory-daily-summary-prod"
+        for resource in _resources(template).values()
+    )
+
+    expected_queue_arn = {"Fn::GetAtt": [queue_id, "Arn"]}
+    expected_rule_arn = {"Fn::GetAtt": [rule_id, "Arn"]}
+    statements = [
+        statement
+        for resource in _resources(template).values()
+        if resource.get("Type") == "AWS::SQS::QueuePolicy"
+        for statement in _as_list(resource["Properties"]["PolicyDocument"]["Statement"])
+    ]
+    assert any(
+        statement.get("Principal") == {"Service": "events.amazonaws.com"}
+        and "sqs:SendMessage" in _as_list(statement.get("Action", []))
+        and statement.get("Resource") == expected_queue_arn
+        and statement.get("Condition", {}).get("ArnEquals", {}).get("aws:SourceArn") == expected_rule_arn
+        for statement in statements
+    )
+
+
+def test_dev_has_no_scheduled_contest_recovery(monkeypatch: Any) -> None:
+    template = _dev_template(monkeypatch)
+
+    assert not any(
+        resource.get("Type") == "AWS::Events::Rule"
+        and resource.get("Properties", {}).get("Name") == "zerde-serverless-contest-ttl-recovery-dev"
+        for resource in _resources(template).values()
+    )
 
 
 def test_sqs_queue_retention_defaults_are_operationally_safe(monkeypatch: Any) -> None:

--- a/tests/test_sqs_task_router.py
+++ b/tests/test_sqs_task_router.py
@@ -139,6 +139,135 @@ def test_process_daily_group_summaries_routes() -> None:
     mock_pd.assert_called_once_with(body, repo=None)
 
 
+def test_daily_summary_task_does_not_share_contest_recovery_failure_domain() -> None:
+    body = {
+        "task_type": "PROCESS_DAILY_GROUP_SUMMARIES",
+        "chat_ids": [-1001],
+    }
+    contest_repo = MagicMock()
+    sqs_repo = MagicMock()
+    memory_repo = MagicMock()
+    with patch("services.sqs_task_router.process_daily_group_summaries_task") as summary:
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            memory_repo,
+            contest_repo=contest_repo,
+            sqs_repo=sqs_repo,
+        )
+
+    sqs_repo.send_contest_ttl_recovery_task.assert_not_called()
+    summary.assert_called_once_with(body, repo=memory_repo)
+
+
+def test_process_contest_ttl_recovery_routes_with_existing_dependencies() -> None:
+    body = {
+        "task_type": "PROCESS_CONTEST_TTL_RECOVERY",
+        "start_key": {
+            "pk": "CONTEST_TTL_OUTBOX",
+            "sk": "CHAT#-1001#ROOT#0000000000011",
+        },
+    }
+    contest_repo = MagicMock()
+    sqs_repo = MagicMock()
+    with patch("services.sqs_task_router.process_contest_ttl_recovery_task") as recovery:
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            contest_repo=contest_repo,
+            sqs_repo=sqs_repo,
+        )
+
+    recovery.assert_called_once_with(body, repo=contest_repo, sqs_repo=sqs_repo)
+
+
+def test_contest_ttl_recovery_failure_bubbles_for_independent_queue_retry() -> None:
+    body = {"task_type": "PROCESS_CONTEST_TTL_RECOVERY"}
+    with (
+        patch(
+            "services.sqs_task_router.process_contest_ttl_recovery_task",
+            side_effect=RuntimeError("recovery boom"),
+        ),
+        pytest.raises(RuntimeError, match="recovery boom"),
+    ):
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            contest_repo=MagicMock(),
+            sqs_repo=MagicMock(),
+        )
+
+
+def test_process_contest_ttl_sweep_routes_with_existing_dependencies() -> None:
+    body = {
+        "task_type": "PROCESS_CONTEST_TTL_SWEEP",
+        "chat_id": -1001,
+        "root_message_id": 11,
+    }
+    contest_repo = MagicMock()
+    sqs_repo = MagicMock()
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch("services.sqs_task_router.process_contest_ttl_sweep_task") as sweep,
+    ):
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            contest_repo=contest_repo,
+            sqs_repo=sqs_repo,
+        )
+    sweep.assert_called_once_with(body, repo=contest_repo, sqs_repo=sqs_repo)
+
+
+def test_contest_ttl_sweep_failure_bubbles_for_queue_retry() -> None:
+    body = {
+        "task_type": "PROCESS_CONTEST_TTL_SWEEP",
+        "chat_id": -1001,
+        "root_message_id": 11,
+    }
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=True),
+        patch(
+            "services.sqs_task_router.process_contest_ttl_sweep_task",
+            side_effect=RuntimeError("sweep boom"),
+        ),
+        pytest.raises(RuntimeError, match="sweep boom"),
+    ):
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            contest_repo=MagicMock(),
+            sqs_repo=MagicMock(),
+        )
+
+
+def test_contest_ttl_cleanup_survives_chat_configuration_removal() -> None:
+    body = {
+        "task_type": "PROCESS_CONTEST_TTL_SWEEP",
+        "chat_id": -1001,
+        "root_message_id": 11,
+    }
+    contest_repo = MagicMock()
+    sqs_repo = MagicMock()
+    with (
+        patch("services.sqs_task_router.is_configured_group_chat", return_value=False),
+        patch("services.sqs_task_router.process_contest_ttl_sweep_task") as sweep,
+    ):
+        process_sqs_event(
+            {"Records": [_record(body)]},
+            MagicMock(),
+            MagicMock(),
+            contest_repo=contest_repo,
+            sqs_repo=sqs_repo,
+        )
+    sweep.assert_called_once_with(body, repo=contest_repo, sqs_repo=sqs_repo)
+
+
 def test_process_vector_memory_routes() -> None:
     body = {
         "task_type": "PROCESS_VECTOR_MEMORY",

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -71,6 +71,19 @@ def test_set_message_reaction_posts_single_emoji(monkeypatch):
     }
 
 
+def test_get_me_caches_bot_identity(monkeypatch):
+    fake_http = _FakeHttp(
+        [_Response(status=200, data=b'{"ok":true,"result":{"id":123,"is_bot":true,"username":"zerde"}}')]
+    )
+    monkeypatch.setattr(telegram, "http", fake_http)
+    client = TelegramClient()
+
+    assert client.get_me()["id"] == 123
+    assert client.get_me()["username"] == "zerde"
+    assert len(fake_http.requests) == 1
+    assert fake_http.requests[0]["url"].endswith("/getMe")
+
+
 def test_ban_chat_member_posts_permanent_ban_without_until_date(monkeypatch):
     fake_http = _FakeHttp([_Response(status=200, data=b'{"ok":true,"result":true}')])
     monkeypatch.setattr(telegram, "http", fake_http)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from services.contest import ContestRetryRequiredError
 from webhook import (
     _handle_api_gateway,
     create_response,
@@ -121,6 +122,7 @@ def test_pending_captcha_message_skips_spam_screening():
     with (
         patch("webhook._spam_screening", return_value=screener),
         patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update") as observe_contest,
         patch("webhook.observe_group_memory_update") as observe_memory,
         patch("webhook.maybe_enqueue_ambient_reaction") as ambient_reaction,
         patch("webhook.handle_group_agent_update") as group_agent,
@@ -128,6 +130,7 @@ def test_pending_captcha_message_skips_spam_screening():
         _handle_api_gateway(event, dispatcher, MagicMock())
 
     screener.run.assert_not_called()
+    observe_contest.assert_not_called()
     observe_memory.assert_not_called()
     ambient_reaction.assert_not_called()
     group_agent.assert_not_called()
@@ -156,6 +159,7 @@ def test_enforced_spam_short_circuits_normal_group_flows():
     with (
         patch("webhook._spam_screening", return_value=screener),
         patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update") as observe_contest,
         patch("webhook.observe_group_memory_update") as observe_memory,
         patch("webhook.maybe_enqueue_ambient_reaction") as ambient_reaction,
         patch("webhook.handle_group_agent_update") as group_agent,
@@ -164,6 +168,7 @@ def test_enforced_spam_short_circuits_normal_group_flows():
 
     assert json.loads(resp["body"])["message"] == "ok"
     screener.run.assert_called_once_with(body)
+    observe_contest.assert_not_called()
     observe_memory.assert_not_called()
     ambient_reaction.assert_not_called()
     group_agent.assert_not_called()
@@ -192,6 +197,7 @@ def test_queued_spam_short_circuits_normal_group_flows():
     with (
         patch("webhook._spam_screening", return_value=screener),
         patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update") as observe_contest,
         patch("webhook.observe_group_memory_update") as observe_memory,
         patch("webhook.maybe_enqueue_ambient_reaction") as ambient_reaction,
         patch("webhook.handle_group_agent_update") as group_agent,
@@ -200,7 +206,112 @@ def test_queued_spam_short_circuits_normal_group_flows():
 
     assert json.loads(resp["body"])["message"] == "ok"
     screener.run.assert_called_once_with(body)
+    observe_contest.assert_not_called()
     observe_memory.assert_not_called()
     ambient_reaction.assert_not_called()
     group_agent.assert_not_called()
     dispatcher.process_update.assert_not_called()
+
+
+def test_contest_observation_runs_before_existing_memory_ambient_and_agent_flows():
+    body = {
+        "message": {
+            "message_id": 12,
+            "message_thread_id": 11,
+            "reply_to_message": {"message_id": 11},
+            "text": "Мен қатысамын",
+            "chat": {"id": -100123, "type": "supergroup"},
+            "from": {"id": 42, "is_bot": False},
+        }
+    }
+    event = {
+        "headers": {"x-telegram-bot-api-secret-token": "test-webhook-secret"},
+        "body": json.dumps(body),
+    }
+    dispatcher = MagicMock()
+    dispatcher.captcha_repo.get_pending.return_value = None
+    screener = MagicMock()
+    screener.should_screen.return_value = False
+    order: list[str] = []
+
+    with (
+        patch("webhook._spam_screening", return_value=screener),
+        patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update", side_effect=lambda *args, **kwargs: order.append("contest")),
+        patch("webhook.observe_group_memory_update", side_effect=lambda *args, **kwargs: order.append("memory")),
+        patch("webhook.maybe_enqueue_ambient_reaction", side_effect=lambda *args, **kwargs: order.append("ambient")),
+        patch("webhook.handle_group_agent_update", side_effect=lambda *args, **kwargs: order.append("agent") or False),
+    ):
+        _handle_api_gateway(event, dispatcher, MagicMock())
+
+    assert order == ["contest", "memory", "ambient", "agent"]
+    dispatcher.process_update.assert_called_once_with(body)
+
+
+def test_contest_persistence_failure_returns_500_before_acknowledging_update():
+    body = {
+        "message": {
+            "message_id": 12,
+            "message_thread_id": 11,
+            "reply_to_message": {"message_id": 11},
+            "text": "Мен қатысамын",
+            "chat": {"id": -100123, "type": "supergroup"},
+            "from": {"id": 42, "is_bot": False},
+        }
+    }
+    event = {
+        "headers": {"x-telegram-bot-api-secret-token": "test-webhook-secret"},
+        "body": json.dumps(body),
+    }
+    dispatcher = MagicMock()
+    dispatcher.captcha_repo.get_pending.return_value = None
+    screener = MagicMock()
+    screener.should_screen.return_value = False
+
+    with (
+        patch("webhook._spam_screening", return_value=screener),
+        patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update", side_effect=RuntimeError("ddb unavailable")),
+        patch("webhook.observe_group_memory_update") as observe_memory,
+        patch("webhook.maybe_enqueue_ambient_reaction") as ambient,
+    ):
+        response = _handle_api_gateway(event, dispatcher, MagicMock())
+
+    assert response["statusCode"] == 500
+    observe_memory.assert_not_called()
+    ambient.assert_not_called()
+    dispatcher.process_update.assert_not_called()
+
+
+def test_contest_command_retry_error_returns_500_for_telegram_redelivery():
+    body = {
+        "message": {
+            "message_id": 30,
+            "text": "/contest draw",
+            "chat": {"id": -100123, "type": "supergroup"},
+            "from": {"id": 42, "is_bot": False},
+            "reply_to_message": {"message_id": 11},
+        }
+    }
+    event = {
+        "headers": {"x-telegram-bot-api-secret-token": "test-webhook-secret"},
+        "body": json.dumps(body),
+    }
+    dispatcher = MagicMock()
+    dispatcher.captcha_repo.get_pending.return_value = None
+    dispatcher.process_update.side_effect = ContestRetryRequiredError("SQS unavailable")
+    screener = MagicMock()
+    screener.should_screen.return_value = False
+
+    with (
+        patch("webhook._spam_screening", return_value=screener),
+        patch("webhook.is_configured_group_chat", return_value=True),
+        patch("webhook.observe_contest_update"),
+        patch("webhook.observe_group_memory_update"),
+        patch("webhook.maybe_enqueue_ambient_reaction"),
+        patch("webhook.handle_group_agent_update", return_value=False),
+    ):
+        response = _handle_api_gateway(event, dispatcher, MagicMock())
+
+    assert response["statusCode"] == 500
+    dispatcher.process_update.assert_called_once_with(body)


### PR DESCRIPTION
## Summary

- create Kazakh contests only from initial official linked-channel discussion roots containing standalone #конкурс
- register each eligible direct personal-account қатысамын reply exactly once and acknowledge accepted entries with the Bot API-supported 🎉 reaction
- add creator-only draw/redraw/cancel, creator-or-admin status, secure full-pagination reservoir sampling, at most three distinct winners, and anchored public evidence
- preserve existing AI, memory, ambient-reaction, captcha, and spam flows

## Reliability and retention

- persist contest lifecycle, exact participant count, first accepted evidence, winners, rules aliases, and logical expiry in the existing DynamoDB memory table
- use conditional transactions and unique creation/draw attempt tokens for webhook, registration, and draw concurrency
- persist winners before Telegram delivery and replay the same pending winner after ambiguous delivery
- atomically create a durable TTL outbox marker on first draw/cancel, process bounded sweep/recovery pages, and add an always-on production EventBridge recovery seed targeting the existing main queue
- keep initial cleanup enqueue best-effort so queue outages do not block winner or status responses

## Verification

- uv run pytest tests/ -q: 555 passed
- uv run pre-commit run --all-files: passed
- git diff --check: passed
- final correctness review: no actionable P0-P3 findings
- final POST plan review: aligned, no blocker/major/minor
- production CDK diff shows the contest-specific recovery rule and an exact events.amazonaws.com -> existing main queue policy

The CDK diff also exposes unrelated existing local environment/config drift (chat map, ambient settings, Gemini limit, and RU schedules). Those values are not changed by this commit and were not deployed.

## Live acceptance

Implemented but unproven live. This PR does not deploy, merge, alter the webhook subscription, or run acceptance in a real Telegram group.

Telegram sendMessage has no idempotency key, so an ambiguous acknowledgement can produce a duplicate announcement for the same already-persisted winner. It cannot silently reopen registration or select a replacement winner.
